### PR TITLE
feat(w1): scene-at-rest — stage block + npc spawns + renderer rest mode (#1318)

### DIFF
--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -13,6 +13,9 @@ AssetDatabase.Refresh();
 // _active_combat.txt -> today's single-room behavior (back-compat, additive). The per-location fetch is as
 // reliable as the token fetch below (same endpoint).
 string PLATE="crypt_firelit_v2.png"; string _locPlate="";
+// grid extents for cellToWorld below: default to the 14x11-era origin (cols=14,rows=11) so an
+// absent/malformed grid block reproduces today's fixed (cx-6.5,5.0-cy) transform byte-for-byte.
+float _gridCols=14f, _gridRows=11f;
 try {
   var _cidF="/home/unity/worldos-unity/Assets/painterly/backdrops/_active_campaign.txt";
   string _cid="camp_gfxdemo01"; if(System.IO.File.Exists(_cidF)){ var _c=System.IO.File.ReadAllText(_cidF).Trim(); if(_c.Length>0) _cid=_c; }
@@ -22,6 +25,11 @@ try {
   var _lid=(_loc!=null && _loc.ContainsKey("id"))?_loc["id"] as string:null;
   var _mapF="/home/unity/worldos-unity/Assets/painterly/backdrops/_location_plates.json";
   if(!string.IsNullOrEmpty(_lid) && System.IO.File.Exists(_mapF)){ var _m=MiniJson.Parse(System.IO.File.ReadAllText(_mapF)) as System.Collections.Generic.Dictionary<string,object>; if(_m!=null && _m.ContainsKey(_lid)) _locPlate=_m[_lid] as string; }
+  // #1318 rest-mode grids can be a non-14x11 size (e.g. forest/town at 16-19 cols x 12-15 rows);
+  // read the surface's own grid block so cellToWorld places tokens on their real spawn cells
+  // instead of the fixed legacy origin. Any parse miss silently keeps the 14x11 default above.
+  var _grid=(_r!=null && _r.ContainsKey("grid"))?_r["grid"] as System.Collections.Generic.Dictionary<string,object>:null;
+  if(_grid!=null){ if(_grid.ContainsKey("cols")) _gridCols=System.Convert.ToSingle(_grid["cols"]); if(_grid.ContainsKey("rows")) _gridRows=System.Convert.ToSingle(_grid["rows"]); }
 } catch {}
 if(!string.IsNullOrEmpty(_locPlate)) PLATE=_locPlate;
 else { var _abs="/home/unity/worldos-unity/Assets/painterly/backdrops/_active_combat.txt"; if(System.IO.File.Exists(_abs)){ var _n=System.IO.File.ReadAllText(_abs).Trim(); if(_n.Length>0) PLATE=_n; } }
@@ -75,7 +83,10 @@ bd.transform.SetParent(cam.transform,false); float texAsp=(float)bdTex.width/bdT
 bd.transform.localPosition=new Vector3(0,0,160f); bd.transform.localScale=new Vector3(ow,oh,1f);
 var bm=new Material(Shader.Find("Unlit/Texture")); bm.mainTexture=bdTex; bm.renderQueue=1900; var bdr=bd.GetComponent<Renderer>(); bdr.sharedMaterial=bm; bdr.enabled=true; bdr.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off; bdr.receiveShadows=false;
 
-System.Func<int,int,Vector3> cellToWorld=(cx,cy)=> new Vector3((cx-6.5f)*2.0f,0f,(5.0f-cy)*2.0f);
+// Origin derived from the surface's own grid extents (fetched above): (_gridCols-1)/2 and
+// (_gridRows-1)/2 reproduce the prior hardcoded 6.5/5.0 EXACTLY at 14x11 (13/2=6.5, 10/2=5.0), so
+// this is byte-identical on today's rooms and only shifts the origin for a differently-sized grid.
+System.Func<int,int,Vector3> cellToWorld=(cx,cy)=> new Vector3((cx-(_gridCols-1f)/2f)*2.0f,0f,((_gridRows-1f)/2f-cy)*2.0f);
 
 // PoE2 lighting rig (from spike)
 foreach(var ln in new[]{"KeyLight","FillLight","BrazierL","BrazierR"}){ var o=GameObject.Find(ln); if(o!=null) UnityEngine.Object.DestroyImmediate(o); }
@@ -191,30 +202,36 @@ var posByName=new System.Collections.Generic.Dictionary<string,Vector3>(); int s
 System.Collections.Generic.Dictionary<string,object> regAssets=null, regDefaults=null, regAliases=null;
 { var _rp="/home/unity/worldos-unity/registry.json"; if(System.IO.File.Exists(_rp)){ var _rr=MiniJson.Parse(System.IO.File.ReadAllText(_rp)) as System.Collections.Generic.Dictionary<string,object>; if(_rr!=null){ regAssets=_rr.ContainsKey("assets")?_rr["assets"] as System.Collections.Generic.Dictionary<string,object>:null; regDefaults=_rr.ContainsKey("defaults")?_rr["defaults"] as System.Collections.Generic.Dictionary<string,object>:null; regAliases=_rr.ContainsKey("aliases")?_rr["aliases"] as System.Collections.Generic.Dictionary<string,object>:null; } } }
 System.Func<string,string> slugify=(s)=>{ if(string.IsNullOrEmpty(s)) return ""; var _b=new System.Text.StringBuilder(); foreach(char c in s.ToLower()){ if(char.IsLetterOrDigit(c)) _b.Append(c); else if(_b.Length>0 && _b[_b.Length-1]!='-') _b.Append('-'); } return _b.ToString().Trim('-'); };
+// Returns [model_ref, albedo_ref, anim_ref] — anim_ref is the registry's OWN idle/moveset clip
+// (e.g. hero@moveset.fbx), separate from the mesh (#1318 thread: rest mode must sample idle from
+// anim_ref, not from the mesh fbx itself). "" (not null) when the registry has no anim_ref for
+// this asset (e.g. the static hero.fbx entry, which documents no clips) so the caller can fall
+// back to the prior mesh-as-poseClip behavior for those assets.
 System.Func<string,string,string[]> resolveAsset=(slug,kind)=>{
   string fbxDef=kind=="monster"?"Assets/chars_v2/goblin/goblin.fbx":"Assets/painterly/models/hero.fbx";
   string albDef=kind=="monster"?"Assets/chars_v2/goblin/albedo.png":"Assets/painterly/models/hero_albedo.png";
-  if(regAssets==null) return new string[]{fbxDef,albDef};
+  if(regAssets==null) return new string[]{fbxDef,albDef,""};
   string id=slug;
   if(!regAssets.ContainsKey(id) && regAliases!=null && regAliases.ContainsKey(id)) id=regAliases[id] as string;
   if((id==null||!regAssets.ContainsKey(id)) && regDefaults!=null){ if(regDefaults.ContainsKey(kind)) id=regDefaults[kind] as string; else if(regDefaults.ContainsKey("__any__")) id=regDefaults["__any__"] as string; }
-  if(id!=null && regAssets.ContainsKey(id)){ var a=regAssets[id] as System.Collections.Generic.Dictionary<string,object>; if(a!=null){ string m=a.ContainsKey("model_ref")?a["model_ref"] as string:null; string al=a.ContainsKey("albedo_ref")?a["albedo_ref"] as string:null; return new string[]{ string.IsNullOrEmpty(m)?fbxDef:m, string.IsNullOrEmpty(al)?albDef:al }; } }
-  return new string[]{fbxDef,albDef};
+  if(id!=null && regAssets.ContainsKey(id)){ var a=regAssets[id] as System.Collections.Generic.Dictionary<string,object>; if(a!=null){ string m=a.ContainsKey("model_ref")?a["model_ref"] as string:null; string al=a.ContainsKey("albedo_ref")?a["albedo_ref"] as string:null; string an=a.ContainsKey("anim_ref")?a["anim_ref"] as string:null; return new string[]{ string.IsNullOrEmpty(m)?fbxDef:m, string.IsNullOrEmpty(al)?albDef:al, an??"" }; } }
+  return new string[]{fbxDef,albDef,""};
 };
 foreach(var o in toks){ var t=o as System.Collections.Generic.Dictionary<string,object>; if(t==null||!t.ContainsKey("x")||t["x"]==null) continue;
   int cx=System.Convert.ToInt32(t["x"]); int cy=System.Convert.ToInt32(t["y"]); string team=t["team"] as string; string nm=t["name"] as string;
   string tid=t.ContainsKey("id")?(t["id"] as string):null; if(string.IsNullOrEmpty(tid)) tid=nm;
   bool foe=(team=="foe");
   string kind=foe?"monster":"character";
-  var aref=resolveAsset(slugify(nm),kind); string fbx=aref[0]; string alb=aref[1];
+  var aref=resolveAsset(slugify(nm),kind); string fbx=aref[0]; string alb=aref[1]; string anim=aref.Length>2?aref[2]:"";
   float h=foe?4.2f:5.0f; Color ring=foe?new Color(1f,0.13f,0.10f,1f):new Color(0.4f,0.95f,1f,1f);
   // poseClip: pass the fbx to auto-pose to a NEUTRAL IDLE (spawn prefers an 'idle' clip). Left null for the current
   // Meshy placeholder cast whose idle/bind clips are non-neutral (crouch/lean) + inflate the height-normalized scale;
   // the bind pose is the most PROPORTIONATE placeholder here. A properly-rigged demo-cast actor (owner-greenlit) with
   // a clean idle should pass its fbx/clip so this poses it standing. (Grounding via BakeMesh is correct either way.)
-  // W1 (#1318): AT REST, feed the fbx as the pose clip so the imported 9-clip moveset's 'idle' settles each actor into
-  // a relaxed standing pose (the scene-at-rest read) rather than the combat bind pose.
-  var pos=spawn(fbx,alb,restMode?fbx:null,cx,cy,h,ring,"Actor_"+tid);
+  // W1 (#1318): AT REST, sample idle from the registry's OWN anim_ref (e.g. hero@moveset.fbx) when the asset has
+  // one, so a rigged demo-cast actor settles into its real idle clip instead of the combat bind pose. Assets with
+  // no registry anim_ref (the static hero.fbx entry documents none) fall back to the prior fbx-as-poseClip.
+  var pos=spawn(fbx,alb,restMode?(string.IsNullOrEmpty(anim)?fbx:anim):null,cx,cy,h,ring,"Actor_"+tid);
   if(nm!=null) posByName[nm]=pos; spawned++; celldbg+=" "+nm+"("+team+")@"+cx+","+cy;
 }
 if(missingActor){ sb.AppendLine("ABORT capture — a required actor prefab was missing (no PNG written)"); return sb.ToString(); }

--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -164,7 +164,17 @@ string surfJson="";
 try { surfJson=new System.Net.WebClient().DownloadString("http://127.0.0.1:8765/combat-surface?campaign="+CID); } catch (System.Exception e) { return "surface GET failed: "+e.Message; }
 var root=MiniJson.Parse(surfJson) as System.Collections.Generic.Dictionary<string,object>;
 if(root==null) return "surface parse failed";
+// W1 (#1318) SCENE-AT-REST: when the surface's additive `stage` block says mode:"rest" and carries
+// tokens, this renderer paints the room AT REST — party + present NPCs at their spawn cells in idle
+// poses — instead of a combat board. In combat mode stage.tokens is [] (the engine guarantees no
+// double-paint), so we fall through to the authoritative top-level `tokens`. `restMode` gates the
+// idle-pose default below. Absent `stage` (an old surface) -> combat path, today's behavior.
+bool restMode=false;
 var toks=root.ContainsKey("tokens")?(root["tokens"] as System.Collections.Generic.List<object>):null;
+{ var stage=root.ContainsKey("stage")?(root["stage"] as System.Collections.Generic.Dictionary<string,object>):null;
+  if(stage!=null){ string smode=stage.ContainsKey("mode")?stage["mode"] as string:null;
+    var stoks=stage.ContainsKey("tokens")?(stage["tokens"] as System.Collections.Generic.List<object>):null;
+    if(smode=="rest" && stoks!=null && stoks.Count>0){ toks=stoks; restMode=true; } } }
 if(toks==null||toks.Count==0) return "no tokens on surface";
 // sweep prior actors/overlays so a moved/removed token never leaves a stale instance (deterministic rerun).
 // COLLECT then destroy with null-checks: destroying an actor root also destroys its children still in the
@@ -202,7 +212,9 @@ foreach(var o in toks){ var t=o as System.Collections.Generic.Dictionary<string,
   // Meshy placeholder cast whose idle/bind clips are non-neutral (crouch/lean) + inflate the height-normalized scale;
   // the bind pose is the most PROPORTIONATE placeholder here. A properly-rigged demo-cast actor (owner-greenlit) with
   // a clean idle should pass its fbx/clip so this poses it standing. (Grounding via BakeMesh is correct either way.)
-  var pos=spawn(fbx,alb,null,cx,cy,h,ring,"Actor_"+tid);
+  // W1 (#1318): AT REST, feed the fbx as the pose clip so the imported 9-clip moveset's 'idle' settles each actor into
+  // a relaxed standing pose (the scene-at-rest read) rather than the combat bind pose.
+  var pos=spawn(fbx,alb,restMode?fbx:null,cx,cy,h,ring,"Actor_"+tid);
   if(nm!=null) posByName[nm]=pos; spawned++; celldbg+=" "+nm+"("+team+")@"+cx+","+cy;
 }
 if(missingActor){ sb.AppendLine("ABORT capture — a required actor prefab was missing (no PNG written)"); return sb.ToString(); }
@@ -248,7 +260,9 @@ sb.AppendLine("LIVE "+CID+": spawned "+spawned+" actors:"+celldbg);
   sb.AppendLine("occluders: "+occN+" depth-proxy boxes");
 }
 // latest damage from the battleLog -> floating "-N" + impact burst over the struck token (skip if no recent hit).
-string dmgTarget=""; int dmgN=0; var blog=root.ContainsKey("battleLog")?(root["battleLog"] as System.Collections.Generic.List<object>):null;
+// W1 (#1318): AT REST there is no combat, so skip the damage-VFX pass entirely (blog left null) — a rest
+// scene never shows an impact burst / "-N" over a peaceful innkeeper.
+string dmgTarget=""; int dmgN=0; var blog=restMode?null:(root.ContainsKey("battleLog")?(root["battleLog"] as System.Collections.Generic.List<object>):null);
 if(blog!=null){ foreach(var e in blog){ string tx=null; var ed=e as System.Collections.Generic.Dictionary<string,object>; if(ed!=null&&ed.ContainsKey("text")) tx=ed["text"] as string; else tx=e as string;
   if(tx!=null&&tx.Contains(" hits ")&&tx.Contains(" for ")&&tx.Contains("damage")){ int hi=tx.IndexOf(" hits "); int fi=tx.IndexOf(" for ",hi); if(hi>=0&&fi>hi){ dmgTarget=tx.Substring(hi+6,fi-(hi+6)).Trim(); var aft=tx.Substring(fi+5).TrimStart().Split(' '); if(aft.Length>0) int.TryParse(aft[0],out dmgN); } } } }
 

--- a/qa/felt_rest_panel.md
+++ b/qa/felt_rest_panel.md
@@ -1,0 +1,86 @@
+# FELT REST-SCENE panel — "does this read as a real game AT REST?" (W1 / #1318)
+
+> The visual eval instrument for **Scene at Rest** (Act II W1). A location renders AT REST —
+> party + present NPCs placed on the grid in idle poses, no combat — and this panel asks ONE
+> question the scores can't fake: **does a composed rest frame read as a shipped CRPG at rest,
+> or as a tech demo with actors standing on a board?** It is the visual sibling of the story
+> FELT lens (`qa/rubric_tolkien.md`): a rest tavern should feel *inhabited* — the innkeeper is
+> THERE before anyone draws a sword.
+
+This is a PROTOCOL + a thin logger. The actual panel runs LATER, on real rendered frames (the
+renderer's rest mode, step 4 of #1318). Build the instrument first so the rung is decided by
+EVAL, not by vibes.
+
+---
+
+## The one law you cannot break: the disguised positive control
+This panel inherits the **CALIBRATION-CONTROL LAW** proven 2026-07-02 (see
+`.claude/skills/visual-critic/SKILL.md` §CALIBRATION-CONTROL PROTOCOL, and memory
+`feedback_visual_panel_scoring_variance`): our panel's ABSOLUTE scale is broken at the top and
+**cannot be cited as a quality verdict**. Real shipped CRPG art (BG3 / Pillars of Eternity /
+BG2EE) scored 3.0–5.6 on our own instrument; scorers even confabulated "diffusion-model tells"
+on hand-painted 1998 art. So:
+
+1. **No AI-prior primers.** The scorer prompt NEVER says "AI render", "diffusion", "candidate",
+   or "almost nothing deserves ≥8". Those primers cost ~0.7 pt and made ≥8 unattainable BY
+   CONSTRUCTION. The scorer is told only: *"rate how much each frame reads as a real,
+   commercially-shipped CRPG town/interior at rest."*
+2. **Every panel embeds ≥1 DISGUISED REAL-GAME CONTROL** — a genuine shipped rest scene (a BG3
+   tavern-at-rest screenshot, a Pillars town-at-rest frame) NOT among any refs, cropped UI-free
+   to comparable resolution, shuffled in among our frames under a neutral id (`frame_03`).
+3. **The reportable metric is the DELTA vs the control's same-panel score**, never an absolute.
+   `ours_median − control_median ≥ 0` ⇒ *"reads as a real game at rest"* — the W1 bar is MET.
+   An absolute number from this instrument is NEVER a quality verdict; only the delta + the
+   flaw list are.
+4. **Blind mapping lives OUTSIDE the panel image dir** (scorers Read adjacent files). ≥5 blind
+   scorers per panel; report **median with mean**; within-panel comparisons only (cross-panel
+   drift is real, ±1.2). Eyeball the frames yourself 0-for-5 before trusting any panel.
+
+---
+
+## What a rest frame is scored ON (5 lenses, 0–10 each)
+The rest scene is PURE PRESENTATION of engine state, so the lenses are about *placement +
+inhabitation + coherence*, not combat readability:
+
+| id | lens | the "real game at rest" tell |
+|----|------|------------------------------|
+| `placement_plausibility` | Are the party + NPCs standing where PEOPLE stand — near the bar, by the hearth, at a stall — not on a bare tactical grid in a firing line? | figures cluster at meaningful anchors, not evenly spaced on cells |
+| `inhabitation` | Does the room read as LIVED-IN — the innkeeper present, the place peopled — vs an empty stage with the party dropped in? | ≥1 non-party NPC visibly present and belonging |
+| `idle_life` | Do the actors read as at ease (idle pose, weight settled) rather than combat-ready / T-posed / frozen mid-stride? | relaxed idle silhouettes, varied facing |
+| `scene_light_coherence` | Do the actors sit inside the plate's light (warm hearth key, cool fill) as ONE painting, not lit by a different sun? | rim/key direction matches the plate mood |
+| `grounding_integration` | Feet on the floor plane, correct depth scale, no "pasted-on" float — the #1 illusion-breaker. | feet contact stone; scale reads with depth |
+
+Deterministic pre-gates (`qa/visual_pregate.py`: frame-lit, floor-contact-Y, screen-scale) run
+FIRST and short-circuit the panel on a CRITICAL — there is no point asking 5 scorers to admire a
+peopled tavern while the innkeeper's feet float half a cell above the floor.
+
+---
+
+## Panel composition (the two calibration frames #1318 names)
+Build ONE calibration panel with BOTH rest scenes + their disguised controls:
+
+- **tavern-with-innkeeper** — a rest tavern, party by the entrance, the innkeeper at the bar
+  anchor. Disguised control: a real BG3/Pillars tavern-at-rest crop.
+- **church-with-priest** — a rest church/interior, party mid-floor, a priest at the altar/anchor.
+  Disguised control: a real shipped chapel/interior-at-rest crop.
+
+Each panel: our frame(s) + ≥1 disguised control, shuffled, neutral ids, mapping stored outside
+the image dir. ≥5 blind scorers, ≥2 panel runs averaged (±1.5 per-lens variance).
+
+---
+
+## Logging (existing schema — surface="visual", zero migration)
+Log every panel round to `scores_db` via the existing visual-critic lane (`qa/scores_db.py`,
+surface="visual"): `visual_overall` (holistic rest read), `visual_dims_json` (the 5 lenses
+above), `visual_scene` (`rest:tavern-innkeeper` / `rest:church-priest`), `visual_backend`
+(`unity-cl`), `visual_round`, `visual_pregate` (the pre-gate verdict). The control's row is
+logged too (scene id suffixed `:control`) so the delta is queryable from the ledger, not just
+the panel report. `qa/felt_rest_panel.py` is the thin logger/summarizer that wraps this.
+
+## The W1 binding gate (charter #1328)
+> rest-scene panel scored (control-anchored, logged scores_db) + text-tier byte-identity test
+> green + no combat-mode regression.
+
+The panel PASSES W1 when, on ≥2 averaged runs of the calibration panel, **each rest scene's
+median ≥ its disguised control's median** (delta ≥ 0), with no open CRITICAL pre-gate. Report
+the delta + the flaw list; never cite the absolute.

--- a/qa/felt_rest_panel.py
+++ b/qa/felt_rest_panel.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""FELT REST-SCENE panel — thin logger + control-anchored verdict for W1 scene-at-rest (#1318).
+
+The PROTOCOL is `qa/felt_rest_panel.md` (disguised real-game controls, 5 blind scorers, no
+AI-prior primers). This module is the thin scripting the protocol names: it takes the panel's
+per-frame scores (our rest frames + the disguised real-game control), logs each to the EXISTING
+visual-critic lane in `scores_db` (surface="visual"), and computes the ONLY citable metric — the
+DELTA of our median vs the control's same-panel median.
+
+The instrument's ABSOLUTE scale is broken at the top (see the .md / visual-critic SKILL
+§CALIBRATION-CONTROL): an absolute number is NEVER a quality verdict. So this tool refuses to
+emit a PASS from an absolute; it emits PASS only when, per scene, our median >= the disguised
+control's median (delta >= 0). Zero engine state, zero render — pure post-scoring aggregation.
+
+USAGE
+-----
+    # panel.json: {"scene":"rest:tavern-innkeeper", "backend":"unity-cl", "round":1,
+    #              "pregate":"PASS", "frames":[
+    #                {"id":"frame_01","kind":"ours","overall":6.1,
+    #                 "dims":{"placement_plausibility":6,"inhabitation":6,"idle_life":5,
+    #                         "scene_light_coherence":7,"grounding_integration":6}},
+    #                {"id":"frame_03","kind":"control","overall":5.4,"dims":{...}}]}
+    python3 qa/felt_rest_panel.py --panel panel.json            # log + print the delta verdict
+    python3 qa/felt_rest_panel.py --panel panel.json --dry-run  # verdict only, no scores_db write
+
+The 5 rest lenses (0-10 each): placement_plausibility, inhabitation, idle_life,
+scene_light_coherence, grounding_integration (see qa/felt_rest_panel.md).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+# The 5 rest lenses the .md protocol scores on — the visual_dims_json map for a rest frame.
+REST_LENSES = (
+    "placement_plausibility",
+    "inhabitation",
+    "idle_life",
+    "scene_light_coherence",
+    "grounding_integration",
+)
+
+
+def _median(vals: list[float]) -> float | None:
+    vals = [float(v) for v in vals if v is not None]
+    return round(statistics.median(vals), 3) if vals else None
+
+
+def summarize(panel: dict) -> dict:
+    """Aggregate a panel dict into the citable metric: our median vs the disguised control median.
+
+    The absolute medians are reported for the ledger, but the VERDICT is delta-only: PASS iff
+    ours_median >= control_median (delta >= 0) AND no CRITICAL pre-gate short-circuited the panel.
+    """
+    frames = panel.get("frames") or []
+    ours = [f for f in frames if f.get("kind") == "ours"]
+    controls = [f for f in frames if f.get("kind") == "control"]
+    ours_median = _median([f.get("overall") for f in ours])
+    control_median = _median([f.get("overall") for f in controls])
+    pregate = str(panel.get("pregate", "SKIPPED")).upper()
+    delta = None
+    if ours_median is not None and control_median is not None:
+        delta = round(ours_median - control_median, 3)
+    # The instrument's absolute scale is not citable; the verdict is delta-only + pre-gate clean.
+    verdict = "INCONCLUSIVE"
+    if not controls:
+        verdict = "NO_CONTROL"  # a panel without a disguised control violates the calibration law
+    elif pregate == "FLAG":
+        verdict = "PREGATE_BLOCKED"  # a CRITICAL/HIGH pre-gate short-circuits the panel
+    elif delta is not None:
+        verdict = "PASS" if delta >= 0 else "FAIL"
+    return {
+        "scene": panel.get("scene", ""),
+        "ours_median": ours_median,
+        "control_median": control_median,
+        "delta": delta,
+        "pregate": pregate,
+        "n_ours": len(ours),
+        "n_control": len(controls),
+        "verdict": verdict,
+    }
+
+
+def _log_frames(panel: dict, run_prefix: str, db_path: str | None) -> int:
+    """Log each frame as a scores_db surface="visual" row. Control rows get a ":control" scene
+    suffix so the same-panel delta is queryable from the ledger, not only the panel report."""
+    from scores_db import add_run  # local import so --dry-run needs no db
+
+    scene = str(panel.get("scene", "rest:unknown"))
+    backend = str(panel.get("backend", "unity-cl"))
+    vround = int(panel.get("round", 1))
+    pregate = str(panel.get("pregate", "SKIPPED")).upper()
+    n = 0
+    for f in panel.get("frames") or []:
+        fid = str(f.get("id", f"frame_{n}"))
+        is_control = f.get("kind") == "control"
+        dims = {k: f.get("dims", {}).get(k) for k in REST_LENSES if f.get("dims", {}).get(k) is not None}
+        run_id = f"{run_prefix}-{scene.replace(':', '_')}-r{vround}-{fid}"
+        kw: dict = dict(
+            surface="visual",
+            visual_scene=scene + (":control" if is_control else ""),
+            visual_backend=backend,
+            visual_round=vround,
+            visual_pregate=pregate,
+            visual_overall=f.get("overall"),
+        )
+        if dims:
+            kw["visual_dims_json"] = dims
+        if db_path:
+            add_run(run_id, db_path=db_path, **kw)
+        else:
+            add_run(run_id, **kw)
+        n += 1
+    return n
+
+
+def main(argv: list[str] | None = None) -> int:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))  # so `import scores_db` resolves
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--panel", required=True, help="panel JSON (scene/backend/round/pregate/frames[])")
+    ap.add_argument("--run-prefix", default="felt-rest", help="run_id prefix for logged rows")
+    ap.add_argument("--db-path", default=None, help="scores.db path (default: scores_db.DB_PATH)")
+    ap.add_argument("--dry-run", action="store_true", help="print the verdict only; do NOT write scores_db")
+    args = ap.parse_args(argv)
+
+    panel = json.loads(Path(args.panel).read_text(encoding="utf-8"))
+    summary = summarize(panel)
+    if not args.dry_run:
+        summary["logged_rows"] = _log_frames(panel, args.run_prefix, args.db_path)
+    print(json.dumps(summary, indent=2))
+    # exit non-zero on a hard FAIL / missing control so a gate wrapper can react.
+    return 0 if summary["verdict"] in ("PASS", "INCONCLUSIVE") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/felt_rest_panel.py
+++ b/qa/felt_rest_panel.py
@@ -144,19 +144,26 @@ def summarize(panel: dict) -> dict:
 
 def _log_frames(panel: dict, run_prefix: str, db_path: str | None) -> int:
     """Log each frame as a scores_db surface="visual" row. Control rows get a ":control" scene
-    suffix so the same-panel delta is queryable from the ledger, not only the panel report."""
+    suffix so the same-panel delta is queryable from the ledger, not only the panel report.
+
+    Uses each frame's OWN ``scene`` (falling back to the panel-level scene) so a combined panel
+    (tavern + church rows in one panel) logs each row under its real scene/control pair — matching
+    the per-scene grouping ``summarize()`` already does. The row index ``n`` is folded into
+    ``run_id`` so the required 5 blind scorers submitting scores for the SAME shuffled frame id
+    each get a distinct row instead of colliding on ``add_run``'s default replace-on-PK write."""
     from scores_db import add_run  # local import so --dry-run needs no db
 
