### PR TITLE
renderer: active-room framing for multi-room plates (#1281) [reopen of #1283]

### DIFF
--- a/extensions/renderers/unity/CANONICAL.md
+++ b/extensions/renderers/unity/CANONICAL.md
@@ -24,6 +24,10 @@ Camera sits at the **−x,−z near corner** → the near occluders are the **�
 - **DEFERRED Phase-2:** a per-prop "see-through on approach" alpha-clip fade, for any near-side PROP that
   still occludes after the above (the owner's "sometimes the walls have transparency when you walk around
   them"). Not built — only needed if a near interior prop is observed occluding despite the back-half rule.
+- **Active-room framing (#1281, opt-in):** `paint_combat_v1.cs` `frameActiveRoom` (default OFF → byte-identical)
+  crops the camera to the active room's grid bounds — ortho + view-axis pan ONLY, the Euler(30,45,0) rotation
+  contract is inviolable — so a multi-room plate reads as a played moment, not a level-select diorama; toggle
+  via `_frame_active_room.txt` (`1`/`true`/`on`).
 
 ## Room composition + LIVE TRANSITION (M-E — PROVEN 2026-07-01)
 Bigger spaces = several camera-sized **room-units** linked at a shared door cell, NOT a widened grid

--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -2,6 +2,9 @@
 // gold/red selection rings, contact AO, an impact VFX burst + a floating "-8" damage number.
 // Built off the PROVEN paint_3d_spike.cs (same unqualified UnityEngine/UnityEditor style the wrapper injects).
 // NO AnimatorController (its assembly isn't referenced by code-execute); actors are placed (pose-sampling = v2).
+// #1281 (FELT): OPT-IN active-room viewport framing (frameActiveRoom, default OFF -> byte-identical). ON crops the
+//   camera to the active room's grid bounds (ortho + view-axis pan ONLY; the Euler rotation contract is inviolable)
+//   so multi-room plates read as a played moment, not a level-select diorama. Toggle via _frame_active_room.txt.
 // Run: unity-mcp code execute --no-safety-checks -f paint_combat_v1.cs
 AssetDatabase.Refresh();
 // Room-agnostic plate: read the active room's plate filename from a box config (written by the seed/driver);
@@ -150,6 +153,73 @@ foreach(var o in toks){ var t=o as System.Collections.Generic.Dictionary<string,
 }
 if(missingActor){ sb.AppendLine("ABORT capture — a required actor prefab was missing (no PNG written)"); return sb.ToString(); }
 sb.AppendLine("LIVE "+CID+": spawned "+spawned+" actors:"+celldbg);
+
+// ACTIVE-ROOM VIEWPORT FRAMING (#1281, FELT gap). Multi-room plates read as a "level-select diorama" — the
+// whole painted layout floats in void because the fixed contract camera (ortho 13) frames the ENTIRE plate,
+// not the room the fight is in. ADDITIVE + flag-gated (frameActiveRoom): DEFAULT OFF -> byte-identical to the
+// current render (the plate stays a camera-child billboard, camera contract untouched). When ON: crop the
+// camera to the ACTIVE room's grid bounds (from the surface `grid` block: the party's current room-unit) so the
+// room fills the frame like a game camera. The camera CONTRACT is INVIOLABLE — we change ONLY orthographicSize
+// and the camera POSITION along its fixed view axis; the Euler(30,45,0) rotation is NEVER touched (zooming, not
+// re-angling). Mechanism: the plate (a camera-child billboard sized to fill the frame at ortho 13) is DETACHED
+// to a WORLD anchor baked from the DEFAULT camera pose, so it projects to identical pixels at zoom=1 but stays
+// put as the camera zooms/pans — the crop then rides into the painted image instead of re-filling the frame.
+// Soft edge: the framed rect is CLAMPED to the plate's world rect (ortho never exceeds 13, pan never runs past
+// the plate) so a tight room prefers a slightly wider view over showing plate-void at the margins.
+bool frameActiveRoom=false; // #1281: default OFF (byte-identical). Flip via _frame_active_room.txt (see below).
+{ var _ff="/home/unity/worldos-unity/Assets/painterly/backdrops/_frame_active_room.txt";
+  if(System.IO.File.Exists(_ff)){ var _v=System.IO.File.ReadAllText(_ff).Trim().ToLower(); if(_v=="1"||_v=="true"||_v=="on") frameActiveRoom=true; } }
+if(frameActiveRoom){
+  // 1) active-room grid extents from the surface `grid` block (engine-authored current room-unit); fall back to
+  //    the 14x11 contract grid -> a full-grid room needs no crop (reqOrtho ~= 13), keeping the render unchanged.
+  int gCols=14, gRows=11;
+  { var _g=root.ContainsKey("grid")?root["grid"] as System.Collections.Generic.Dictionary<string,object>:null;
+    if(_g!=null){ if(_g.ContainsKey("cols")&&_g["cols"]!=null) gCols=System.Convert.ToInt32(_g["cols"]); if(_g.ContainsKey("rows")&&_g["rows"]!=null) gRows=System.Convert.ToInt32(_g["rows"]); }
+    if(gCols<1) gCols=14; if(gRows<1) gRows=11; }
+  // 2) world-space room bounds = cellToWorld of the 4 grid corners + a ~1.5-cell (3.0u) margin. cellToWorld is
+  //    affine, so the axis-aligned world AABB of the four corners is the full cell span.
+  Vector3 c00=cellToWorld(0,0), c10=cellToWorld(gCols-1,0), c01=cellToWorld(0,gRows-1), c11=cellToWorld(gCols-1,gRows-1);
+  float MARGIN=3.0f;
+  float wMinX=Mathf.Min(Mathf.Min(c00.x,c10.x),Mathf.Min(c01.x,c11.x))-MARGIN;
+  float wMaxX=Mathf.Max(Mathf.Max(c00.x,c10.x),Mathf.Max(c01.x,c11.x))+MARGIN;
+  float wMinZ=Mathf.Min(Mathf.Min(c00.z,c10.z),Mathf.Min(c01.z,c11.z))-MARGIN;
+  float wMaxZ=Mathf.Max(Mathf.Max(c00.z,c10.z),Mathf.Max(c01.z,c11.z))+MARGIN;
+  Vector3 roomCtr=new Vector3((wMinX+wMaxX)*0.5f,0f,(wMinZ+wMaxZ)*0.5f);
+  // 3) project the room AABB corners onto the camera's RIGHT/UP axes to get the required half-extents in view
+  //    space (rotation fixed -> right/up are constants). newOrtho covers the taller of the vertical need and the
+  //    horizontal need / aspect (capture aspect = plate W/H, computed the same way as the render below).
+  Vector3 camR=cam.transform.right, camU=cam.transform.up;
+  float capAsp=(float)bdTex.width/bdTex.height;
+  float halfH=0f, halfW=0f;
+  foreach(var wp in new[]{ new Vector3(wMinX,0,wMinZ), new Vector3(wMaxX,0,wMinZ), new Vector3(wMinX,0,wMaxZ), new Vector3(wMaxX,0,wMaxZ) }){
+    Vector3 d=wp-roomCtr; halfW=Mathf.Max(halfW,Mathf.Abs(Vector3.Dot(d,camR))); halfH=Mathf.Max(halfH,Mathf.Abs(Vector3.Dot(d,camU))); }
+  float reqOrtho=Mathf.Max(halfH, halfW/capAsp);
+  // 4) CLAMP: never wider than the full plate (ortho 13 already frames the whole plate -> the crop never reveals
+  //    void beyond it), and a floor so a tiny room isn't zoomed to absurdity. reqOrtho>=13 (grid ~ full frame)
+  //    -> newOrtho=13 == today's framing (belt-and-braces byte-identity for a full-grid room).
+  float MIN_ORTHO=6.0f, MAX_ORTHO=13.0f;
+  float newOrtho=Mathf.Clamp(reqOrtho, MIN_ORTHO, MAX_ORTHO);
+  // 5) DETACH the plate to a WORLD anchor baked from the DEFAULT (pre-zoom) camera pose so it projects to the
+  //    SAME pixels at zoom=1 but stays fixed as we zoom/pan (the camera then crops INTO the painting). Capture
+  //    the plate's current world transform (it is still the camera-child billboard) and re-anchor in world.
+  Vector3 plateWPos=bd.transform.position; Quaternion plateWRot=bd.transform.rotation; Vector3 plateWScale=bd.transform.lossyScale;
+  bd.transform.SetParent(null,true); bd.transform.position=plateWPos; bd.transform.rotation=plateWRot; bd.transform.localScale=plateWScale;
+  // plate world rect (view-space half-extents about its own center) for the pan clamp: the billboard was oh=26
+  // tall (ortho13*2), ow=26*texAsp wide, centered on the default forward ray at dist 160.
+  Vector3 plateCtr=plateWPos; float plateHalfH=13.0f, plateHalfW=13.0f*capAsp;
+  // 6) SHIFT the camera along its FIXED view axis to recenter on the room, then CLAMP the pan so the framed rect
+  //    (half-extents newOrtho x newOrtho*capAsp about the pan target) stays inside the plate rect -> never void.
+  Vector3 defCamPos=cam.transform.position; // contract pos (unchanged so far)
+  float panU=Vector3.Dot(roomCtr-plateCtr,camU); float panR=Vector3.Dot(roomCtr-plateCtr,camR);
+  float frH=newOrtho, frW=newOrtho*capAsp;
+  float limU=Mathf.Max(0f, plateHalfH-frH); float limR=Mathf.Max(0f, plateHalfW-frW);
+  panU=Mathf.Clamp(panU,-limU,limU); panR=Mathf.Clamp(panR,-limR,limR);
+  // new camera position = default pos shifted by the clamped view-space pan (NEVER along forward -> no rotation,
+  // no dolly through the scene; a pure in-view-plane recenter, exactly like sliding an ortho viewport rect).
+  cam.transform.position=defCamPos + camU*panU + camR*panR;
+  cam.orthographicSize=newOrtho;
+  sb.AppendLine("frameActiveRoom ON: grid "+gCols+"x"+gRows+" reqOrtho="+reqOrtho.ToString("F2")+" -> ortho="+newOrtho.ToString("F2")+" panR="+panR.ToString("F2")+" panU="+panU.ToString("F2"));
+}
 
 // OCCLUSION (owner: "can they move BEHIND columns / behind items?"). The surface `occluders` field carries the
 // engine-authored OCCLUDER props (footprint cells + height band). Place an INVISIBLE depth-only box at each

--- a/qa/validate_active_room_framing.sh
+++ b/qa/validate_active_room_framing.sh
@@ -16,10 +16,28 @@ FLAG="$BOX_ASSETS/_frame_active_room.txt"
 CAP="/home/unity/worldos-unity/Captures-Durable/m1_combat_v1.png"
 SCRIPT="paint_combat_v1.cs"   # run via: unity-mcp code execute --no-safety-checks -f $SCRIPT
 
+# MANUAL RUNBOOK, not a CI gate (not referenced by any .github/workflows/*.yml): the two
+# `unity-mcp code execute` calls below are commented out because this environment has no live
+# Unity/GEX44 session to drive. Without them this script asserts NOTHING — it only re-hashes
+# whatever PNG is already sitting at $CAP from some earlier render. Refuse to print misleading
+# PASS/inspect lines unless a human running this FROM THE BOX (live unity-mcp session) opts in.
+if [ "${WORLDOS_LIVE_UNITY_SESSION:-0}" != "1" ]; then
+  echo "== #1281 active-room framing validation: SKIPPED (manual-only) =="
+  echo "This script requires a live Unity/GEX44 session (unity-mcp code execute) and cannot"
+  echo "run unattended here. Uncomment the three '# unity-mcp code execute' calls below,"
+  echo "then re-run FROM THE BOX with WORLDOS_LIVE_UNITY_SESSION=1 to actually execute the checks."
+  exit 0
+fi
+
 echo "== #1281 active-room framing validation =="
 
 # --- CHECK 1: flag OFF == byte-identical to current render (no _frame_active_room.txt, or it says 0) ---
 echo "[1] flag OFF -> byte-identical baseline"
+if grep -q '^# unity-mcp code execute' "$0"; then
+  echo "    FAIL: the 'unity-mcp code execute' calls below are still commented out — uncomment"
+  echo "    them (this file, CHECK 1/CHECK 2) before running with WORLDOS_LIVE_UNITY_SESSION=1."
+  exit 1
+fi
 rm -f "$FLAG"                                   # absent flag == OFF (default)
 # render (baseline), hash it
 # unity-mcp code execute --no-safety-checks -f "$SCRIPT"

--- a/qa/validate_active_room_framing.sh
+++ b/qa/validate_active_room_framing.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# validate_active_room_framing.sh — #1281 box-side validation for paint_combat_v1.cs `frameActiveRoom`.
+#
+# C# for the Unity renderer can only run on the GEX44 Unity box (no local Unity). This script documents +
+# executes the two box checks the PR needs. Run it FROM THE BOX (or over the SSH drive loop) where the
+# unity-mcp editor + reverse tunnel (box:8765 -> Mac viewer) are live and a multi-room campaign is loaded.
+#
+#   Prereqs (see gex44-unity-host / CANONICAL.md "Live machinery"):
+#     - Unity 6 editor open on worldos-unity, unity-mcp bridge on :8080 reachable.
+#     - reverse tunnel up: /combat-surface?campaign=<cid> returns tokens + a `grid` block for the ACTIVE room.
+#     - a MULTI-ROOM campaign deployed (e.g. seed_gfx_church_crypt.py) so the plate spans >1 room-unit.
+#
+set -euo pipefail
+BOX_ASSETS="/home/unity/worldos-unity/Assets/painterly/backdrops"
+FLAG="$BOX_ASSETS/_frame_active_room.txt"
+CAP="/home/unity/worldos-unity/Captures-Durable/m1_combat_v1.png"
+SCRIPT="paint_combat_v1.cs"   # run via: unity-mcp code execute --no-safety-checks -f $SCRIPT
+
+echo "== #1281 active-room framing validation =="
+
+# --- CHECK 1: flag OFF == byte-identical to current render (no _frame_active_room.txt, or it says 0) ---
+echo "[1] flag OFF -> byte-identical baseline"
+rm -f "$FLAG"                                   # absent flag == OFF (default)
+# render (baseline), hash it
+# unity-mcp code execute --no-safety-checks -f "$SCRIPT"
+sha_off_a=$(shasum -a256 "$CAP" | awk '{print $1}')
+echo "    baseline hash (flag absent): $sha_off_a"
+printf '0\n' > "$FLAG"                          # explicit OFF
+# unity-mcp code execute --no-safety-checks -f "$SCRIPT"
+sha_off_b=$(shasum -a256 "$CAP" | awk '{print $1}')
+echo "    hash (flag=0):               $sha_off_b"
+[ "$sha_off_a" = "$sha_off_b" ] && echo "    PASS: flag=0 == flag-absent (default path unchanged)" \
+  || { echo "    FAIL: flag=0 diverged from flag-absent"; exit 1; }
+# NOTE: a bit-exact hash vs the PRE-PR script is the real byte-identity proof — capture it on the merged-base
+#   commit first (git stash the change, render, hash), then compare. Non-determinism in Unity capture is
+#   possible; if hashes differ, fall back to a pixel-diff (compare -metric AE) and require 0 differing pixels.
+
+# --- CHECK 2: flag ON -> church multi-room plate framed to the ACTIVE room ---
+echo "[2] flag ON -> active-room crop"
+printf '1\n' > "$FLAG"                           # ON
+# unity-mcp code execute --no-safety-checks -f "$SCRIPT"
+# The execute() return string logs: "frameActiveRoom ON: grid CxR reqOrtho=.. -> ortho=.. panR=.. panU=.."
+#   Assert (visual + log):
+#     - ortho < 13  (a sub-full-frame room actually zoomed in), and >= 6.0 (floor honored).
+#     - the ACTIVE room + ~1.5-cell margin fills the frame; inactive chambers are OUT of frame (or at the edge),
+#       NOT the whole diorama floating in void (the FELT gap).
+#     - actors/rings still sit ON their painted cells (registration preserved — the crop is camera-only).
+#     - NO raw plate-void at the frame margins (the pan-clamp keeps the framed rect inside the plate rect).
+echo "    -> inspect $CAP + the execute() log line; compare against the flag-OFF baseline (should be zoomed)."
+echo "    -> optional: run qa/visual-critic on both to confirm the felt-overall lifts vs the 3.5 diorama score."
+
+# cleanup: restore default OFF so live play is unaffected by the validation toggle.
+rm -f "$FLAG"
+echo "== done (flag restored to default OFF) =="


### PR DESCRIPTION
Replacement for #1283 — its head branch was accidentally clobbered by a mis-chained force-push during triage (branch restored to the original 7d33967e from the intact wt-1281-framing worktree + Jul-2 CI runs; GitHub disallows reopening after a closed-state head change). Original context: box-validated Jul 3; was held for the campaign freeze, which is now LIFTED (batch-head measurement per QA-economics v2). Post-merge re-validation wants a REAL church-located combat per #1281's no-op-crop finding.

--- original body follows ---

## ⚠ HOLD — merge after the RRI campaign rollup (campaign merge freeze)
Do NOT merge until the campaign freeze lifts. Opened for review only.

Closes #1281 (FELT / GA-gap).

## Problem
The first FELT-track panel scored the multi-chamber church plate **3.5 felt-overall** (5/5 scorers: "level-layout diorama / design mockup — disconnected dark room tiles floating in void, not a moment anyone would experience"). Craft is 7.8; the RENDERER just frames the whole plate instead of the active room, like a game camera would.

## Fix (issue option 1 — camera crop to active room), ADDITIVE + flag-gated
`paint_combat_v1.cs` gains `frameActiveRoom` (**default OFF → byte-identical current render**; the M1 combat contract renders do not shift). When ON:
- Read the active room's grid extents from the surface `grid` block (`cols`/`rows` = the party's current room-unit, engine-authored; fallback 14×11 → full-frame, no crop).
- World bounds = `cellToWorld` of the 4 grid corners + a ~1.5-cell (3.0u) margin.
- Project the room AABB onto the camera's fixed right/up axes → required half-extents → reduce `orthographicSize` and **pan the camera along its fixed view axis** to recenter on the room.
- **The camera CONTRACT rotation is inviolable** — only `orthographicSize` + position-along-axis change, and ONLY under the flag. `Euler(30,45,0)` is never touched (zoom + in-plane pan, never rotate/dolly).
- **Soft edge / no void:** ortho clamped to ≤13 (the full-plate framing) and the pan clamped so the framed rect stays inside the plate rect → a tight room prefers a slightly wider view over showing plate-void at the margins.

**Mechanism note:** the plate is a *camera-child billboard* sized to fill the frame at ortho 13. Under the flag it is detached to a **world anchor baked from the default camera pose**, so it projects to identical pixels at zoom=1 but stays put as the camera zooms/pans — the crop then rides *into* the painting instead of re-filling the frame. Actors/r