### PR TITLE
docs: QA-economics v2 — playtests are batch evidence, never PR gates

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -31,6 +31,19 @@ Full detail: the `worldos-dev` skill / `WorldOS-RUNBOOK.md`. Heavy QA runs on th
 
 ## Run economics — match the instrument to the question
 
+**★ QA-economics v2 (owner-ratified 2026-07-06) — playtests are BATCH evidence, never PR gates:**
+- **An hour-scale playtest duo is NEVER a per-PR validation step.** The 24-beat Opus ruler duo runs
+  ONCE per merged BATCH (e.g. at the end of a sprint/push), as release evidence — not per PR, not per
+  iteration. If you are about to launch a long duo to check one PR's effect, stop: that question has a
+  cheaper instrument.
+- **Default PR validation ladder** (stop at the first rung that answers): Tier-0 `qa/fast_gate.sh`
+  (free, seconds, EVERY change) → Tier-1.5 `qa/mechanism_probe.sh` (~$1, cue/mechanism questions) →
+  `qa/run_combat_sprint.sh` (~2 min) when the change is combat-adjacent. LLM story lenses are NOT run
+  per-PR.
+- **Story-quality iteration runs in the BACKGROUND on GLM** (off-budget z.ai; batch-read the results at
+  the next natural checkpoint) and never blocks the build critical path. Story polish is a later-pass
+  concern once the system is feature-complete; the engine/renderer/pipeline lanes keep moving.
+
 Spend the cheapest instrument that answers the question (tier table + honest signal accounting:
 `docs/qa/FAST_GATE.md`):
 - **MECHANISM iterations** ("does obligation cue X fire? does the DM act on it?") → the **Tier-1.5


### PR DESCRIPTION
Owner-ratified 2026-07-06: hour-scale duos never gate a PR (batch evidence only, once per merged batch); default PR ladder = fast_gate → mechanism probe → combat sprint; story iteration = GLM background only, never blocking the build path. Amends the Run-economics section (#1336).