### PR TITLE
docs(ga): P1 fix-pass — CHANGELOG absorption, tier-table, scorer caveat, pointer de-drift (#1346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,31 @@ WorldOS is source-available commercial software; world seeds are licensed separa
 
 ## [Unreleased]
 
-- **HV1 — per-artifact eval instruments (#1323, epic Act II Harvest Loop).** The harvest loop's
+### Combat — the tactical layer (epic #1100, engine side complete)
+- AoE templates on the combat grid — sphere/cone/line, Chebyshev (#1257/#1251)
+- Cover + line-of-sight — supercover LoS, half/three-quarters/total cover tiers (#1261/#1252)
+- Difficult terrain + creature size/reach — Dijkstra costs, NxN footprints (#1265/#1253)
+- Flanking advantage — line-through-centres (#1267/#1254)
+- Tactics-aware monster AI v2 — improvement-only overlay (#1268/#1255)
+- Fixes: cast-spell attack-roll leg through the economy gate (#1273/#1270); greedy movement
+  respects impassable/difficult (#1275/#1269); surprise/ambush gate (#1277/#1271)
+- Equipment-owned AC with provenance flag (#1248/#806 Stage 2)
+- Combat-UI: Cast/Item/Move ActionTiles wired to move-kinds (#1250)
+
+### Story & engagement
+- Every-beat quest/relationship/camp obligation cues + momentum guidance (#1299/#1286/#1288)
+- WS3a DM-unavoidable per-beat progression/closure cues (#1160)
+- Adopt the staging-law pass-1 room prompt (#1274)
+- **Cue-stack chain (#1313 series) — closing the loop from "cue exists" to "cue enforced" to
+  "cue can't be skipped."** Surface the top per-beat obligation as an imperative `next_action`
+  enforcement lever, the cue half of the #1313 Option 3 decision (#1314). Endgame quest-resolution
+  cue — the closure-half iteration for a satisfying finish, not just mid-arc momentum (#1317). The
+  wrap-window now opens on a **skip-proof beat counter**: closure cues no longer gate on the optional
+  `mark_climax` call, closing the loophole where a DM that never marks a climax never sees the
+  wrap-window cue either (#1334).
+
+### Act II — Harvest Loop + Living World (epic-series HV1/HV2/W1, charter #1328)
+- **HV1 — per-artifact eval instruments (#1323, merged via #1331).** The harvest loop's
   INSTRUMENT ships first: a per-artifact scorer for the four harvestable content classes
   (quest / npc / location / encounter). New `qa/rubric_artifact_<class>.md` + plain-number
   `qa/score_schema_artifact_<class>.json` pairs (one-decimal dims, same discipline as the story lens);
@@ -24,17 +48,67 @@ WorldOS is source-available commercial software; world seeds are licensed separa
   **±1.2 noise law**. Thin read-only snapshot reader (`qa/artifact_snapshot_reader.py`) CONSUMES HV2's
   canonical extractor to feed the calibration; `qa/artifact_calibration_panel.py` runs one blind panel
   per class. Artifact ruler `ac_986d87bf235a`; engine-duo `sc_be859353df20` / `lc_c603a22aac3d`
-  unchanged. **Envelope reconciliation (post-#1329):** the shared envelope
-  `data/library/artifact_schema.json` is HV2's canonical version (merged first); HV1 adds one ADDITIVE
-  optional `provenance.source` tag (nullable string; distinguishes disguised controls from live
-  extractions) and validates each class-payload shape explicitly in `artifact_score.py` until #1329/HV3
-  binds the per-class definitions via `if`/`then`.
-- Gameplay toward the RRI bar (story ≥4.3, mechanical ≥4.5) — the GA work, on the honest,
-  un-gamed measurement that 1.0.5-rc1 established.
-- The post-rc5 plan: engine-AI competence **v2.1** (off-turn reactions — Shield / Counterspell /
-  opportunity attacks; AoE cluster targeting; difficulty tiers dumb/normal/smart; multi-turn memory),
-  the combat-control **QA-driver integration**, and the **iso combat tiles** (#1061) — see
-  `docs/roadmap/combat-control-policy.md`.
+  unchanged.
+- **HV2 — export_campaign_artifacts extractor (#1324, merged via #1329).** Snapshot+transcript →
+  structured artifact JSONs; authors the shared envelope `data/library/artifact_schema.json` that HV1
+  consumes. **Envelope reconciliation:** HV1 adds one ADDITIVE optional `provenance.source` tag
+  (nullable string; distinguishes disguised controls from live extractions) and validates each
+  class-payload shape explicitly in `artifact_score.py` until HV3 binds the per-class definitions via
+  `if`/`then`.
+- **W1 — scene-at-rest (#1318, merged via #1330).** Stage block + NPC spawns + a renderer rest mode —
+  the living-world foundation for a room that keeps breathing between player actions.
+- **Tier-1.5 mechanism probe (#1336).** A new deterministic QA instrument: seeded-fixture + short
+  live-beats cue-iteration harness (~$1 vs a $6+ full duo) — see the QA-economics entry below.
+
+### Act II Sprint 2 (charter #1337)
+- **HV3 — Promote (epic #1325, merged via #1338).** The harvest loop's eval-gated PROMOTION gate:
+  scored artifacts → `library/`. `tools/library/promote.py` is the SOLE writer of `library/`
+  (`--batch`, idempotent via `library/.promoted.jsonl`); gate = `overall ≥4.0 AND every dim ≥3.0 AND
+  control-valid → stable` (`canonical` stays human-only, never automatic). `tools/library/library_lint.py`
+  validates provenance/license + pack metadata + class↔subdir + room_ref integrity. New library layout:
+  `library/pack.json` + `library/{quests,npcs,locations,encounters,rooms}/`; room entries reference
+  `room_recipes.json` + the asset registry rather than copying.
+- **HV5 slice 1 — closeout auto-nomination (epic #1327, merged via #1342).** Every scored run now
+  auto-nominates its promising HV2-extracted artifacts into `qa/nominations.jsonl` — the queue HV3's
+  `promote.py --batch` consumes — via an additive, non-fatal tail hook on `qa/closeout.py`'s
+  `build_closeout` (fired from a sibling `qa/nominate.py`, independently CLI-invokable; no change to the
+  duo hot path). Gate: `story_overall >= 4.3` for a quest/npc-class run; scoring stays a deferred nightly
+  batch (later HV5 slices — nightly batch scoring, weekly curation, `library_metrics`, backdrop cadence —
+  are not built here).
+- **QA-economics v2 (#1340, owner-ratified 2026-07-06).** Playtests are BATCH evidence, never PR
+  gates: an hour-scale duo runs once per merged batch, not per PR or per iteration. Default PR
+  validation ladder: Tier-0 `fast_gate.sh` → Tier-1.5 `mechanism_probe.sh` → `run_combat_sprint.sh`
+  when combat-adjacent; LLM story lenses are not run per-PR. Story-quality iteration moves to the
+  background on GLM (off-budget), never blocking the build critical path.
+
+### Renderer & art pipeline (PoE2 painterly)
+- Actor-integration levers — contact shadows, scene-light take, pose variety (#1282/#1280)
+- Layered 3-pass room-gen recipe: macro→detail/populate→staging-last (#1258) + hardening
+  (anti-text/UI negatives, deterministic best-of-N, asset-dict chaining) (#1259/#1263)
+- Templatized layered pass2/3 prompts per-room + bosshall recipe (#1294) — tavern + bosshall
+  plates ADOPTED (2-panel control-anchored evidence)
+- Cross-door UI affordance gating + tests (#1293/#1292); wave-1 monster registry (#1295/#1290)
+- Day/night plate selection (#1298) [PENDING rebase]; CANONICAL.md plate/actor rows (#1297)
+
+### QA instruments & infra
+- Luma staging-law pre-gate + visual-critic calibration-control protocol (#1276/#1242)
+- Scorer-auth hardening chain: SDK marker scrub, config-dir isolation, keychain fallback,
+  Linux fallback (#1262/#1264/#1266/#1279/#1260)
+- Run-invalidation guard + passive-perception WARN (#1300/#1285/#1287)
+- bash 5.3 multibyte-identifier crash fix (#1249)
+
+### Docs
+- Product roadmap: S1–S10 ladder→sprint→version map + VISION amendments (#1301)
+- Combat-loop ADR sync (#1256); box tunnel-recovery runbook (#1272); LoRA v4 verdict (#1247)
+
+The post-rc5 plan: engine-AI competence **v2.1** (off-turn reactions — Shield / Counterspell /
+opportunity attacks; AoE cluster targeting; difficulty tiers dumb/normal/smart; multi-turn memory),
+the combat-control **QA-driver integration**, and the **iso combat tiles** (#1061) — see
+`docs/roadmap/combat-control-policy.md`.
+
+> **Not yet in this batch (still OPEN as of this entry):** #1341 (W2-engine `walk_to` + rest-mode
+> pathing) and #1345 (Animator/VFX reel wiring) — both awaiting merge; append on landing rather than
+> pre-claiming.
 
 ---
 

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -222,10 +222,12 @@ push → `gh pr create` (no `tail` in an `&&` chain) → merge after checks pass
 ## THE QA LOOP
 
 **Pick the TIER — don't run the 90-min sweep to iterate.** Tier 0 `qa/fast_gate.sh` ($0 / ~2s, every
-change) → Tier 1 `qa/fast_probe.sh` (~$2–3 / ~20 min, DM-craft/UX/satisfaction) → Tier 2 the milestone
-5-persona `.app` sweep (~$10 / ~90 min, only before a version bump). Strategy + the adversarial-validated
-signal accounting: `docs/qa/FAST_GATE.md` and the `worldos-dev` skill's "QA STRATEGY" table. The runners
-below are what each tier composes.
+change) → Tier 1.5 `qa/mechanism_probe.sh` (~$1 / ~10 min, a seeded-fixture + 2–3 real DM beats
+yielding a deterministic ACTED / IGNORED / INCONCLUSIVE / CUE_ABSENT verdict — no LLM lens; iteration
+signal only, never a release verdict) → Tier 1 `qa/fast_probe.sh` (~$2–3 / ~20 min, DM-craft/UX/
+satisfaction) → Tier 2 the milestone 5-persona `.app` sweep (~$10 / ~90 min, only before a version
+bump). Strategy + the adversarial-validated signal accounting: `docs/qa/FAST_GATE.md` and the
+`worldos-dev` skill's "QA STRATEGY" table. The runners below are what each tier composes.
 
 The fitness function = **1 hard behavioral gate** + **3 LLM lenses**. Spec: `qa/SCORING.md`.
 **Log every scored run to the ledger: `qa/scores_db.py` → SQLite `scores.db` → rendered to
@@ -342,6 +344,9 @@ Opus-comparable story/mechanical scores.
 ---
 
 ## AGENT DELEGATION
+
+> Absolute `/Users/lume/...` paths below and elsewhere in this section reflect the primary dev
+> machine — substitute your own checkout root.
 
 Orchestrate via subagents; verify from the top.
 

--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -284,6 +284,23 @@ scoring read as a passing run (observed live: `story-craft= mechanical= angry-dm
   NOT record it in `scores_db`, do NOT read its (failed) lenses as quality signal. Re-run the
   scoring (or the whole duo); inspect `$RUN.<lens>.json` for the `error`/`last_api_error` field.
 
+### Oversize transcripts — the GLM-verbosity scorer-limit caveat (#1343, open)
+A verbose long-form duo — observed on **GLM 24-beat runs**, which run noticeably wordier per beat
+than an Opus duo of the same length — can produce a transcript that **exceeds the scorer prompt
+limit**. All three lenses fail identically with `'Prompt is too long'` (retried 3× each, still
+fails) — this is a **prompt-size ceiling**, not a scorer bug or a quality signal, and it is distinct
+from the `unscorable` infra-failure case above (that's a scorer crash; this is a request the scorer
+never gets to attempt). Behavioral gating on the full untruncated transcript is unaffected.
+
+**Until #1343 lands** (candidate fixes: tail-window the transcript for lens scoring only, chunk-and-
+merge, or distill via `distill.py` before scoring — none implemented yet), an oversize run gets
+**tally + behavioral only**, never a fabricated or partial lens score. Record the run-row per the
+existing convention: stamp `scorer_model='none'` and add a note (e.g. `note="oversize transcript,
+#1343, lenses unscorable"`) rather than leaving the lens columns blank or guessing a number. This is
+an iteration-grade lane (GLM corroborator duos), so it does not block the Opus release ruler — but
+do not read a bare `behavioral=GREEN` on one of these rows as carrying story/mech quality signal;
+it carries only the gate verdict.
+
 ## 6. Variance & noise floor
 The three LLM lenses are **stochastic graders**: re-scoring the *same comparable run* yields
 a slightly different `overall` each time. You cannot read a score without knowing this


### PR DESCRIPTION
## Summary
Mechanical docs fix-pass for the GA-readiness epic #1346, per the docs-audit comment's P1/P2 items. VISION.md and docs/roadmap/PRODUCT-ROADMAP.md intentionally untouched (orchestrator owns those separately).

- **CHANGELOG.md** — absorbed the staged v1.0.5 draft (`~/worldos-session-notes/v105-CHANGELOG-draft.md`) into `[Unreleased]`, theme-batched (not per-PR), then extended with everything merged since: the cue-stack chain (#1314 next_action, #1317 endgame cue, #1334 skip-proof wrap window), Act II Sprint 1 (#1329 HV2 extractor, #1330 W1 scene-at-rest, #1331 HV1 artifact evals, #1336 Tier-1.5 probe), and Sprint 2 (#1338 HV3 promote, #1342 HV5 auto-nomination, #1340 QA-economics v2). Every claim verified against `gh pr view --json title,mergedAt`. #1341 (W2 walk_to) and #1345 (Animator/VFX reel) are confirmed still **OPEN** — explicitly called out as not-yet-landed rather than absorbed.
- **WorldOS-RUNBOOK.md** — added the Tier-1.5 mechanism-probe row to the QA tier progression (between Tier-0 and Tier-1), wording aligned with `docs/qa/FAST_GATE.md`'s table (updated in #1336); added a one-line `/Users/lume` path-substitution note to the top of the AGENT DELEGATION section.
- **qa/SCORING.md** — documented the #1343 caveat: oversize transcripts (verbose GLM 24-beat runs) exceed the scorer prompt limit, all three lenses fail `'Prompt is too long'`; until #1343 lands, these runs get tally+behavioral only, recorded with the `scorer_model='none'` + note convention.
- **Line-pointer de-drift** — swept WorldOS-RUNBOOK.md + WorldOS-GUI-RUNBOOK.md + docs/OPERATIONS.md for `file.py:NNN`-style pointers with multiple regex passes. Finding: **zero exist in these three files** (before/after: 0/0) — the drifted pointers the audit's 8-spot-check found live in `docs/roadmap/PRODUCT-ROADMAP.md` (out of scope here) and the dated `docs/audits/ENGINE-AUDIT-2026-06-11.md` snapshot, not in the three files this item named.

No markdown linter exists in this repo's CI (checked `.github/workflows/*.yml` + repo root for markdownlint/remark config) — nothing to run there.

## Test plan
- [x] Every CHANGELOG claim traced to a merged PR via `gh pr view <n> --json title,mergedAt,state`
- [x] #1341/#1345 confirmed OPEN (not merged) and excluded from absorbed content
- [x] Line-pointer sweep re-verified with 4 independent regex patterns across all 3 named files — zero false negatives
- [x] No markdown lint config found in CI — n/a
- [ ] Owner skim of the CHANGELOG batch grouping for tone/accuracy