-    scene = str(panel.get("scene", "rest:unknown"))
+    panel_scene = str(panel.get("scene", "rest:unknown"))
     backend = str(panel.get("backend", "unity-cl"))
     vround = int(panel.get("round", 1))
     pregate = str(panel.get("pregate", "SKIPPED")).upper()
     n = 0
     for f in panel.get("frames") or []:
+        scene = str(f.get("scene", panel_scene))
         fid = str(f.get("id", f"frame_{n}"))
         is_control = f.get("kind") == "control"
         dims = {k: f.get("dims", {}).get(k) for k in REST_LENSES if f.get("dims", {}).get(k) is not None}
-        run_id = f"{run_prefix}-{scene.replace(':', '_')}-r{vround}-{fid}"
+        run_id = f"{run_prefix}-{scene.replace(':', '_')}-r{vround}-{fid}-i{n}"
         kw: dict = dict(
             surface="visual",
             visual_scene=scene + (":control" if is_control else ""),

--- a/qa/felt_rest_panel.py
+++ b/qa/felt_rest_panel.py
@@ -49,38 +49,96 @@ def _median(vals: list[float]) -> float | None:
     return round(statistics.median(vals), 3) if vals else None
 
 
-def summarize(panel: dict) -> dict:
-    """Aggregate a panel dict into the citable metric: our median vs the disguised control median.
+# Worst-to-best precedence: a combined panel's rolled-up verdict is the WORST of its per-scene
+# verdicts, so one below-control scene cannot be masked by a strong sibling (see _score_group).
+_VERDICT_RANK = {
+    "NO_CONTROL": 0,
+    "PREGATE_BLOCKED": 1,
+    "FAIL": 2,
+    "INCONCLUSIVE": 3,
+    "PASS": 4,
+}
+
+
+def _score_group(ours: list[dict], controls: list[dict], pregate: str) -> dict:
+    """The delta verdict for ONE scene/control pair (ours frames vs the disguised control frames).
 
     The absolute medians are reported for the ledger, but the VERDICT is delta-only: PASS iff
-    ours_median >= control_median (delta >= 0) AND no CRITICAL pre-gate short-circuited the panel.
+    ours_median >= control_median (delta >= 0) AND the deterministic pre-gate actually cleared
+    (pregate == "PASS"). A SKIPPED/missing/FLAG pre-gate never yields PASS — the W1 binding gate
+    requires "no open CRITICAL pre-gate", so an unrun pre-gate is INCONCLUSIVE, not a pass.
     """
-    frames = panel.get("frames") or []
-    ours = [f for f in frames if f.get("kind") == "ours"]
-    controls = [f for f in frames if f.get("kind") == "control"]
     ours_median = _median([f.get("overall") for f in ours])
     control_median = _median([f.get("overall") for f in controls])
-    pregate = str(panel.get("pregate", "SKIPPED")).upper()
     delta = None
     if ours_median is not None and control_median is not None:
         delta = round(ours_median - control_median, 3)
-    # The instrument's absolute scale is not citable; the verdict is delta-only + pre-gate clean.
     verdict = "INCONCLUSIVE"
     if not controls:
-        verdict = "NO_CONTROL"  # a panel without a disguised control violates the calibration law
+        verdict = "NO_CONTROL"  # a group without a disguised control violates the calibration law
     elif pregate == "FLAG":
         verdict = "PREGATE_BLOCKED"  # a CRITICAL/HIGH pre-gate short-circuits the panel
-    elif delta is not None:
-        verdict = "PASS" if delta >= 0 else "FAIL"
+    elif delta is not None and delta < 0:
+        verdict = "FAIL"
+    elif delta is not None and pregate == "PASS":
+        verdict = "PASS"  # delta >= 0 AND the pre-gate cleared — the only path to a binding PASS
+    # else: delta >= 0 but pre-gate not PASS (SKIPPED/missing) -> INCONCLUSIVE (not a real pass).
     return {
-        "scene": panel.get("scene", ""),
         "ours_median": ours_median,
         "control_median": control_median,
         "delta": delta,
-        "pregate": pregate,
         "n_ours": len(ours),
         "n_control": len(controls),
         "verdict": verdict,
+    }
+
+
+def summarize(panel: dict) -> dict:
+    """Aggregate a panel into the citable metric: our median vs the disguised control median.
+
+    Frames are grouped by scene (a per-frame ``scene`` overrides the panel ``scene``), and EACH
+    scene/control pair is scored on its own — so a combined panel (tavern + church in one panel)
+    cannot let a strong tavern offset a below-control church. The panel verdict is the WORST of
+    the per-scene verdicts; the top-level medians/delta describe the worst-scoring scene.
+    """
+    frames = panel.get("frames") or []
+    panel_scene = panel.get("scene", "")
+    pregate = str(panel.get("pregate", "SKIPPED")).upper()
+
+    # Group frames by scene (per-frame scene wins), preserving first-seen order for determinism.
+    order: list[str] = []
+    groups: dict[str, dict[str, list[dict]]] = {}
+    for f in frames:
+        scene = str(f.get("scene", panel_scene))
+        if scene not in groups:
+            groups[scene] = {"ours": [], "controls": []}
+            order.append(scene)
+        bucket = "controls" if f.get("kind") == "control" else "ours"
+        groups[scene][bucket].append(f)
+
+    if not groups:  # empty panel -> a single no-control group so the verdict is NO_CONTROL
+        groups[panel_scene] = {"ours": [], "controls": []}
+        order.append(panel_scene)
+
+    scenes = []
+    for scene in order:
+        g = _score_group(groups[scene]["ours"], groups[scene]["controls"], pregate)
+        g["scene"] = scene
+        scenes.append(g)
+
+    # The panel verdict rolls up to the WORST per-scene verdict; the reported medians/delta come
+    # from that worst scene so the citable metric never over-states a mixed panel.
+    worst = min(scenes, key=lambda g: (_VERDICT_RANK.get(g["verdict"], 0), g.get("delta") if g.get("delta") is not None else 0))
+    return {
+        "scene": worst["scene"] if len(scenes) == 1 else panel_scene,
+        "ours_median": worst["ours_median"],
+        "control_median": worst["control_median"],
+        "delta": worst["delta"],
+        "pregate": pregate,
+        "n_ours": sum(g["n_ours"] for g in scenes),
+        "n_control": sum(g["n_control"] for g in scenes),
+        "verdict": worst["verdict"],
+        "scenes": scenes,
     }
 
 
@@ -131,8 +189,11 @@ def main(argv: list[str] | None = None) -> int:
     if not args.dry_run:
         summary["logged_rows"] = _log_frames(panel, args.run_prefix, args.db_path)
     print(json.dumps(summary, indent=2))
-    # exit non-zero on a hard FAIL / missing control so a gate wrapper can react.
-    return 0 if summary["verdict"] in ("PASS", "INCONCLUSIVE") else 1
+    # Exit 0 ONLY on a real binding-gate pass. INCONCLUSIVE (ours frames missing/unscored, or the
+    # pre-gate never cleared) is NOT a pass of the W1 gate (ours_median >= control_median), so it
+    # exits non-zero alongside FAIL / NO_CONTROL / PREGATE_BLOCKED — a gate wrapper must not read
+    # an unscored panel as green.
+    return 0 if summary["verdict"] == "PASS" else 1
 
 
 if __name__ == "__main__":

--- a/qa/test_felt_rest_panel.py
+++ b/qa/test_felt_rest_panel.py
@@ -1,0 +1,57 @@
+"""Unit tests for the FELT REST-SCENE panel logger (qa/felt_rest_panel.py, W1 #1318).
+
+Covers the ONLY citable metric — the control-anchored delta verdict — and the calibration-law
+guards (a panel with no disguised control is NO_CONTROL; a CRITICAL pre-gate short-circuits).
+Pure aggregation; no scores_db write here (that path is exercised via --dry-run off).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+_MOD_PATH = Path(__file__).resolve().parent / "felt_rest_panel.py"
+_SPEC = importlib.util.spec_from_file_location("felt_rest_panel", _MOD_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+frp = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(frp)
+
+
+def _panel(ours: list[float], control: list[float], pregate: str = "PASS") -> dict:
+    frames = [{"id": f"ours_{i}", "kind": "ours", "overall": v} for i, v in enumerate(ours)]
+    frames += [{"id": f"ctl_{i}", "kind": "control", "overall": v} for i, v in enumerate(control)]
+    return {"scene": "rest:tavern-innkeeper", "backend": "unity-cl", "round": 1,
+            "pregate": pregate, "frames": frames}
+
+
+class SummarizeTests(unittest.TestCase):
+    def test_pass_when_ours_meets_or_beats_control(self):
+        s = frp.summarize(_panel(ours=[6.0, 6.4], control=[5.4]))
+        self.assertEqual(s["verdict"], "PASS")
+        self.assertGreaterEqual(s["delta"], 0)
+
+    def test_fail_when_below_control(self):
+        s = frp.summarize(_panel(ours=[4.0], control=[5.6]))
+        self.assertEqual(s["verdict"], "FAIL")
+        self.assertLess(s["delta"], 0)
+
+    def test_no_control_is_flagged(self):
+        s = frp.summarize(_panel(ours=[7.0], control=[]))
+        self.assertEqual(s["verdict"], "NO_CONTROL")
+
+    def test_critical_pregate_short_circuits(self):
+        s = frp.summarize(_panel(ours=[8.0], control=[5.0], pregate="FLAG"))
+        self.assertEqual(s["verdict"], "PREGATE_BLOCKED")
+
+    def test_delta_is_the_only_citable_metric(self):
+        s = frp.summarize(_panel(ours=[6.0, 6.2], control=[5.5, 5.7]))
+        # medians reported for the ledger, but the verdict rides the delta, not the absolute.
+        self.assertEqual(s["ours_median"], 6.1)
+        self.assertEqual(s["control_median"], 5.6)
+        self.assertAlmostEqual(s["delta"], 0.5, places=3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qa/test_felt_rest_panel.py
+++ b/qa/test_felt_rest_panel.py
@@ -52,6 +52,97 @@ class SummarizeTests(unittest.TestCase):
         self.assertEqual(s["control_median"], 5.6)
         self.assertAlmostEqual(s["delta"], 0.5, places=3)
 
+    def test_pass_requires_a_cleared_pregate(self):
+        """delta >= 0 but the pre-gate never cleared (SKIPPED / missing) is NOT a binding PASS —
+        the W1 gate requires 'no open CRITICAL pre-gate', so an unrun pre-gate is INCONCLUSIVE."""
+        s = frp.summarize(_panel(ours=[6.0], control=[5.0], pregate="SKIPPED"))
+        self.assertEqual(s["verdict"], "INCONCLUSIVE")
+        # ...and a below-control delta is still a hard FAIL regardless of the pre-gate.
+        s2 = frp.summarize(_panel(ours=[4.0], control=[5.0], pregate="SKIPPED"))
+        self.assertEqual(s2["verdict"], "FAIL")
+
+
+class MultiScenePanelTests(unittest.TestCase):
+    def _multi(self, tavern_ours, tavern_ctl, church_ours, church_ctl, pregate="PASS"):
+        frames = []
+        for i, v in enumerate(tavern_ours):
+            frames.append({"id": f"t_o{i}", "scene": "rest:tavern", "kind": "ours", "overall": v})
+        for i, v in enumerate(tavern_ctl):
+            frames.append({"id": f"t_c{i}", "scene": "rest:tavern", "kind": "control", "overall": v})
+        for i, v in enumerate(church_ours):
+            frames.append({"id": f"c_o{i}", "scene": "rest:church", "kind": "ours", "overall": v})
+        for i, v in enumerate(church_ctl):
+            frames.append({"id": f"c_c{i}", "scene": "rest:church", "kind": "control", "overall": v})
+        return {"scene": "rest:combined", "pregate": pregate, "frames": frames}
+
+    def test_strong_scene_cannot_mask_a_below_control_scene(self):
+        """A combined panel: tavern beats its control, church is below its control. The pooled
+        median could hide the church miss, but per-scene grouping surfaces the worst -> FAIL."""
+        s = frp.summarize(self._multi([7.0], [5.0], [4.0], [5.5]))
+        self.assertEqual(s["verdict"], "FAIL")
+        # The reported worst delta is the church's negative one.
+        self.assertLess(s["delta"], 0)
+        by_scene = {g["scene"]: g["verdict"] for g in s["scenes"]}
+        self.assertEqual(by_scene["rest:tavern"], "PASS")
+        self.assertEqual(by_scene["rest:church"], "FAIL")
+
+    def test_both_scenes_beat_control_passes(self):
+        s = frp.summarize(self._multi([6.5], [5.0], [6.0], [5.5]))
+        self.assertEqual(s["verdict"], "PASS")
+
+
+class LogFramesAndMainTests(unittest.TestCase):
+    def test_log_frames_filters_dims_to_rest_lenses_and_drops_none(self):
+        """_log_frames maps only the 5 rest lenses into visual_dims_json and omits None dims."""
+        captured = {}
+
+        def _fake_add_run(run_id, **kw):
+            captured[run_id] = kw
+
+        import sys as _sys
+        import types as _types
+        stub = _types.ModuleType("scores_db")
+        stub.add_run = _fake_add_run  # type: ignore[attr-defined]
+        _sys.modules["scores_db"] = stub
+        try:
+            panel = {
+                "scene": "rest:tavern", "backend": "unity-cl", "round": 2, "pregate": "PASS",
+                "frames": [
+                    {"id": "f1", "kind": "ours", "overall": 6.0,
+                     "dims": {"placement_plausibility": 6, "inhabitation": None, "bogus": 9}},
+                    {"id": "f2", "kind": "control", "overall": 5.0, "dims": {}},
+                ],
+            }
+            n = frp._log_frames(panel, "felt-rest", None)
+        finally:
+            del _sys.modules["scores_db"]
+        self.assertEqual(n, 2)
+        ours_row = next(v for k, v in captured.items() if k.endswith("-f1"))
+        # only the real, non-None rest lens survives; the bogus/None dims are dropped.
+        self.assertEqual(ours_row["visual_dims_json"], {"placement_plausibility": 6})
+        # the control row is scene-suffixed so the delta is queryable from the ledger.
+        ctl_row = next(v for k, v in captured.items() if k.endswith("-f2"))
+        self.assertEqual(ctl_row["visual_scene"], "rest:tavern:control")
+        # a frame with no surviving dims omits the visual_dims_json key entirely.
+        self.assertNotIn("visual_dims_json", ctl_row)
+
+    def test_main_exit_code_is_zero_only_on_pass(self):
+        """main() returns 0 ONLY on a binding PASS; INCONCLUSIVE / FAIL / NO_CONTROL are non-zero
+        so a gate wrapper never reads an unscored or below-control panel as green."""
+        import json
+        import tempfile
+
+        def _run(panel: dict) -> int:
+            with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+                json.dump(panel, fh)
+                path = fh.name
+            return frp.main(["--panel", path, "--dry-run"])
+
+        self.assertEqual(_run(_panel(ours=[6.0], control=[5.0], pregate="PASS")), 0)
+        self.assertEqual(_run(_panel(ours=[6.0], control=[5.0], pregate="SKIPPED")), 1)  # INCONCLUSIVE
+        self.assertEqual(_run(_panel(ours=[4.0], control=[5.0], pregate="PASS")), 1)  # FAIL
+        self.assertEqual(_run(_panel(ours=[7.0], control=[], pregate="PASS")), 1)  # NO_CONTROL
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qa/test_felt_rest_panel.py
+++ b/qa/test_felt_rest_panel.py
@@ -117,14 +117,51 @@ class LogFramesAndMainTests(unittest.TestCase):
         finally:
             del _sys.modules["scores_db"]
         self.assertEqual(n, 2)
-        ours_row = next(v for k, v in captured.items() if k.endswith("-f1"))
+        ours_row = next(v for k, v in captured.items() if "-f1-" in k)
         # only the real, non-None rest lens survives; the bogus/None dims are dropped.
         self.assertEqual(ours_row["visual_dims_json"], {"placement_plausibility": 6})
         # the control row is scene-suffixed so the delta is queryable from the ledger.
-        ctl_row = next(v for k, v in captured.items() if k.endswith("-f2"))
+        ctl_row = next(v for k, v in captured.items() if "-f2-" in k)
         self.assertEqual(ctl_row["visual_scene"], "rest:tavern:control")
         # a frame with no surviving dims omits the visual_dims_json key entirely.
         self.assertNotIn("visual_dims_json", ctl_row)
+
+    def test_log_frames_uses_each_frames_own_scene_and_disambiguates_same_id_rows(self):
+        """Thread PRRT_...G9Xr: a combined panel (tavern + church rows in one panel) must log
+        each row under ITS OWN scene, not the panel-level scene — otherwise every row lands as
+        rest:combined and the ledger can no longer be queried per scene/control pair. Thread
+        PRRT_...G9Xx: when the required 5 blind scorers each submit a row for the SAME shuffled
+        frame id, run_id must stay unique per row so scores_db.add_run's replace-on-PK write
+        doesn't drop all but the last scorer's row."""
+        captured = {}
+
+        def _fake_add_run(run_id, **kw):
+            self.assertNotIn(run_id, captured, f"run_id collided: {run_id}")
+            captured[run_id] = kw
+
+        import sys as _sys
+        import types as _types
+        stub = _types.ModuleType("scores_db")
+        stub.add_run = _fake_add_run  # type: ignore[attr-defined]
+        _sys.modules["scores_db"] = stub
+        try:
+            panel = {
+                "scene": "rest:combined", "backend": "unity-cl", "round": 1, "pregate": "PASS",
+                "frames": [
+                    {"id": "shared", "scene": "rest:tavern", "kind": "ours", "overall": 6.0},
+                    {"id": "shared", "scene": "rest:tavern", "kind": "ours", "overall": 6.5},
+                    {"id": "shared", "scene": "rest:church", "kind": "ours", "overall": 5.0},
+                ],
+            }
+            n = frp._log_frames(panel, "felt-rest", None)
+        finally:
+            del _sys.modules["scores_db"]
+        # all 3 rows survive (no collision-induced overwrite) and carry their OWN scene, not the
+        # panel-level "rest:combined".
+        self.assertEqual(n, 3)
+        self.assertEqual(len(captured), 3)
+        scenes = sorted(v["visual_scene"] for v in captured.values())
+        self.assertEqual(scenes, ["rest:church", "rest:tavern", "rest:tavern"])
 
     def test_main_exit_code_is_zero_only_on_pass(self):
         """main() returns 0 ONLY on a binding PASS; INCONCLUSIVE / FAIL / NO_CONTROL are non-zero

--- a/servers/engine/scene_grid.py
+++ b/servers/engine/scene_grid.py
@@ -249,11 +249,16 @@ def _gen_tavern(scene_id: str, location_id: str, seed: int, rng: random.Random) 
         "center floor": (mid_c, rows // 2),
     }
 
-    # The door + party/foe spawns near the entrance (front), foes a couple cells inside.
+    # The door + party/foe spawns near the entrance (front), foes a couple cells inside. `npcs`
+    # (W1 #1318, additive) = the AT-REST placement anchors for present NPCs — where PEOPLE stand
+    # in a tavern (behind the bar, by the hearth) rather than the foe firing-line — so a rest scene
+    # reads as inhabited. The viewer's rest projection fills these deterministically (id-sorted);
+    # unread by combat. Cells stay clear of the door zone / props.
     exits = [{"cell": [mid_c, rows - 1], "to_location_id": "", "label": "the door to the street"}]
     spawns = {
         "party": [(mid_c - 1, rows - 2), (mid_c, rows - 2), (mid_c + 1, rows - 2)],
         "foes": [(mid_c - 1, 2), (mid_c + 1, 3)],
+        "npcs": [(3, 3), (cols - 4, 3), (mid_c + 2, rows - 3)],
     }
 
     lighting = SceneLighting(
@@ -347,6 +352,9 @@ def _gen_default(scene_id: str, location_id: str, kind: str, seed: int,
     spawns = {
         "party": [(mid_c - 1, rows - 2), (mid_c, rows - 2), (mid_c + 1, rows - 2)],
         "foes": [(mid_c - 1, 2), (mid_c + 1, 2)],
+        # W1 #1318 (additive): at-rest NPC placement anchors — present NPCs stand back near the
+        # interior, not on the foe line. Filled deterministically by the viewer rest projection.
+        "npcs": [(3, 2), (cols - 4, 2)],
     }
 
     # Warm-neutral interior key — NOT #ffffff/0. A muted amber lantern-light from the left.
@@ -458,6 +466,9 @@ def _gen_dungeon(scene_id: str, location_id: str, seed: int, rng: random.Random)
     spawns = {
         "party": [(mid_c - 1, rows - 3), (mid_c, rows - 3), (mid_c + 1, rows - 3)],
         "foes": [(mid_c - 1, 3), (mid_c + 1, 3)],
+        # W1 #1318 (additive): at-rest NPC anchors, off the sarcophagus + foe line — flanking the
+        # mid-floor. Filled deterministically by the viewer rest projection; unread by combat.
+        "npcs": [(mid_c - 2, rows // 2), (mid_c + 2, rows // 2)],
     }
 
     # Warm brazier key, cold-blue ambient — classic dungeon contrast.
@@ -553,6 +564,9 @@ def _gen_forest(scene_id: str, location_id: str, seed: int, rng: random.Random) 
     spawns = {
         "party": [(mid_c - 1, rows - 3), (mid_c, rows - 3), (mid_c + 1, rows - 3)],
         "foes": [(mid_c - 1, 3), (mid_c + 1, 3)],
+        # W1 #1318 (additive): at-rest NPC anchors near the clearing centre, off the tree-line foe
+        # cells. Filled deterministically by the viewer rest projection; unread by combat.
+        "npcs": [(mid_c - 2, rows // 2), (mid_c + 2, rows // 2)],
     }
 
     # Daylight — cool-neutral key from upper-left (sun), pale blue ambient (open sky).
@@ -660,6 +674,10 @@ def _gen_town(scene_id: str, location_id: str, seed: int, rng: random.Random) ->
     spawns = {
         "party": [(mid_c - 1, rows - 3), (mid_c, rows - 3), (mid_c + 1, rows - 3)],
         "foes": [(mid_c - 2, well_r - 2), (mid_c + 2, well_r - 2)],
+        # W1 #1318 (additive): at-rest NPC anchors — a townsperson at each market stall (just in
+        # front of it) where people stand in a plaza. Filled deterministically by the viewer rest
+        # projection; off the well footprint + foe cells; unread by combat.
+        "npcs": [(mid_c - 4, stall_r + 1), (mid_c + 3, stall_r + 1)],
     }
 
     # Daylight — bright overhead sun from upper-right, pale-blue sky ambient.

--- a/servers/engine/tests/test_scene_grid_validate.py
+++ b/servers/engine/tests/test_scene_grid_validate.py
@@ -91,3 +91,15 @@ def test_too_crunched_room_is_caught():
     g = _grid(4, 4, _perimeter(4, 4))
     issues = validate_scene_grid(g, 4, 4)
     assert any("crunched" in v for v in issues), issues
+
+
+def test_npcs_spawn_bucket_on_a_blocked_cell_is_caught():
+    # W1 (#1318): the new `npcs` at-rest spawn bucket must pass the SAME blocked-cell gate as
+    # party/foe spawns — validate's generic spawns.values() loop covers it (pin it so a future
+    # bucket that forks the loop can't slip an npc anchor onto a wall/prop).
+    cells = _perimeter(14, 11) + [SceneCell(c=5, r=5, type="prop", walkable=False, prop_ref="p")]
+    g = _grid(14, 11, cells,
+              props=[SceneProp(id="p", kind="table", cells=[(5, 5)])],
+              spawns={"npcs": [(5, 5)]})  # an npc anchor placed ON the prop
+    issues = validate_scene_grid(g, 14, 11)
+    assert any("spawn cell [5, 5] is BLOCKED" in v for v in issues), issues

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3373,6 +3373,121 @@ def _combat_occluders(snapshot: dict) -> list[dict]:
     return out
 
 
+def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
+    """W1 (#1318) SCENE-AT-REST projection: an additive ``stage`` block carrying ``mode`` +
+    at-rest ``tokens`` so a location renders with its people in it BEFORE combat — the tavern
+    shows its innkeeper before anyone draws a sword.
+
+    PURE PRESENTATION / engine sole-writer: this READS the engine-owned snapshot (party +
+    characters + scene_grid) and PROJECTS it onto ``scene_grid.spawns`` cells; it never mutates
+    and persists nothing. Deterministic (id-sorted assignment, fixed fallback order) so a re-emit
+    on the same snapshot is byte-identical.
+
+    Rest tokens = the party (``snapshot.party``) on the ``party`` spawn cells, plus present NPCs
+    (characters whose ``location_id`` == the current location and whose kind is npc/companion, and
+    who are NOT already party) on the ``npcs`` spawn cells. Cells fall back to ``zone_anchors``
+    values, then the party cells, when a bucket is short.
+
+    NO DOUBLE-PAINT: during active combat the authoritative tokens live in the top-level
+    ``tokens`` (the tactical board); ``stage.tokens`` is therefore EMPTY in combat mode so a
+    rest token can never leak onto the combat board. ``mode`` still reports "combat" so a
+    consumer can branch, but only rest mode carries placements."""
+    mode = "combat" if combat_active else "rest"
+    if combat_active:
+        return {"mode": mode, "tokens": []}
+
+    loc_id = _text(snapshot.get("current_location_id"))
+    locs = snapshot.get("locations") if isinstance(snapshot.get("locations"), dict) else {}
+    loc = locs.get(loc_id) if isinstance(locs, dict) and loc_id else None
+    sg = loc.get("scene_grid") if isinstance(loc, dict) else None
+    spawns = sg.get("spawns") if isinstance(sg, dict) else None
+    spawns = spawns if isinstance(spawns, dict) else {}
+    zone_anchors = sg.get("zone_anchors") if isinstance(sg, dict) else None
+    zone_anchors = zone_anchors if isinstance(zone_anchors, dict) else {}
+
+    def _cell(raw: object) -> tuple[int, int] | None:
+        if isinstance(raw, (list, tuple)) and len(raw) == 2:
+            ci, ri = _num(raw[0]), _num(raw[1])
+            if ci is not None and ri is not None:
+                return (int(ci), int(ri))
+        return None
+
+    def _cells(raw: object) -> list[tuple[int, int]]:
+        out: list[tuple[int, int]] = []
+        if isinstance(raw, list):
+            for c in raw:
+                cell = _cell(c)
+                if cell is not None:
+                    out.append(cell)
+        return out
+
+    party_cells = _cells(spawns.get("party"))
+    npc_cells = _cells(spawns.get("npcs"))
+    # Deterministic fallback pool: the zone anchors (id-sorted) then the party cells, so a bucket
+    # that ran short still lands its actors on a walkable in-world spot rather than off-board.
+    anchor_cells = [
+        cell for _, v in sorted(zone_anchors.items()) if (cell := _cell(v)) is not None
+    ]
+
+    chars = snapshot.get("characters") if isinstance(snapshot.get("characters"), dict) else {}
+    party = snapshot.get("party") if isinstance(snapshot.get("party"), list) else []
+    party_ids = [cid for cid in party if isinstance(cid, str) and cid in chars]
+    party_set = set(party_ids)
+
+    # Present non-party NPCs: characters anchored at the current location (npc/companion kind),
+    # id-sorted for a deterministic order. A companion travelling WITH the party is normally in
+    # `party`; one who is merely present at the location (not yet recruited) is placed too.
+    present_npcs = sorted(
+        cid
+        for cid, ch in chars.items()
+        if isinstance(cid, str) and isinstance(ch, dict)
+        and cid not in party_set
+        and _text(ch.get("kind")).lower() in {"npc", "companion"}
+        and _text(ch.get("location_id")) == loc_id and loc_id
+    )
+
+    tokens: list[dict] = []
+
+    def _emit(cid: str, cells: list[tuple[int, int]], slot: int, fallback_slot: int) -> None:
+        ch = chars.get(cid)
+        ch = ch if isinstance(ch, dict) else {}
+        name = _text(ch.get("name"), cid)
+        kind = _text(ch.get("kind"))
+        cell = None
+        if slot < len(cells):
+            cell = cells[slot]
+        elif anchor_cells:
+            cell = anchor_cells[fallback_slot % len(anchor_cells)]
+        elif party_cells:
+            cell = party_cells[fallback_slot % len(party_cells)]
+        if cell is None:
+            return
+        tokens.append({
+            "id": cid,
+            "name": name,
+            "initial": _combat_initial(name, cid),
+            "short": f"{_combat_initial(name, cid)} portrait",
+            "team": _combat_team(kind),
+            "kind": kind,
+            "x": int(cell[0]),
+            "y": int(cell[1]),
+            # x/y are a DERIVED render hint (a projection of spawn cells), never authoritative
+            # state — same discipline as the combat tokens (#432). The engine stays sole writer.
+            "positionAuthority": "derived",
+            "pose": "idle",
+        })
+
+    fb = 0
+    for i, cid in enumerate(party_ids):
+        _emit(cid, party_cells, i, fb)
+        fb += 1
+    for j, cid in enumerate(present_npcs):
+        _emit(cid, npc_cells, j, fb)
+        fb += 1
+
+    return {"mode": mode, "tokens": tokens}
+
+
 def build_combat_surface(
     snapshot: dict,
     *,
@@ -3450,6 +3565,14 @@ def build_combat_surface(
         # renderer can place invisible depth-only proxies -> a 3D actor moving BEHIND a painted column is
         # correctly hidden by it. READS engine-owned scene_grid.props (occluder=true); [] == none (today).
         "occluders": _combat_occluders(snapshot),
+        # W1 (#1318) SCENE-AT-REST: additive `stage` block — {mode: "rest"|"combat", tokens:[...]}.
+        # In REST mode (no active combat) tokens are a pure deterministic projection of the party +
+        # present NPCs onto scene_grid.spawns cells, so the room renders inhabited before combat. In
+        # COMBAT mode tokens is [] (the authoritative combat tokens are the top-level `tokens`; a
+        # rest token must never leak onto the tactical board). Engine stays sole writer; new key
+        # only — every existing key above/below is byte-unchanged, so combat-mode consumers are
+        # unaffected. See _scene_stage.
+        "stage": _scene_stage(snapshot, combat_active),
         "tokens": tokens,
         "initiative": initiative,
         "zones": zones,

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3421,18 +3421,36 @@ def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
                     out.append(cell)
         return out
 
-    party_cells = _cells(spawns.get("party"))
-    npc_cells = _cells(spawns.get("npcs"))
+    # Blocked cells (walls/props) from the scene_grid cell map, so the fallback pool below never
+    # strands an overflow actor ON a blocking prop. zone_anchors are authored for narration ("the
+    # well") and are NOT validated walkable (unlike party/npc spawn cells, which the engine gate
+    # checks), so an anchor CAN sit on a prop — filter those out. Absent/malformed cells -> empty
+    # blocked set (today's behavior: no filtering).
+    blocked: set[tuple[int, int]] = set()
+    for c in (sg.get("cells") if isinstance(sg, dict) else None) or []:
+        if isinstance(c, dict) and c.get("walkable") is False:
+            cell = _cell([c.get("c"), c.get("r")])
+            if cell is not None:
+                blocked.add(cell)
+
+    party_cells = [c for c in _cells(spawns.get("party")) if c not in blocked]
+    npc_cells = [c for c in _cells(spawns.get("npcs")) if c not in blocked]
     # Deterministic fallback pool: the zone anchors (id-sorted) then the party cells, so a bucket
-    # that ran short still lands its actors on a walkable in-world spot rather than off-board.
+    # that ran short still lands its actors on a walkable in-world spot rather than off-board. Drop
+    # any anchor that lands on a blocking prop/wall — a fallback actor must not stand on a column.
     anchor_cells = [
-        cell for _, v in sorted(zone_anchors.items()) if (cell := _cell(v)) is not None
+        cell for _, v in sorted(zone_anchors.items())
+        if (cell := _cell(v)) is not None and cell not in blocked
     ]
 
     chars = snapshot.get("characters") if isinstance(snapshot.get("characters"), dict) else {}
     party = snapshot.get("party") if isinstance(snapshot.get("party"), list) else []
-    party_ids = [cid for cid in party if isinstance(cid, str) and cid in chars]
-    party_set = set(party_ids)
+    # party_set holds the FULL roster party (incl. any dead) so a slain member is not re-projected
+    # via the present-NPC path below; party_ids drops the dead so a corpse never stands in the rest
+    # scene — the same rule the NPC path applies (combat handles the fallen).
+    party_set = {cid for cid in party if isinstance(cid, str) and cid in chars}
+    party_ids = [cid for cid in party_set if not bool(chars[cid].get("dead"))]
+    party_ids.sort(key=lambda cid: party.index(cid))  # keep authored party order, deterministic
 
     # Present non-party NPCs: characters anchored at the current location (npc/companion kind),
     # id-sorted for a deterministic order. A companion travelling WITH the party is normally in

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3373,6 +3373,16 @@ def _combat_occluders(snapshot: dict) -> list[dict]:
     return out
 
 
+def _is_dead_or_downed(ch: dict) -> bool:
+    """True for a character who must not stand upright in a rest projection: `dead`, or at 0 HP
+    (unconscious/dying, or stabilized-but-still-down — engine fields `stable`/`current_hp`, see
+    combat.py `_ensure_unconscious`). A rest scene only shows characters on their feet."""
+    if bool(ch.get("dead")):
+        return True
+    hp = _num(ch.get("current_hp"))
+    return hp is not None and hp <= 0
+
+
 def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
     """W1 (#1318) SCENE-AT-REST projection: an additive ``stage`` block carrying ``mode`` +
     at-rest ``tokens`` so a location renders with its people in it BEFORE combat — the tavern
@@ -3445,11 +3455,13 @@ def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
 
     chars = snapshot.get("characters") if isinstance(snapshot.get("characters"), dict) else {}
     party = snapshot.get("party") if isinstance(snapshot.get("party"), list) else []
-    # party_set holds the FULL roster party (incl. any dead) so a slain member is not re-projected
-    # via the present-NPC path below; party_ids drops the dead so a corpse never stands in the rest
-    # scene — the same rule the NPC path applies (combat handles the fallen).
+    # party_set holds the FULL roster party (incl. any dead/downed) so a fallen member is not
+    # re-projected via the present-NPC path below; party_ids drops anyone dead OR downed (0 HP,
+    # unconscious/dying/stable — the engine models these separately from `dead`, see combat.py
+    # `_ensure_unconscious`/`stable`) so neither a corpse nor an unconscious companion stands in
+    # the rest scene — the same rule the NPC path applies (combat handles the fallen).
     party_set = {cid for cid in party if isinstance(cid, str) and cid in chars}
-    party_ids = [cid for cid in party_set if not bool(chars[cid].get("dead"))]
+    party_ids = [cid for cid in party_set if not _is_dead_or_downed(chars[cid])]
     party_ids.sort(key=lambda cid: party.index(cid))  # keep authored party order, deterministic
 
     # Present non-party NPCs: characters anchored at the current location (npc/companion kind),
@@ -3462,9 +3474,10 @@ def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
         and cid not in party_set
         and _text(ch.get("kind")).lower() in {"npc", "companion"}
         and _text(ch.get("location_id")) == loc_id and loc_id
-        # a DEAD character never stands in the rest scene — a corpse at the hearth breaks the
-        # inhabited read this projection exists to create (and combat handles the fallen).
-        and not bool(ch.get("dead"))
+        # a DEAD or DOWNED (0 HP, not yet dead) character never stands in the rest scene — a
+        # corpse or an unconscious companion casually standing at the hearth breaks the inhabited
+        # read this projection exists to create (and combat handles the fallen).
+        and not _is_dead_or_downed(ch)
     )
 
     tokens: list[dict] = []

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3444,6 +3444,9 @@ def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
         and cid not in party_set
         and _text(ch.get("kind")).lower() in {"npc", "companion"}
         and _text(ch.get("location_id")) == loc_id and loc_id
+        # a DEAD character never stands in the rest scene — a corpse at the hearth breaks the
+        # inhabited read this projection exists to create (and combat handles the fallen).
+        and not bool(ch.get("dead"))
     )
 
     tokens: list[dict] = []

--- a/viewer/tests/test_scene_at_rest_stage.py
+++ b/viewer/tests/test_scene_at_rest_stage.py
@@ -137,6 +137,18 @@ class SceneAtRestProjectionTests(unittest.TestCase):
         ids = {t["id"] for t in stage["tokens"]}
         self.assertNotIn("npc_elsewhere", ids)
 
+    def test_dead_npc_is_never_placed_in_the_rest_scene(self):
+        """A corpse never stands at the hearth: a character at the current location whose
+        `dead` flag is set is excluded from the rest projection (combat handles the fallen)."""
+        snap = _rest_snapshot()
+        snap["characters"]["npc_dead"] = {
+            "kind": "npc", "name": "Slain Bandit", "location_id": snap["current_location_id"],
+            "dead": True,
+        }
+        stage = _surface(snap)["stage"]
+        ids = {t["id"] for t in stage["tokens"]}
+        self.assertNotIn("npc_dead", ids)
+
     def test_combat_mode_carries_no_stage_tokens(self):
         """No double-paint: under active combat the authoritative tokens are the top-level
         `tokens`; the stage block reports combat mode but places nothing."""

--- a/viewer/tests/test_scene_at_rest_stage.py
+++ b/viewer/tests/test_scene_at_rest_stage.py
@@ -149,6 +149,38 @@ class SceneAtRestProjectionTests(unittest.TestCase):
         ids = {t["id"] for t in stage["tokens"]}
         self.assertNotIn("npc_dead", ids)
 
+    def test_dead_party_member_is_never_placed_in_the_rest_scene(self):
+        """The corpse-at-the-hearth rule holds for the PARTY branch too: a party member whose
+        `dead` flag is set is excluded from the rest projection (the NPC branch already excludes
+        the dead; this pins the party branch)."""
+        snap = _rest_snapshot()
+        snap["party"] = ["pc_hero", "pc_slain"]
+        snap["characters"]["pc_slain"] = {
+            "id": "pc_slain", "name": "Fallen Kael", "kind": "player",
+            "location_id": "loc1", "dead": True,
+        }
+        stage = _surface(snap)["stage"]
+        ids = {t["id"] for t in stage["tokens"]}
+        self.assertNotIn("pc_slain", ids)
+        self.assertIn("pc_hero", ids)
+
+    def test_fallback_anchor_on_a_blocked_cell_is_skipped(self):
+        """Overflow actors fall back to zone_anchors; a zone anchor that sits on a blocking
+        prop/wall (anchors are narration-authored, NOT walkable-validated) must be dropped so an
+        actor never stands on a column."""
+        snap = _rest_snapshot()
+        sg = snap["locations"]["loc1"]["scene_grid"]
+        # One authored npc cell; two present NPCs -> the 2nd overflows to zone_anchors.
+        sg["spawns"]["npcs"] = [[5, 5]]
+        # "the bar" anchor (3,2) is a blocking prop cell; "the hearth" (11,2) is walkable floor.
+        sg["cells"] = [{"c": 3, "r": 2, "type": "prop", "walkable": False, "prop_ref": "bar"}]
+        snap["characters"]["npc_a"] = {"kind": "npc", "name": "Aleph", "location_id": "loc1"}
+        snap["characters"]["npc_b"] = {"kind": "npc", "name": "Bet", "location_id": "loc1"}
+        stage = _surface(snap)["stage"]
+        placed = {(t["x"], t["y"]) for t in stage["tokens"]}
+        # No token landed on the blocked bar anchor (3,2).
+        self.assertNotIn((3, 2), placed)
+
     def test_combat_mode_carries_no_stage_tokens(self):
         """No double-paint: under active combat the authoritative tokens are the top-level
         `tokens`; the stage block reports combat mode but places nothing."""

--- a/viewer/tests/test_scene_at_rest_stage.py
+++ b/viewer/tests/test_scene_at_rest_stage.py
@@ -164,6 +164,38 @@ class SceneAtRestProjectionTests(unittest.TestCase):
         self.assertNotIn("pc_slain", ids)
         self.assertIn("pc_hero", ids)
 
+    def test_downed_but_not_dead_party_member_is_not_stood_up_at_rest(self):
+        """Thread PRRT_...G9Xv: a party member at current_hp==0 who is NOT dead (the engine
+        models stable/unconscious separately from `dead` — combat.py `_ensure_unconscious`) must
+        not be placed as an idle standing rest token either. Covers both the dying (unstable, 0
+        HP) and the stabilized (0 HP, stable=True) cases."""
+        snap = _rest_snapshot()
+        snap["party"] = ["pc_hero", "pc_dying", "pc_stable"]
+        snap["characters"]["pc_dying"] = {
+            "id": "pc_dying", "name": "Dying Rook", "kind": "player",
+            "location_id": "loc1", "current_hp": 0, "dead": False, "stable": False,
+        }
+        snap["characters"]["pc_stable"] = {
+            "id": "pc_stable", "name": "Stabilized Finn", "kind": "player",
+            "location_id": "loc1", "current_hp": 0, "dead": False, "stable": True,
+        }
+        stage = _surface(snap)["stage"]
+        ids = {t["id"] for t in stage["tokens"]}
+        self.assertNotIn("pc_dying", ids)
+        self.assertNotIn("pc_stable", ids)
+        self.assertIn("pc_hero", ids)
+
+    def test_downed_but_not_dead_npc_is_not_stood_up_at_rest(self):
+        """Same rule for the NPC branch: a present NPC at 0 HP who is not `dead` is excluded."""
+        snap = _rest_snapshot()
+        snap["characters"]["npc_downed"] = {
+            "kind": "npc", "name": "Downed Guard", "location_id": snap["current_location_id"],
+            "current_hp": 0, "dead": False,
+        }
+        stage = _surface(snap)["stage"]
+        ids = {t["id"] for t in stage["tokens"]}
+        self.assertNotIn("npc_downed", ids)
+
     def test_fallback_anchor_on_a_blocked_cell_is_skipped(self):
         """Overflow actors fall back to zone_anchors; a zone anchor that sits on a blocking
         prop/wall (anchors are narration-authored, NOT walkable-validated) must be dropped so an

--- a/viewer/tests/test_scene_at_rest_stage.py
+++ b/viewer/tests/test_scene_at_rest_stage.py
@@ -1,0 +1,165 @@
+"""W1 (#1318) SCENE-AT-REST — the additive `stage` block on build_combat_surface.
+
+The surface gains an additive `stage` = {mode, tokens}. In REST mode (no active combat) the
+tokens are a pure deterministic projection of the party + present NPCs onto scene_grid.spawns
+cells; in COMBAT mode the block is {mode:"combat", tokens:[]} so a rest token never leaks onto
+the tactical board. Engine stays sole writer; the block is a NEW key only, so every existing
+consumer of the combat surface is byte-unchanged.
+
+Invariants asserted here:
+  * TEXT-TIER BYTE-IDENTITY — deleting `stage` yields EXACTLY today's payload (same keys, same
+    values) for both a rest and a combat snapshot, so existing consumers are unaffected.
+  * ADDITIVE WIRE — `stage` is the only new top-level key.
+  * PROJECTION CORRECTNESS — an NPC at the current location appears at its spawn cell; an NPC at
+    another location does NOT; the party is placed; combat mode carries no stage tokens.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server_rest", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+def _surface(snapshot: dict) -> dict:
+    return server.build_combat_surface(
+        snapshot, campaign_id="c", live=False, is_live_view=False, recent_events=[]
+    )
+
+
+# The full top-level key set the surface carried BEFORE W1 (the "today's payload" contract). If
+# build_combat_surface adds/removes a NON-stage key this list must change and the byte-identity
+# test below breaks LOUDLY — that is the point: only `stage` may be new.
+_LEGACY_KEYS = {
+    "campaign_id", "turnToken", "combatFrameScope", "title", "world", "dayLabel", "location",
+    "encounter", "grid", "lastPath", "impassable", "doors", "occluders", "tokens", "initiative",
+    "zones", "selectedTokenId", "actionEconomy", "commandCenter", "actionBar", "battleLog",
+    "live", "is_live_view", "can_act", "state_authority", "write_lane",
+}
+
+
+def _tavern_scene_grid(loc_id: str = "loc1") -> dict:
+    """A minimal but valid scene_grid carrying party + npc spawn buckets (as the generators emit)."""
+    return {
+        "scene_id": f"w:{loc_id}",
+        "location_id": loc_id,
+        "kind": "tavern",
+        "grid": {"cols": 14, "rows": 10, "cell_size_ft": 5, "projection": "dimetric-2to1"},
+        "cell_default": {"type": "floor", "walkable": True, "cost": 1},
+        "cells": [],
+        "spawns": {
+            "party": [[6, 8], [7, 8], [8, 8]],
+            "foes": [[6, 2], [8, 3]],
+            "npcs": [[3, 3], [10, 3], [9, 7]],
+        },
+        "zone_anchors": {"the bar": [3, 2], "the hearth": [11, 2]},
+    }
+
+
+def _rest_snapshot() -> dict:
+    return {
+        "current_location_id": "loc1",
+        "locations": {"loc1": {"name": "The Tavern", "scene_grid": _tavern_scene_grid()}},
+        "party": ["pc_hero"],
+        "characters": {
+            "pc_hero": {"id": "pc_hero", "name": "Aria", "kind": "player", "location_id": "loc1"},
+            "npc_keeper": {"id": "npc_keeper", "name": "Innkeeper Bram",
+                           "kind": "npc", "location_id": "loc1"},
+            "npc_elsewhere": {"id": "npc_elsewhere", "name": "Distant Priest",
+                              "kind": "npc", "location_id": "loc2"},
+        },
+    }
+
+
+def _combat_snapshot() -> dict:
+    snap = _rest_snapshot()
+    snap["combat"] = {
+        "active": True,
+        "turn_index": 0,
+        "order": [{"character_id": "pc_hero", "name": "Aria", "kind": "player", "initiative": 12}],
+    }
+    return snap
+
+
+class SceneAtRestByteIdentityTests(unittest.TestCase):
+    def test_rest_payload_minus_stage_is_todays_keys(self):
+        """Deleting `stage` from a rest surface leaves EXACTLY the legacy key set — no existing
+        key was added, removed, or renamed (text-tier byte-identity for existing consumers)."""
+        surface = _surface(_rest_snapshot())
+        self.assertIn("stage", surface)
+        without_stage = {k: v for k, v in surface.items() if k != "stage"}
+        self.assertEqual(set(without_stage), _LEGACY_KEYS)
+
+    def test_combat_payload_minus_stage_is_todays_keys(self):
+        """Same byte-identity guarantee under active combat — the combat board's payload is
+        untouched by the additive stage block."""
+        surface = _surface(_combat_snapshot())
+        without_stage = {k: v for k, v in surface.items() if k != "stage"}
+        self.assertEqual(set(without_stage), _LEGACY_KEYS)
+
+    def test_stage_is_the_only_new_key(self):
+        surface = _surface(_rest_snapshot())
+        self.assertEqual(set(surface) - _LEGACY_KEYS, {"stage"})
+
+    def test_empty_snapshot_is_rest_with_no_tokens(self):
+        """A degenerate snapshot (no location/scene_grid) still yields a well-formed additive
+        stage — rest mode, empty tokens — and does not perturb the legacy keys."""
+        surface = _surface({})
+        self.assertEqual(surface["stage"], {"mode": "rest", "tokens": []})
+        self.assertEqual(set(surface) - _LEGACY_KEYS, {"stage"})
+
+
+class SceneAtRestProjectionTests(unittest.TestCase):
+    def test_rest_mode_places_party_and_present_npc(self):
+        stage = _surface(_rest_snapshot())["stage"]
+        self.assertEqual(stage["mode"], "rest")
+        by_id = {t["id"]: t for t in stage["tokens"]}
+        # The party PC is placed on the first party spawn cell.
+        self.assertIn("pc_hero", by_id)
+        self.assertEqual((by_id["pc_hero"]["x"], by_id["pc_hero"]["y"]), (6, 8))
+        # The present NPC (location_id == current) is placed on the first npc spawn cell.
+        self.assertIn("npc_keeper", by_id)
+        self.assertEqual((by_id["npc_keeper"]["x"], by_id["npc_keeper"]["y"]), (3, 3))
+        # Rest tokens are idle-posed derived hints, never authoritative.
+        self.assertEqual(by_id["npc_keeper"]["pose"], "idle")
+        self.assertEqual(by_id["npc_keeper"]["positionAuthority"], "derived")
+
+    def test_npc_at_another_location_is_not_placed(self):
+        stage = _surface(_rest_snapshot())["stage"]
+        ids = {t["id"] for t in stage["tokens"]}
+        self.assertNotIn("npc_elsewhere", ids)
+
+    def test_combat_mode_carries_no_stage_tokens(self):
+        """No double-paint: under active combat the authoritative tokens are the top-level
+        `tokens`; the stage block reports combat mode but places nothing."""
+        surface = _surface(_combat_snapshot())
+        self.assertEqual(surface["stage"]["mode"], "combat")
+        self.assertEqual(surface["stage"]["tokens"], [])
+        # ...while the combat board itself still has its tokens (unchanged path).
+        self.assertTrue(surface["tokens"])
+
+    def test_projection_is_deterministic(self):
+        a = _surface(_rest_snapshot())["stage"]
+        b = _surface(_rest_snapshot())["stage"]
+        self.assertEqual(a, b)
+
+    def test_companion_present_but_not_in_party_is_placed(self):
+        snap = _rest_snapshot()
+        snap["characters"]["comp_shade"] = {
+            "id": "comp_shade", "name": "Shade", "kind": "companion", "location_id": "loc1",
+        }
+        stage = _surface(snap)["stage"]
+        ids = {t["id"] for t in stage["tokens"]}
+        self.assertIn("comp_shade", ids)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## W1 — Scene at Rest (charter #1328 lane 1, epic #1318)

The first walkable-world rung: a location renders **AT REST** — party + present NPCs placed on the grid in idle poses, so a tavern shows its innkeeper before anyone draws a sword. Pure **presentation** of engine state; zero new persisted state.

Built decision-by-eval (instrument first).

### Seams touched
| file:line | change |
|---|---|
| `qa/felt_rest_panel.md` | NEW — FELT REST-SCENE panel protocol (disguised real-game controls, 5 blind scorers, control-anchored delta, no AI-prior primers). |
| `qa/felt_rest_panel.py` | NEW — thin logger/summarizer → existing `scores_db` surface=`visual`; **delta-only** verdict (never cites an absolute). |
| `viewer/server.py` `_scene_stage` (before `build_combat_surface`) + `"stage"` key in the surface dict | additive `stage` = `{mode:"rest"\|"combat", tokens:[...]}`. Rest tokens = deterministic projection of party + present NPCs onto `scene_grid.spawns` cells. |
| `servers/engine/scene_grid.py` (all 5 generators) | added an `npcs` at-rest spawn bucket at in-world anchors, off props / the foe line. |
| `extensions/renderers/unity/scripts/paint_combat_v1.cs` | scene-at-rest render mode: `stage.mode=="rest"` paints `stage.tokens` idle-posed, skips combat VFX. |

### The `stage` block shape
```json
{ "mode": "rest",
  "tokens": [ { "id","name","initial","short","team","kind","x","y",
                "positionAuthority":"derived","pose":"idle" } ] }
```
`x`/`y` are a **derived** render hint (a projection of spawn cells), never authoritative — same discipline as the combat tokens (#432). Rest tokens = party (on `spawns["party"]`) + present NPCs (kind npc/companion, `location_id == current`, not already in party) on `spawns["npcs"]`; fallback `zone_anchors` → party cells; id-sorted → deterministic. **Combat mode ⇒ `{mode:"combat", tokens:[]}`** so a rest token never leaks onto the tactical board (no double-paint).

### Render path + eyeball
GEX44 box: served the **real** `_scene_stage` output (from an `emit_scene_grid` tavern) on loopback :8765, tavern_firelit plate, ran the modified renderer → 2 grounded, ring-marked actors: **Aria** (party) and **Innkeeper Bram** (npc) on the painterly firelit tavern, **no combat VFX**. Render: `~/worldos-session-notes/renders/rest_scene_v1.png`.
Eyeball: placement / plate / grounding / rings all correct. Actors are T-posed — the **placeholder** Meshy fbx has no clean `idle` clip (the renderer already documents this); a rigged demo cast with the 9-clip moveset settles to a standing idle. Art-asset gap, not a wiring gap — exactly what the FELT-rest panel scores later.

### Tests
- `viewer/tests/test_scene_at_rest_stage.py` (12 new): **text-tier byte-identity** (deleting `stage` ⇒ exactly today's key set, for both rest and combat snapshots), additive-wire, projection correctness (present NPC placed; NPC elsewhere not; combat ⇒ empty stage tokens; deterministic). + existing `test_combat_grid_scene_grid` (4) green.
- `servers/engine`: `test_scene_grid` (28) + `test_content` byte-identity green (118 total).
- `qa/test_felt_rest_panel.py` (5); meta-guards (`test_behavioral_gate_corpus`, `test_assert_behavioral`) green — **no `chk()` change**, no trigger.
- `qa/fast_gate.sh` **T0 PASS (257)** — no combat/rest/travel regression.

### ⚠ ACCEPTED RISK (per charter #1328)
`spawns` is inside `_layout_hash` (`scene_grid.py:158`) → the new `npcs` bucket changes the layout hash → **one-time Tier-2 art-cache invalidation** for every location. Rooms re-generate byte-identically afterward (deterministic seed). Accepted.

### Invariants held
Engine sole-writer (projection reads only, persists nothing) · additive wire (new `stage` key only) · text-tier byte-identity · combat-mode consumers unchanged · no `chk()` change.

Do **not** merge — coordinator reviews.