### PR TITLE
[W3-engine] parley stage metadata + approach-to-talk (additive; #1320)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -10361,6 +10361,94 @@ def _parley_npc_difficulty(ch) -> str:
     return _ATTITUDE_DEFAULT_DIFFICULTY.get(band, "medium")
 
 
+def _nearest_walkable_adjacent(
+    goal: tuple[int, int],
+    start: "tuple[int, int] | None",
+    blocked: set[tuple[int, int]],
+    width: int,
+    height: int,
+) -> "tuple[int, int] | None":
+    """W3 (#1320): the ADJACENT-to-``goal`` cell (Chebyshev distance <=1 — the SAME 5ft-reach
+    definition as ``combat_grid.in_melee_reach``, combat_grid.py) that is walkable AND reachable,
+    closest to ``start``. This is the cell the party walks TO so it stands beside the speaking NPC
+    (never onto it). Reuses ``combat_grid.shortest_path`` for reachability — pathing is never
+    forked. Returns None when every one of the 8 neighbours is blocked/off-grid/unreachable (the
+    caller then falls back to today's freeform parley — the MED-addendum fallback for #1320)."""
+    candidates: list[tuple[int, int]] = []
+    for dx in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            if dx == 0 and dy == 0:
+                continue  # the NPC's own cell — never stand on the interlocutor
+            cell = (goal[0] + dx, goal[1] + dy)
+            if not (0 <= cell[0] < width and 0 <= cell[1] < height):
+                continue
+            if cell in blocked:
+                continue
+            assert combat_grid.in_melee_reach(cell, goal)  # Chebyshev<=1 by construction
+            candidates.append(cell)
+    if not candidates:
+        return None
+    if start is None:
+        # An unplaced mover: any free adjacent cell is a legal placement; pick the deterministic
+        # first (reading order) so a re-approach on the same board is stable.
+        return sorted(candidates)[0]
+    if start in candidates:
+        return start  # already standing adjacent — no walk needed
+    # Reachable candidates only, ranked by the routed step count (then reading order) so the party
+    # takes the shortest legal approach. `blocked` doubles as `occupied` (same as walk_to's call).
+    reachable: list[tuple[int, tuple[int, int]]] = []
+    for cell in candidates:
+        routed = combat_grid.shortest_path(start, cell, blocked, width, height)
+        if routed is not None:
+            reachable.append((len(routed), cell))
+    if not reachable:
+        return None
+    reachable.sort(key=lambda t: (t[0], t[1]))
+    return reachable[0][1]
+
+
+def _approach_to_talk(campaign_id: str, mover_id: str, npc) -> "dict | None":
+    """W3 (#1320) approach-to-talk: walk ``mover_id`` to a cell ADJACENT to the tracked ``npc``'s
+    stage cell, THEN return an approach descriptor — so a click-NPC parley opens AT the actor
+    instead of via a disembodied portrait. Reuses W2's ``rest_blocked_cells`` + ``walk_to`` (the
+    sole writer of ``stage_cell``); pathing is never forked.
+
+    Returns ``{walked, from, to, npc_cell, path}`` on a successful approach (or when the mover is
+    already adjacent — walked False, empty path), or ``None`` to DEGRADE to today's freeform
+    parley when there is nothing to approach: the NPC has no known stage cell, no scene grid /
+    combat is active (walk_to would refuse), or no legal adjacent cell is reachable (blocked
+    pathing — the MED-addendum fallback). Never raises: approach is best-effort positioning."""
+    c = _require(campaign_id)
+    if c.combat.active:
+        return None  # combat lane owns positioning — walk_to would refuse; freeform parley
+    loc = c.locations.get(c.current_location_id) if c.current_location_id else None
+    if loc is None or getattr(loc, "scene_grid", None) is None:
+        return None  # no painted room to approach across (additive: today's behavior)
+    npc_cell = getattr(npc, "stage_cell", None)
+    if npc_cell is None:
+        return None  # the NPC isn't staged anywhere — nothing to approach; freeform parley
+    npc_cell = (int(npc_cell[0]), int(npc_cell[1]))
+    mover = c.characters.get(mover_id)
+    if mover is None:
+        return None
+    # The mover never blocks itself; the NPC's own cell stays blocked (we stand BESIDE it).
+    width, height, blocked = rest_blocked_cells(c, loc, exclude_id=mover_id)
+    if width <= 0 or height <= 0:
+        return None
+    start = getattr(mover, "stage_cell", None)
+    start = (int(start[0]), int(start[1])) if start is not None else None
+    dest = _nearest_walkable_adjacent(npc_cell, start, blocked, width, height)
+    if dest is None:
+        return None  # no legal adjacent cell reachable → freeform parley (MED-addendum fallback)
+    if start is not None and start == dest:
+        return {"walked": False, "from": list(start), "to": list(start), "npc_cell": list(npc_cell), "path": [list(start)]}
+    # Reuse walk_to — the SOLE writer of stage_cell (takes its own lock + save + rest_walk beat).
+    res = walk_to(campaign_id, mover_id, dest[0], dest[1])
+    if not res.get("walked"):
+        return None  # a race lost the cell between planning and the walk → freeform parley
+    return {"walked": True, "from": res.get("from"), "to": res.get("to"), "npc_cell": list(npc_cell), "path": res.get("path", [])}
+
+
 @mcp.tool()
 def generate_parley_options(
     campaign_id: str,
@@ -10374,27 +10462,37 @@ def generate_parley_options(
     target_id: str = "",
     character_id: str = "",
     id: str = "",
+    approach: bool = False,
 ) -> dict:
     """Call this BEFORE narrating a social encounter or any choice point: it lays out the
-    PLAYER'S available options with sheet-correct DCs so you author a real Parley menu
-    instead of railroading to one narrated path. This is NOT `companion_advise` (the
-    companion's in-character take) or `get_scene` (the authored scene beats) — it returns
-    the lead PC's own alignment + the actual skill modifiers off their sheet + a suggested
-    DC per skill, so you write 2-4 tagged choices WITHOUT hand-computing anything.
+    PLAYER'S available options with sheet-correct DCs so you author a real Parley menu instead
+    of railroading (NOT `companion_advise`/`get_scene`). It returns the lead PC's alignment +
+    sheet-correct skill modifiers + a suggested DC per skill, so you write tagged choices without
+    hand-computing.
     Bind to a TRACKED NPC via ``npc_id`` (aliases ``target_id`` / ``character_id`` / ``id``)
-    so the surface carries an ``npc`` block and the default ``difficulty`` is derived from the
-    target's attitude (hostile=HARD, friendly=EASY, indifferent=MEDIUM); an explicit
-    ``difficulty`` always wins, an unknown npc_id degrades to a freeform parley."""
+    so the surface carries an ``npc`` block and the default ``difficulty`` derives from the
+    target's attitude; an explicit ``difficulty`` always wins, an unknown npc_id degrades to a
+    freeform parley.
+    ``approach=True`` walks the PC adjacent to the NPC first (W2 walk_to); parley opens AT the
+    actor, else freeform."""
+    # W3: approach-to-talk WRITES stage_cell (via walk_to) and must run BEFORE the read-only
+    # projection below so the npc/approach blocks reflect the post-walk board. Resolve the actor +
+    # NPC ids first (a pure read), walk, then re-load fresh objects for the options snapshot.
     c = _require(campaign_id)
     aid = actor_id or _lead_pc_id(c)
     if not aid:
         raise ValueError("campaign has no characters to parley with; create the PC first")
-    actor = _char(c, aid)
-
     # F10-2/SYN-07: bind to a tracked NPC (additive). Accept the id the DM reaches for; an
     # unknown id DEGRADES to a freeform parley (no npc block) — like event_id, it never
     # raises mid-scene. The binding is a pure READ: nothing on the NPC is mutated here.
     npc_id = npc_id or target_id or character_id or id
+    approach_info: dict | None = None
+    if approach and npc_id and npc_id in c.characters:
+        # Best-effort positioning; None -> freeform parley (no `approach` key). walk_to re-saves,
+        # so re-load below to project the moved stage cells.
+        approach_info = _approach_to_talk(campaign_id, aid, c.characters[npc_id])
+        c = _require(campaign_id)
+    actor = _char(c, aid)
     the_npc = c.characters.get(npc_id) if npc_id else None
 
     # Default skill set: the actor's own proficient/expertise skills UNION the four core
@@ -10455,6 +10553,17 @@ def generate_parley_options(
             "met": the_npc.met,
             "difficulty": effective_difficulty or "medium",
         }
+        # W3 (#1320): where the SPEAKING NPC stands, so the DM/renderer can open the dialogue AT
+        # the actor. Read-only echo of the NPC's stage cell (walk_to is the sole writer). Only
+        # when the NPC is actually staged — absent -> no key (byte-identical to today's block).
+        if the_npc.stage_cell is not None:
+            out["npc"]["stage_cell"] = [int(the_npc.stage_cell[0]), int(the_npc.stage_cell[1])]
+    # W3 (#1320): the approach-to-talk result — present ONLY when approach=True actually walked (or
+    # found the party already adjacent). Absent when approach was not requested OR degraded to a
+    # freeform parley (no stage cell / no grid / combat / unreachable) — so the default payload is
+    # byte-identical to before. `walked` distinguishes a real walk from an already-adjacent no-op.
+    if approach_info is not None:
+        out["approach"] = approach_info
     # Quest & Arc engine, Layer 3: when a live Event is named, attach its authored options as
     # the menu slots (the free-form path above stays). A resolved/unknown Event omits the block,
     # degrading to today's freeform parley. resolve_event applies a picked option's ripple.

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -10384,7 +10384,10 @@ def _nearest_walkable_adjacent(
                 continue
             if cell in blocked:
                 continue
-            assert combat_grid.in_melee_reach(cell, goal)  # Chebyshev<=1 by construction
+            # cell is always within combat_grid.in_melee_reach (Chebyshev<=1) of goal here:
+            # dx,dy range over {-1,0,1} excluding (0,0) above, so this holds by construction
+            # and isn't re-verified at runtime (an assert here would be stripped under -O and
+            # adds no real guard — the invariant is the loop bounds, not a check on cell).
             candidates.append(cell)
     if not candidates:
         return None
@@ -10431,6 +10434,13 @@ def _approach_to_talk(campaign_id: str, mover_id: str, npc) -> "dict | None":
     mover = c.characters.get(mover_id)
     if mover is None:
         return None
+    # walk_to (W2 review fix) rejects a mover anchored at a location_id different from the
+    # current one — mirror that guard here so we degrade to freeform instead of ever reaching
+    # walk_to's raise (this is the one walk_to precondition _approach_to_talk didn't already
+    # pre-check; None/"" — the party's own not-yet-travelled sentinel, #1349 — is left alone,
+    # matching walk_to's own carve-out).
+    if mover.location_id and mover.location_id != loc.id:
+        return None
     # The mover never blocks itself; the NPC's own cell stays blocked (we stand BESIDE it).
     width, height, blocked = rest_blocked_cells(c, loc, exclude_id=mover_id)
     if width <= 0 or height <= 0:
@@ -10443,7 +10453,14 @@ def _approach_to_talk(campaign_id: str, mover_id: str, npc) -> "dict | None":
     if start is not None and start == dest:
         return {"walked": False, "from": list(start), "to": list(start), "npc_cell": list(npc_cell), "path": [list(start)]}
     # Reuse walk_to — the SOLE writer of stage_cell (takes its own lock + save + rest_walk beat).
-    res = walk_to(campaign_id, mover_id, dest[0], dest[1])
+    # Belt-and-suspenders on the docstring's absolute "Never raises" contract: every precondition
+    # walk_to checks is already mirrored above, but a TOCTOU race (state changing between our
+    # planning read and walk_to's own re-check under its lock) could still surface one of walk_to's
+    # ValueErrors here — catch and degrade to freeform rather than ever propagating.
+    try:
+        res = walk_to(campaign_id, mover_id, dest[0], dest[1])
+    except ValueError:
+        return None  # lost a race between planning and the walk → freeform parley
     if not res.get("walked"):
         return None  # a race lost the cell between planning and the walk → freeform parley
     return {"walked": True, "from": res.get("from"), "to": res.get("to"), "npc_cell": list(npc_cell), "path": res.get("path", [])}

--- a/servers/engine/tests/test_parley_approach.py
+++ b/servers/engine/tests/test_parley_approach.py
@@ -25,7 +25,6 @@ import pytest
 
 import server  # imported FIRST: resolves the models<->scene_grid import cycle in the right order
 import combat_grid  # noqa: F401  (referenced by name in assertions/comments)
-import store
 from scene_grid import (
     SceneGrid,
     SceneGridSpec,
@@ -129,7 +128,6 @@ def test_approach_already_adjacent_is_a_noop_walk(talk_room):
 def test_approach_unreachable_npc_degrades_to_freeform(talk_room):
     cid, hero, npc, loc_id = talk_room
     # Wall off every neighbour of the NPC by staging blockers there so no adjacent cell is free.
-    c = server._require(cid)
     b1 = server.create_character(cid, "Guard A", kind="npc")["id"]
     b2 = server.create_character(cid, "Guard B", kind="npc")["id"]
     b3 = server.create_character(cid, "Guard C", kind="npc")["id"]
@@ -162,6 +160,22 @@ def test_approach_during_combat_degrades_to_freeform(talk_room):
     out = server.generate_parley_options(cid, npc_id=npc, approach=True)
     assert "approach" not in out
     assert out["npc"]["id"] == npc  # options still open
+
+
+def test_approach_location_mismatch_degrades_to_freeform_never_raises(talk_room):
+    # Regression for the "Never raises" contract: walk_to (W2 review fix) rejects a mover
+    # anchored at a location_id different from the current one. _approach_to_talk must degrade
+    # to freeform BEFORE ever reaching that raise, not propagate a ValueError mid-parley.
+    cid, hero, npc, loc_id = talk_room
+    c = server._require(cid)
+    c.characters[hero].location_id = "some-other-location"  # anchored elsewhere, not loc_id
+    server.save_campaign(c)
+    out = server.generate_parley_options(cid, npc_id=npc, approach=True)  # must not raise
+    assert "approach" not in out           # degraded to freeform parley
+    assert out["npc"]["id"] == npc         # the parley STILL opens (never blocked)
+    # the hero never moved (walk_to was never reached) and location_id is untouched
+    assert tuple(server._require(cid).characters[hero].stage_cell) == (0, 0)
+    assert server._require(cid).characters[hero].location_id == "some-other-location"
 
 
 # ── byte-identity: the default (no-approach) payload is unchanged ─────────────────────

--- a/servers/engine/tests/test_parley_approach.py
+++ b/servers/engine/tests/test_parley_approach.py
@@ -1,0 +1,189 @@
+"""W3 (#1320, Act II roadmap §4b/W3): approach-to-talk + parley stage metadata — the ENGINE
+half of "Talk". `generate_parley_options` gains an additive ``approach=True`` param that first
+WALKS the lead PC to a cell ADJACENT to the target NPC's rest-mode stage cell (reusing the W2
+``walk_to`` machinery — the sole writer of ``stage_cell``), then opens the parley; and the npc
+block gains an additive ``stage_cell`` echo so the DM/renderer can open the dialogue AT the actor.
+
+INVARIANTS pinned here:
+  * additive / default-off — ``approach`` defaults False; without it the parley payload is
+    BYTE-IDENTICAL to today (no ``approach`` key, no ``stage_cell`` echo when the NPC is unstaged).
+  * engine sole-writer — approach WRITES stage_cell only via ``walk_to``; the parley projection is
+    otherwise a pure read.
+  * combat gate untouched — approach in active combat degrades to a freeform parley (walk_to owns
+    the refusal); the options still open.
+  * MED-addendum fallback — no stage cell / no scene grid / no reachable adjacent cell -> freeform
+    parley (no ``approach`` key), never a raise or a blocked dialogue open.
+  * adjacency = Chebyshev <=1 (combat_grid.in_melee_reach) — the party stands BESIDE the NPC,
+    never onto it; pathing reuses combat_grid.shortest_path (never forked).
+
+Reuses the wall-column rest-scene idiom from test_walk_to.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import server  # imported FIRST: resolves the models<->scene_grid import cycle in the right order
+import combat_grid  # noqa: F401  (referenced by name in assertions/comments)
+import store
+from scene_grid import (
+    SceneGrid,
+    SceneGridSpec,
+    SceneCell,
+    SceneCellDefault,
+    SceneProp,
+)
+
+
+def _wall_column_room() -> SceneGrid:
+    """A 5x3 rest scene with a solid wall down column x=2 (rows 1..2) EXCEPT a gap at (2,0), and
+    a crate prop at (4,2). Cols->x, rows->y. Same fixture idiom as test_walk_to.py."""
+    cells = [SceneCell(c=2, r=r, type="wall", walkable=False) for r in (1, 2)]  # gap at (2,0)
+    props = [SceneProp(id="crate", kind="crates", cells=[(4, 2)], anchor_cell=(4, 2))]
+    cells.append(SceneCell(c=4, r=2, type="prop", walkable=False, prop_ref="crate"))
+    return SceneGrid(
+        scene_id="w:loc", location_id="loc", kind="dungeon",
+        grid=SceneGridSpec(cols=5, rows=3, cell_size_ft=5),
+        cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
+        cells=cells, props=props,
+    )
+
+
+@pytest.fixture
+def talk_room(tmp_path, monkeypatch):
+    """A campaign whose CURRENT location carries the wall-column rest scene: a Hero (lead PC) at
+    (0,0) and an Innkeeper NPC staged at (4,0). No combat (rest mode)."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("W3 talk room")["id"]
+    loc_id = server.add_location(cid, "The Tavern")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=30)["id"]
+    npc = server.create_character(cid, "Innkeeper", kind="npc", max_hp=12)["id"]
+    server.set_attitude(cid, npc, attitude="indifferent", value=0)
+    c = server._require(cid)
+    c.locations[loc_id].scene_grid = _wall_column_room()
+    c.characters[hero].stage_cell = (0, 0)
+    c.characters[npc].stage_cell = (4, 0)
+    c.characters[npc].met = True
+    server.save_campaign(c)
+    return cid, hero, npc, loc_id
+
+
+# ── _nearest_walkable_adjacent: the Chebyshev<=1 approach-cell picker ─────────────────
+
+
+def test_nearest_adjacent_prefers_reachable_neighbour_closest_to_start():
+    # NPC at (4,0) on the 5x3 grid; neighbours are (3,0),(3,1),(4,1). From (0,0) the closest
+    # reachable is (3,0). Adjacency is Chebyshev<=1 by construction.
+    dest = server._nearest_walkable_adjacent((4, 0), (0, 0), blocked=set(), width=5, height=3)
+    assert dest is not None
+    assert combat_grid.in_melee_reach(dest, (4, 0))
+    assert dest == (3, 0)
+
+
+def test_nearest_adjacent_already_adjacent_returns_start():
+    # Standing at (3,0), already beside the NPC at (4,0) -> no walk needed.
+    dest = server._nearest_walkable_adjacent((4, 0), (3, 0), blocked=set(), width=5, height=3)
+    assert dest == (3, 0)
+
+
+def test_nearest_adjacent_none_when_all_neighbours_blocked():
+    # Fence every neighbour of (4,0) -> no legal adjacent cell (fallback trigger).
+    blocked = {(3, 0), (3, 1), (4, 1)}
+    assert server._nearest_walkable_adjacent((4, 0), (0, 0), blocked, 5, 3) is None
+
+
+# ── approach-to-talk via generate_parley_options ──────────────────────────────────────
+
+
+def test_approach_walks_lead_pc_adjacent_and_attaches_block(talk_room):
+    cid, hero, npc, _loc = talk_room
+    out = server.generate_parley_options(cid, npc_id=npc, approach=True)
+    assert out["approach"]["walked"] is True
+    dest = tuple(out["approach"]["to"])
+    assert combat_grid.in_melee_reach(dest, (4, 0))  # ended up adjacent to the NPC
+    assert out["approach"]["npc_cell"] == [4, 0]
+    assert out["approach"]["path"][0] == [0, 0]        # glide starts where the hero stood
+    assert out["approach"]["path"][-1] == list(dest)
+    # engine sole-writer: walk_to actually moved the hero's stage cell.
+    c = server._require(cid)
+    assert tuple(c.characters[hero].stage_cell) == dest
+
+
+def test_approach_echoes_npc_stage_cell(talk_room):
+    cid, _hero, npc, _loc = talk_room
+    out = server.generate_parley_options(cid, npc_id=npc, approach=True)
+    assert out["npc"]["stage_cell"] == [4, 0]  # renderer stages the speaker at its cell
+
+
+def test_approach_already_adjacent_is_a_noop_walk(talk_room):
+    cid, hero, npc, _loc = talk_room
+    c = server._require(cid)
+    c.characters[hero].stage_cell = (3, 0)  # already beside the NPC at (4,0)
+    server.save_campaign(c)
+    out = server.generate_parley_options(cid, npc_id=npc, approach=True)
+    assert out["approach"]["walked"] is False
+    assert out["approach"]["to"] == [3, 0]
+    assert tuple(server._require(cid).characters[hero].stage_cell) == (3, 0)
+
+
+def test_approach_unreachable_npc_degrades_to_freeform(talk_room):
+    cid, hero, npc, loc_id = talk_room
+    # Wall off every neighbour of the NPC by staging blockers there so no adjacent cell is free.
+    c = server._require(cid)
+    b1 = server.create_character(cid, "Guard A", kind="npc")["id"]
+    b2 = server.create_character(cid, "Guard B", kind="npc")["id"]
+    b3 = server.create_character(cid, "Guard C", kind="npc")["id"]
+    c = server._require(cid)
+    c.characters[b1].stage_cell = (3, 0)
+    c.characters[b2].stage_cell = (3, 1)
+    c.characters[b3].stage_cell = (4, 1)
+    server.save_campaign(c)
+    out = server.generate_parley_options(cid, npc_id=npc, approach=True)
+    assert "approach" not in out           # degraded to freeform parley
+    assert out["npc"]["id"] == npc         # the parley STILL opens (never blocked)
+    # the hero never moved (no legal approach was taken)
+    assert tuple(server._require(cid).characters[hero].stage_cell) == (0, 0)
+
+
+def test_approach_unstaged_npc_degrades_to_freeform(talk_room):
+    cid, hero, npc, _loc = talk_room
+    c = server._require(cid)
+    c.characters[npc].stage_cell = None  # NPC not staged anywhere
+    server.save_campaign(c)
+    out = server.generate_parley_options(cid, npc_id=npc, approach=True)
+    assert "approach" not in out
+    assert "stage_cell" not in out["npc"]  # no cell to echo
+    assert tuple(server._require(cid).characters[hero].stage_cell) == (0, 0)
+
+
+def test_approach_during_combat_degrades_to_freeform(talk_room):
+    cid, hero, npc, _loc = talk_room
+    server.start_combat(cid, [hero, npc])  # combat active -> walk_to would refuse
+    out = server.generate_parley_options(cid, npc_id=npc, approach=True)
+    assert "approach" not in out
+    assert out["npc"]["id"] == npc  # options still open
+
+
+# ── byte-identity: the default (no-approach) payload is unchanged ─────────────────────
+
+
+def test_no_approach_payload_is_byte_identical(talk_room):
+    # The whole W3 engine change is additive: without approach=True (and no situation), the
+    # payload carries NO approach key. With an unstaged NPC, no stage_cell echo either — so the
+    # npc block is byte-identical to F10-2/SYN-07's shape. (Guards the round-trip invariant.)
+    cid, _hero, npc, _loc = talk_room
+    c = server._require(cid)
+    c.characters[npc].stage_cell = None
+    server.save_campaign(c)
+    out = server.generate_parley_options(cid, npc_id=npc, difficulty="medium")
+    assert "approach" not in out
+    assert set(out["npc"].keys()) == {"id", "name", "attitude", "attitude_value", "met", "difficulty"}
+
+
+def test_absent_npc_id_still_byte_identical_with_approach_true(talk_room):
+    # approach=True with NO npc bound is a no-op: nothing to approach, no npc/approach keys.
+    cid, _hero, _npc, _loc = talk_room
+    out = server.generate_parley_options(cid, difficulty="medium", approach=True)
+    assert "approach" not in out
+    assert "npc" not in out
+    assert set(out.keys()) == {"actor", "skills", "free_form", "guidance", "alignment"}

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -6455,6 +6455,50 @@ def _live_parley_event(snapshot: dict) -> dict | None:
     return None
 
 
+def _cell_pair(raw: object) -> tuple[int, int] | None:
+    """A single (x, y) integer cell from a [x, y]/(x, y) pair, or None. Shared by the parley
+    stage-metadata projection (mirrors the local `_cell` helper in the rest-token builder)."""
+    if isinstance(raw, (list, tuple)) and len(raw) == 2:
+        ci, ri = _num(raw[0]), _num(raw[1])
+        if ci is not None and ri is not None:
+            return (int(ci), int(ri))
+    return None
+
+
+def _stage_cell_for(snapshot: dict, ch: dict, npc_id: str) -> tuple[int, int] | None:
+    """Where a character STANDS in the current location's rest scene, read-only — the
+    authoritative ``Character.stage_cell`` (W2 #1319) if present, else the ``npc:<id>`` spawn
+    anchor W1 (#1318) writes into ``scene_grid.spawns`` (the same forward-compat occupancy source
+    `rest_blocked_cells` folds in). None when neither is known (un-walked, no anchor) — the caller
+    then omits stage keys, so a pre-W1/W2 snapshot projects byte-identically."""
+    sc = _cell_pair(ch.get("stage_cell"))
+    if sc is not None:
+        return sc
+    # W1 forward-compat: the per-NPC spawn anchor in the current location's scene grid.
+    loc_id = _text(snapshot.get("current_location_id"))
+    locs = snapshot.get("locations") if isinstance(snapshot.get("locations"), dict) else {}
+    loc = locs.get(loc_id) if isinstance(locs, dict) and loc_id else None
+    sg = loc.get("scene_grid") if isinstance(loc, dict) else None
+    spawns = sg.get("spawns") if isinstance(sg, dict) else None
+    anchor = spawns.get(f"npc:{npc_id}") if isinstance(spawns, dict) and npc_id else None
+    if isinstance(anchor, list):
+        for c in anchor:
+            cell = _cell_pair(c)
+            if cell is not None:
+                return cell  # first anchor cell (a single-cell NPC footprint)
+    return None
+
+
+def _party_relative_facing(dx: int, dy: int) -> str:
+    """A compass-ish facing string ("e"/"w"/"n"/"s"/"ne"/… or "" when co-located) for a delta
+    from the SPEAKING NPC toward the party's lead PC — so the renderer can turn the NPC to face
+    whoever it's talking to. Grid is cols->x (east +), rows->y (south +): dy>0 is south. Purely
+    a projection of two stage cells; nothing is persisted."""
+    ns = "s" if dy > 0 else "n" if dy < 0 else ""
+    ew = "e" if dx > 0 else "w" if dx < 0 else ""
+    return ns + ew
+
+
 def _parley_npc_block(snapshot: dict, npc_id: str, live_event: dict | None) -> dict | None:
     """The conversation TARGET for a parley, projected read-only from the snapshot — or None.
 
@@ -6478,7 +6522,7 @@ def _parley_npc_block(snapshot: dict, npc_id: str, live_event: dict | None) -> d
     if not isinstance(ch, dict):
         return None  # unknown id -> freeform parley (graceful degrade, like a bad event_id)
     av = _num(ch.get("attitude_value"))
-    return {
+    block = {
         "id": _text(ch.get("id"), target_id),
         "name": _text(ch.get("name"), target_id),
         "attitude": _text(ch.get("attitude")),
@@ -6486,6 +6530,22 @@ def _parley_npc_block(snapshot: dict, npc_id: str, live_event: dict | None) -> d
         "met": bool(ch.get("met")),
         "disposition": _attitude_disposition(ch),
     }
+    # W3 (#1320): additive STAGE metadata so the renderer can stage the speaking NPC AT its cell
+    # (the disembodied-portrait dialogue becomes spatial). Projection-only: reads W2's
+    # `Character.stage_cell` (else W1's `npc:<id>` spawn anchor) — the engine stays sole writer,
+    # nothing is persisted. When the NPC has no known cell (un-walked, no anchor, or a pre-W1/W2
+    # snapshot) NO stage key is emitted, so the block is byte-identical to #751/#615's shape.
+    stage = _stage_cell_for(snapshot, ch, target_id)
+    if stage is not None:
+        block["stage_cell"] = [stage[0], stage[1]]
+        # Party-relative facing: turn the NPC toward the lead PC when BOTH stand on the grid.
+        _lead_id, lead = _lead_pc(snapshot)
+        lead_cell = _stage_cell_for(snapshot, lead, _lead_id) if isinstance(lead, dict) else None
+        if lead_cell is not None:
+            facing = _party_relative_facing(lead_cell[0] - stage[0], lead_cell[1] - stage[1])
+            if facing:  # co-located (same cell) -> no facing key
+                block["facing"] = facing
+    return block
 
 
 def build_parley_surface(

--- a/viewer/tests/test_readmodel_surfaces.py
+++ b/viewer/tests/test_readmodel_surfaces.py
@@ -356,6 +356,68 @@ class ReadModelSurfaceTests(unittest.TestCase):
         self.assertEqual(surface["diagnostics"][0]["message"], "unknown beat ref: missing")
         self.assert_no_private_keys(surface)
 
+    # ── parley: W3 (#1320) additive STAGE metadata (npc stage_cell + party-relative facing) ──
+
+    def _staged_talk_snapshot(self):
+        """A snapshot where the bound NPC (mira, moved to an npc kind in the current location) and
+        the lead PC both carry a rest-mode ``stage_cell``, plus a scene grid to face across."""
+        snap = copy.deepcopy(_SNAPSHOT)
+        snap["locations"]["lanternrest"]["scene_grid"] = {
+            "grid": {"cols": 6, "rows": 4},
+            "spawns": {"npc:barkeep": [[5, 2]]},
+        }
+        snap["characters"]["cassian"]["stage_cell"] = [1, 1]
+        # A tracked NPC in the CURRENT location, staged at (4,1) east of the PC at (1,1).
+        snap["characters"]["barkeep"] = {
+            "id": "barkeep", "name": "The Barkeep", "kind": "npc", "met": True,
+            "location_id": "lanternrest", "attitude": "warm", "attitude_value": 30,
+            "stage_cell": [4, 1],
+        }
+        return snap
+
+    def test_parley_surface_npc_carries_stage_cell(self):
+        # W3: the bound NPC block echoes its stage cell so the renderer stages the speaker AT its
+        # cell (the disembodied-portrait dialogue becomes spatial).
+        self._write("camp_marches", self._staged_talk_snapshot())
+        _status, surface = self._get_json("/parley-surface?campaign=camp_marches&npc=barkeep")
+        self.assertEqual(surface["npc"]["stage_cell"], [4, 1])
+        self.assert_no_private_keys(surface)
+
+    def test_parley_surface_npc_facing_is_party_relative(self):
+        # Facing turns the NPC toward the lead PC: PC at (1,1) is WEST of the NPC at (4,1) -> "w".
+        self._write("camp_marches", self._staged_talk_snapshot())
+        _status, surface = self._get_json("/parley-surface?campaign=camp_marches&npc=barkeep")
+        self.assertEqual(surface["npc"]["facing"], "w")
+
+    def test_parley_surface_npc_stage_cell_falls_back_to_w1_spawn_anchor(self):
+        # No Character.stage_cell yet, but W1 wrote an npc:<id> spawn anchor -> project THAT cell.
+        snap = self._staged_talk_snapshot()
+        del snap["characters"]["barkeep"]["stage_cell"]  # un-walked
+        self._write("camp_marches", snap)
+        _status, surface = self._get_json("/parley-surface?campaign=camp_marches&npc=barkeep")
+        self.assertEqual(surface["npc"]["stage_cell"], [5, 2])  # the npc:barkeep anchor
+
+    def test_parley_surface_unstaged_npc_omits_stage_keys_byte_identical(self):
+        # W3 is additive: an NPC with no stage_cell and no spawn anchor gets NO stage/facing key —
+        # the block is byte-identical to #751/#615's shape (guards the round-trip invariant).
+        snap = copy.deepcopy(_SNAPSHOT)  # olwen: no scene grid, no stage cell, no anchor
+        self._write("camp_marches", snap)
+        _status, surface = self._get_json("/parley-surface?campaign=camp_marches&npc=olwen")
+        npc = surface["npc"]
+        self.assertNotIn("stage_cell", npc)
+        self.assertNotIn("facing", npc)
+        self.assertEqual(set(npc.keys()), {"id", "name", "attitude", "attitude_value", "met", "disposition"})
+
+    def test_parley_surface_facing_omitted_when_pc_unplaced(self):
+        # The NPC is staged but the lead PC has no stage cell -> stage_cell present, facing absent
+        # (there is no PC position to face toward). Never a raise.
+        snap = self._staged_talk_snapshot()
+        del snap["characters"]["cassian"]["stage_cell"]
+        self._write("camp_marches", snap)
+        _status, surface = self._get_json("/parley-surface?campaign=camp_marches&npc=barkeep")
+        self.assertEqual(surface["npc"]["stage_cell"], [4, 1])
+        self.assertNotIn("facing", surface["npc"])
+
     # ── character ───────────────────────────────────────────────────────────────
 
     def test_character_surface_projects_full_party_sheets(self):


### PR DESCRIPTION
## What
Engine + surface half of W3 "Talk" (epic #1320, Act II roadmap §4b/W3) — NPC-on-stage parley metadata + approach-to-talk. **No renderer work** (that's the app/W3-UI lane). Two additive halves:

1. **Parley surface stage metadata** (`viewer/server.py` `build_parley_surface` / `_parley_npc_block`): the bound `npc` block gains an additive `stage_cell` (from W2's `Character.stage_cell`, else W1's `npc:<id>` spawn anchor) + a party-relative `facing` string (NPC turned toward the lead PC). Projection-only — zero new persisted state. Absent stage data → no new keys → byte-identical to #751/#615's block.
2. **Approach-to-talk** (`servers/engine/server.py` `generate_parley_options`): an additive `approach: bool = False` param. When `True` and the target NPC has a rest-mode stage cell, first WALKS the lead PC to a Chebyshev-adjacent free cell, then opens the parley — attaching an `approach` result block + echoing the NPC's `stage_cell`. Default `False` == today, byte-identical.

## ⚠️ Based on #1341 (W2) — draft until it merges
This branch is currently stacked on **#1341's** `w2/walk-engine` commit (`walk_to` / `rest_blocked_cells` / `Character.stage_cell`), which approach-to-talk REUSES. Once #1341 merges to main, this **rebases to exactly 2 commits** (parley surface metadata + approach-to-talk) and moves out of draft. It carries no engine-half W2 changes of its own.

## API-shape choice + why
Additive `approach: bool` param on the EXISTING `generate_parley_options` tool, **not a new verb**. Parley is already NPC-bound (`npc_id`/`target_id`/`character_id`/`id` aliases); a new verb would duplicate the whole options surface and force the DM to call two tools for one intent. `approach=True` is one flag on the intent the DM already expresses. Default-off keeps the payload byte-identical.

## Reuses W2's machinery (never forks pathing)
- `rest_blocked_cells(c, loc, exclude_id)` — the shared rest-mode geometry+occupancy builder.
- `walk_to(...)` — the **sole writer** of `stage_cell`; `_approach_to_talk` delegates the walk to it (own lock + save + `rest_walk` beat), never writes `stage_cell` directly.
- `combat_grid.shortest_path` for reachability; `combat_grid.in_melee_reach` (Chebyshev ≤1) for the adjacency metric (per the epic's HIGH addendum — same 5ft-reach definition, not a new metric).
- **MED-addendum fallback:** no stage cell / no scene grid / combat active / no reachable adjacent cell → degrade to today's freeform parley (no `approach` key), never a raise or a blocked dialogue open.

## Invariants
- **Engine sole-writer** — approach writes `stage_cell` only via `walk_to`; surface + parley projections are pure reads.
- **Additive / byte-identity** — default-off; W3 output byte-identity tests both tiers (`test_no_approach_payload_is_byte_identical`, `test_absent_npc_id_still_byte_identical_with_approach_true`, `test_parley_surface_unstaged_npc_omits_stage_keys_byte_identical`). The W2 serializer guard (`test_walk_to.py::test_character_without_stage_cell_omits_the_key`) is verified red-on-serializer-removal.
- **Combat gate untouched** — approach in active combat degrades to freeform (walk_to owns the refusal).
- **Tool-schema budget** — kept under the 120000 B SYN-02 ceiling (compressed `generate_parley_options` prose to make room for the `approach` param + a terse mention).
- **DM = text tier** — the DM receives IDENTICAL parley moves; approach is additive positioning around the same options payload (W3's EVAL behavioral contract).

## Tests
- `servers/engine/tests/test_parley_approach.py` — **12 assertions** (adjacency picker, walk-adjacent + block echo, npc `stage_cell` echo, already-adjacent no-op, unreachable/unstaged/in-combat fallbacks, 2 byte-identity).
- `viewer/tests/test_readmodel_surfaces.py` — **+5** parley-surface stage-metadata assertions (stage_cell, facing, W1 spawn-anchor fallback, unstaged byte-identity, facing-omitted-when-PC-unplaced).
- Engine focused (parley + approach + walk + schema budget): **76 passed**. Viewer readmodel surfaces: **49 passed**. `qa/fast_gate.sh` T0: **PASS**.
- (Full engine run: 3443 passed; the one red — `test_provider_contract_smoke_rejects_non_temp_move_path_without_override` — is a **pre-existing** env artifact that fails identically on the pristine W2 base because the suite runs from a `/private/tmp` worktree; passes in CI.)
