### PR TITLE
[W2-UI] rest-mode click-to-move + door walk-through + walk_click_replay eval (#1350)

### DIFF
--- a/qa/walk_click_replay.py
+++ b/qa/walk_click_replay.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""walk_click_replay.py — the W2-UI (#1350) lane EVAL: drive rest-mode click-to-move + the
+door-cell walk-through through the REAL viewer, exactly as the browser does, and assert the
+whole UI ↔ /move ↔ engine loop is honest.
+
+Deferred from #1341 by the architect ruling (the ENGINE half shipped there; this exercises the
+UI half). It is the LIGHT replay path from qa/UI_PLAYTEST.md: NO DM / NO LLM / NO Playwright —
+`walk_to_cell` is engine-resolved IN-PROCESS by the viewer (viewer/server.py:_resolve_walk_to),
+so a plain HTTP client hitting the viewer's real `/move` sink + `/combat-surface` + `/events`
+reads exercises the identical click path the browser fires (screen-combat.jsx postRestWalk /
+onRestDoorWalk). We boot the viewer as its own process against a seeded 2-room rest campaign and
+POST the same payloads the JSX posts.
+
+ASSERTS (the acceptance bundle for #1350):
+  A1  PATH LEGALITY — a walk POST returns ok:True with an engine-CONFIRMED path (a contiguous
+      cell list from the start cell to the target); an off-grid / into-a-wall walk is REJECTED
+      (ok:False) — the viewer never invents a route (VISION: renderer = pure consumer).
+  A2  REST_WALK BEAT — the walk lands a `rest_walk` beat in /events, projected as the
+      Action-Replay envelope verb "walk" / anim_hint "glide" carrying the engine path under
+      result.path (the #1303 renderer's glide input).
+  A3  RENDERED CELL == ENGINE stage_cell — after the walk the /combat-surface rest token for the
+      mover renders AT the cell the engine wrote (stage.tokens[mover].x/y == target), so a
+      surface reload glides the token to the confirmed destination (no client prediction).
+  A4  DOOR WALK-THROUGH — clicking a door cell (walk_to_cell onto the doorway, then cross_door)
+      ends in the LINKED room: /combat-surface reports the new current location + its own grid.
+
+Engine = SOLE WRITER: this script only SEEDS (via server.* under the engine lock) and then drives
+the viewer over HTTP; it never writes campaign state directly during the replay.
+
+  uv run --directory servers/engine python "$PWD/qa/walk_click_replay.py"
+  (or plain `python3 qa/walk_click_replay.py` if the engine deps are importable)
+
+Exit 0 = all asserts green; non-zero = the first failed assert (printed).
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE_DIR = ROOT / "servers" / "engine"
+VIEWER = ROOT / "viewer" / "server.py"
+CID = "camp_w2walkreplay01"
+GRID_W, GRID_H = 8, 6
+DOOR = (4, 0)  # back-wall-center doorway, shared link between the two rest units
+
+
+# ── seed: a 2-room REST campaign (no combat) with scene grids + a shared doorway ───────────────
+
+
+def _author_room(loc_id: str, scene_id: str):
+    """A GRID_W×GRID_H rest scene: perimeter walls with a walkable DOOR gap at (4,0), one blocking
+    prop, floor elsewhere. Mirrors qa/seed_gfx_crypt_2room._author_room, trimmed for a rest replay."""
+    from scene_grid import (  # noqa: PLC0415
+        SceneGrid, SceneGridSpec, SceneCell, SceneCellDefault, SceneProp,
+    )
+
+    cells: list = []
+    for c in range(GRID_W):
+        if (c, 0) == DOOR:
+            cells.append(SceneCell(c=c, r=0, type="door", walkable=True))  # the doorway opening
+        else:
+            cells.append(SceneCell(c=c, r=0, type="wall", walkable=False))
+        cells.append(SceneCell(c=c, r=GRID_H - 1, type="wall", walkable=False))
+    for r in range(1, GRID_H - 1):
+        cells.append(SceneCell(c=0, r=r, type="wall", walkable=False))
+        cells.append(SceneCell(c=GRID_W - 1, r=r, type="wall", walkable=False))
+    # one interior blocking prop the walk must route around.
+    prop = SceneProp(id="urn", kind="urn", cells=[(3, 3)], anchor_cell=(3, 3))
+    cells.append(SceneCell(c=3, r=3, type="prop", walkable=False, prop_ref="urn"))
+    return SceneGrid(
+        scene_id=scene_id, location_id=loc_id, kind="dungeon",
+        grid=SceneGridSpec(cols=GRID_W, rows=GRID_H, cell_size_ft=5),
+        cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
+        cells=cells, props=[prop],
+        door_cells=[DOOR],
+    )
+
+
+def seed(state_dir: str) -> dict:
+    os.environ["WORLDOS_STATE_DIR"] = state_dir
+    if str(ENGINE_DIR) not in sys.path:
+        sys.path.insert(0, str(ENGINE_DIR))
+    import server  # noqa: PLC0415
+    from models import Campaign  # noqa: PLC0415
+
+    server.save_campaign(Campaign(id=CID, title="W2 Walk-Replay",
+                                  summary="Two linked rest rooms for the click-to-move replay."))
+    room_a = server.add_location(campaign_id=CID, name="Antechamber", make_current=True,
+                                 description="A small stone antechamber; a doorway leads north.")
+    room_b = server.add_location(campaign_id=CID, name="Inner Hall",
+                                 description="The inner hall beyond the doorway.",
+                                 connections=[room_a["id"]])
+    c = server._require(CID)
+    c.locations[room_a["id"]].scene_grid = _author_room(room_a["id"], f"{CID}:a")
+    c.locations[room_b["id"]].scene_grid = _author_room(room_b["id"], f"{CID}:b")
+    server.save_campaign(c)
+    server.start_session(CID, title="W2 Walk-Replay")
+
+    hero = server.create_character(
+        campaign_id=CID, name="Aldric", kind="player", race="human", class_name="fighter", level=3,
+        apply_srd_defaults=True, add_to_party=True,
+    )
+    # place the hero on a known start cell (no combat — a pure rest scene).
+    c = server._require(CID)
+    c.characters[hero["id"]].stage_cell = (1, 4)
+    server.save_campaign(c)
+    return {"room_a": room_a["id"], "room_b": room_b["id"], "hero_id": hero["id"]}
+
+
+# ── HTTP helpers against the REAL viewer ───────────────────────────────────────────────────────
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _get(base: str, path: str) -> dict:
+    with urllib.request.urlopen(f"{base}{path}", timeout=8) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def _post_move(base: str, body: dict) -> dict:
+    req = urllib.request.Request(
+        f"{base}/move", data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=12) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def _wait_ready(base: str, timeout: float = 20.0) -> None:
+    deadline = time.time() + timeout
+    last = ""
+    while time.time() < deadline:
+        try:
+            _get(base, f"/combat-surface?campaign={CID}")
+            return
+        except (urllib.error.URLError, ConnectionError, OSError) as exc:  # noqa: PERF203
+            last = str(exc)
+            time.sleep(0.25)
+    raise RuntimeError(f"viewer did not come up within {timeout}s: {last}")
+
+
+def _rest_token(surface: dict, cid: str) -> dict | None:
+    for t in ((surface.get("stage") or {}).get("tokens") or []):
+        if t.get("id") == cid:
+            return t
+    return None
+
+
+# ── the assertions ─────────────────────────────────────────────────────────────────────────────
+
+
+class ReplayFail(AssertionError):
+    pass
+
+
+def _check(cond: bool, label: str, detail: str = "") -> None:
+    if not cond:
+        raise ReplayFail(f"{label}{(': ' + detail) if detail else ''}")
+    print(f"  PASS  {label}")
+
+
+def run(base: str, ids: dict) -> None:
+    hero = ids["hero_id"]
+    room_b = ids["room_b"]
+
+    # sanity: the rest surface renders the hero at his seeded stage_cell before any walk.
+    surf0 = _get(base, f"/combat-surface?campaign={CID}")
+    tok0 = _rest_token(surf0, hero)
+    _check(tok0 is not None and (tok0["x"], tok0["y"]) == (1, 4),
+           "rest surface seats the hero at his stage_cell",
+           detail=f"got {tok0 and (tok0.get('x'), tok0.get('y'))}")
+
+    # A1 (legal): walk to an open cell across the room — engine confirms a contiguous path.
+    target = (6, 4)
+    ev_before = len(_get(base, f"/events?campaign={CID}&since=0").get("entries", []))
+    out = _post_move(base, {"kind": "walk_to_cell", "character_id": hero, "x": target[0], "y": target[1]})
+    _check(out.get("ok") is True and out.get("walked") is True,
+           "A1 legal walk is accepted (ok:True)", detail=json.dumps(out))
+    path = out.get("path") or []
+    _check(len(path) >= 2 and tuple(path[0]) == (1, 4) and tuple(path[-1]) == target,
+           "A1 engine-confirmed path runs start→target",
+           detail=f"path={path}")
+    # contiguity: each step is a single grid move (chebyshev-1) — the engine routed it, not the client.
+    steps_ok = all(
+        max(abs(path[i + 1][0] - path[i][0]), abs(path[i + 1][1] - path[i][1])) == 1
+        for i in range(len(path) - 1)
+    )
+    _check(steps_ok, "A1 path is contiguous (engine-routed, no teleport)", detail=f"path={path}")
+
+    # A1 (illegal): a walk into a wall / off-grid is REJECTED — the viewer never invents a route.
+    bad = _post_move(base, {"kind": "walk_to_cell", "character_id": hero, "x": 0, "y": 0})
+    _check(bad.get("ok") is False, "A1 into-a-wall walk is rejected (ok:False)", detail=json.dumps(bad))
+    off = _post_move(base, {"kind": "walk_to_cell", "character_id": hero, "x": 99, "y": 99})
+    _check(off.get("ok") is False, "A1 off-grid walk is rejected (ok:False)", detail=json.dumps(off))
+
+    # A2: the legal walk landed a rest_walk beat → envelope verb "walk" / anim_hint "glide" / path.
+    evs = _get(base, f"/events?campaign={CID}&since=0").get("entries", [])
+    _check(len(evs) > ev_before, "A2 a new event beat landed", detail=f"{ev_before}→{len(evs)}")
+    walk_beats = [e for e in evs if e.get("verb") == "walk"]
+    _check(bool(walk_beats), "A2 a rest_walk beat is projected as verb 'walk'")
+    beat = walk_beats[-1]
+    _check(beat.get("anim_hint") == "glide", "A2 the walk beat carries anim_hint 'glide'",
+           detail=str(beat.get("anim_hint")))
+    beat_path = (beat.get("result") or {}).get("path") or []
+    _check(len(beat_path) >= 2 and tuple(beat_path[-1]) == target,
+           "A2 the beat carries the engine path under result.path", detail=f"{beat_path}")
+
+    # A3: the rendered rest token now sits AT the engine stage_cell (no client-side drift).
+    surf1 = _get(base, f"/combat-surface?campaign={CID}")
+    tok1 = _rest_token(surf1, hero)
+    _check(tok1 is not None and (tok1["x"], tok1["y"]) == target,
+           "A3 rendered rest token == engine stage_cell after the walk",
+           detail=f"got {tok1 and (tok1.get('x'), tok1.get('y'))}, want {target}")
+
+    # A4: DOOR WALK-THROUGH — walk onto the doorway, then cross into the linked room.
+    door_walk = _post_move(base, {"kind": "walk_to_cell", "character_id": hero, "x": DOOR[0], "y": DOOR[1]})
+    _check(door_walk.get("ok") is True, "A4 walk onto the doorway cell is accepted",
+           detail=json.dumps(door_walk))
+    crossed = _post_move(base, {"kind": "cross_door", "x": DOOR[0], "y": DOOR[1]})
+    _check(crossed.get("ok") is True, "A4 cross_door from the doorway is accepted",
+           detail=json.dumps(crossed))
+    surf2 = _get(base, f"/combat-surface?campaign={CID}")
+    _check((surf2.get("location") or {}).get("id") == room_b,
+           "A4 the party arrives in the LINKED room after the door walk-through",
+           detail=f"now at {(surf2.get('location') or {}).get('id')}, want {room_b}")
+    _check(bool((surf2.get("grid") or {}).get("cols")),
+           "A4 the linked room renders its own scene grid")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="w2-walk-replay-") as td:
+        state_dir = str(Path(td) / "state")
+        moves = str(Path(td) / "moves.ndjson")
+        Path(state_dir).mkdir(parents=True, exist_ok=True)
+        ids = seed(state_dir)
+
+        port = _free_port()
+        base = f"http://127.0.0.1:{port}"
+        env = dict(os.environ)
+        env["WORLDOS_STATE_DIR"] = state_dir
+        env["WORLDOS_PLAYER_MOVES"] = moves  # enables the /move write path (the live-game gate)
+        proc = subprocess.Popen(
+            [sys.executable, str(VIEWER), CID, str(port)],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        try:
+            _wait_ready(base)
+            print(f"viewer up on {base} (campaign {CID})")
+            run(base, ids)
+        except ReplayFail as exc:
+            print(f"\nREPLAY FAILED: {exc}", file=sys.stderr)
+            return 1
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+    print("\nwalk_click_replay: ALL ASSERTS GREEN ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/walk_click_replay.py
+++ b/qa/walk_click_replay.py
@@ -249,17 +249,40 @@ def main() -> int:
         Path(state_dir).mkdir(parents=True, exist_ok=True)
         ids = seed(state_dir)
 
-        port = _free_port()
-        base = f"http://127.0.0.1:{port}"
         env = dict(os.environ)
         env["WORLDOS_STATE_DIR"] = state_dir
         env["WORLDOS_PLAYER_MOVES"] = moves  # enables the /move write path (the live-game gate)
-        proc = subprocess.Popen(
-            [sys.executable, str(VIEWER), CID, str(port)],
-            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-        )
+        # Boot with output CAPTURED (not DEVNULL — a silent import/bind/seed failure would
+        # otherwise hide behind a generic _wait_ready timeout) and ONE fresh-port retry:
+        # _free_port() is inherently TOCTOU (close->launch window), so a lost bind race gets a
+        # second freshly-probed port instead of a 20s stall.
+        boot_log = Path(td) / "viewer-boot.log"
+        proc = None
+        base = ""
+        for attempt in (1, 2):
+            port = _free_port()
+            base = f"http://127.0.0.1:{port}"
+            with open(boot_log, "wb") as lf:
+                proc = subprocess.Popen(
+                    [sys.executable, str(VIEWER), CID, str(port)],
+                    env=env, stdout=lf, stderr=subprocess.STDOUT,
+                )
+            try:
+                _wait_ready(base)
+                break
+            except ReplayFail:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                tail = boot_log.read_bytes()[-2000:].decode(errors="replace")
+                if attempt == 2:
+                    print(f"\nviewer never came up; boot log tail:\n{tail}", file=sys.stderr)
+                    return 1
+                print(f"boot attempt {attempt} failed (bind race or slow boot) — retrying on a "
+                      f"fresh port; log tail:\n{tail}", file=sys.stderr)
         try:
-            _wait_ready(base)
             print(f"viewer up on {base} (campaign {CID})")
             run(base, ids)
         except ReplayFail as exc:

--- a/viewer/openworlds/screen-combat.jsx
+++ b/viewer/openworlds/screen-combat.jsx
@@ -100,6 +100,10 @@ function ScreenCombat({ onNavigate, state }) {
   }, [loadSurface]);
 
   const tokens = Array.isArray(surface?.tokens) ? surface.tokens : [];
+  // W2 (#1319): the rest-mode stage projection — the party (+ present NPCs) standing on the scene
+  // grid at their engine stage_cell/spawn cell. Empty during combat (the authoritative tokens are
+  // the top-level `tokens`), so the rest board only lights up outside a fight.
+  const restTokens = Array.isArray(surface?.stage?.tokens) ? surface.stage.tokens : [];
   const initiative = Array.isArray(surface?.initiative) ? surface.initiative : [];
   const actions = Array.isArray(surface?.actionBar) ? surface.actionBar : [];
   const zones = Array.isArray(surface?.zones) ? surface.zones : [];
@@ -121,18 +125,26 @@ function ScreenCombat({ onNavigate, state }) {
   const commandCenter = surface?.commandCenter || {};
   const economy = surface?.actionEconomy || {};
   const canAct = Boolean(surface?.can_act);
+  // W2 (#1319): outside combat, selection resolves against the REST tokens (the walkable party on
+  // the stage); inside combat it resolves against the tactical `tokens` exactly as before. The
+  // selectable pool is combat tokens during a fight, rest tokens at rest — so a click-to-walk always
+  // has a valid mover to send to walk_to.
+  const selectablePool = encounter.active ? tokens : (restTokens.length ? restTokens : tokens);
   const selected =
-    tokens.find((t) => t.id === selectedToken) ||
-    tokens.find((t) => t.id === surface?.selectedTokenId) ||
-    tokens[0] ||
+    selectablePool.find((t) => t.id === selectedToken) ||
+    selectablePool.find((t) => t.id === surface?.selectedTokenId) ||
+    selectablePool[0] ||
     null;
   const visibleLog = [...battleLog, ...localLog];
 
   React.useEffect(() => {
-    if (!selectedToken || !tokens.some((t) => t.id === selectedToken)) {
-      setSelectedToken(surface?.selectedTokenId || tokens[0]?.id || "");
+    // Keep a valid selection as the surface refreshes: if the current pick vanished from the
+    // selectable pool (combat tokens in a fight, rest tokens at rest), fall back to the engine's
+    // hint or the first token so a click-to-walk always has a mover.
+    if (!selectedToken || !selectablePool.some((t) => t.id === selectedToken)) {
+      setSelectedToken(surface?.selectedTokenId || selectablePool[0]?.id || "");
     }
-  }, [surface?.selectedTokenId, selectedToken, tokens]);
+  }, [surface?.selectedTokenId, selectedToken, selectablePool]);
 
   // #598: disarm the Move tile's "pick a zone" mode the instant the surface says the actor can no
   // longer act (turn advanced, action spent, surface went read-only) — otherwise a stale refresh
@@ -305,6 +317,52 @@ function ScreenCombat({ onNavigate, state }) {
   const onCellMove = (x, y) => postCombatIntent({ kind: "move_to_cell", x, y }, "move");
   const onAttackToken = (targetId) => postCombatIntent({ kind: "attack", target_id: targetId }, "attack");
 
+  // W2 (#1319) REST-MODE click-to-walk: post a `walk_to_cell` intent for the SELECTED rest token.
+  // The engine (walk_to) paths around walls/props/standers, writes stage_cell, and returns the
+  // CONFIRMED path — the viewer stays a pure consumer: it never predicts a route, it re-fetches the
+  // surface so the token re-renders at the engine's stage_cell (a CSS transition glides it there).
+  // Same /move lane + busyRef double-submit guard as the combat intents. Only ever called outside
+  // combat (the rest board only renders when !encounter.active).
+  const postRestWalk = async (characterId, x, y, label) => {
+    if (!characterId) {
+      toast({ kind: "danger", eyebrow: "Rest", title: "Pick who walks", body: "Select a party member first, then click where to walk." });
+      return;
+    }
+    if (busyRef.current) return; // synchronous double-click guard
+    busyRef.current = true;
+    setBusyAction(label || "walk");
+    try {
+      const response = await fetch("/move", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "walk_to_cell", character_id: characterId, x, y, campaign: surface?.campaign_id || campaignId }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || payload.ok === false) throw new Error(payload.reason || `walk ${response.status}`);
+      setLocalLog((rows) => [
+        ...rows,
+        { event: "player-intent", title: "Player walk", text: `→ cell (${x}, ${y})`, meta: [{ label: "lane", value: "/move" }] },
+      ]);
+      await loadSurface();
+      return payload;
+    } catch (error) {
+      toast({ kind: "danger", title: "Walk not sent", body: error?.message || "The viewer could not reach /move." });
+      return { ok: false };
+    } finally {
+      busyRef.current = false;
+      setBusyAction("");
+    }
+  };
+  const onRestWalk = (x, y) => postRestWalk(selected?.id, x, y, "walk");
+  // Door click: WALK the selected member onto the doorway cell first (engine paths there), then
+  // cross into the linked room. If the walk is refused (already on the cell / no route) we still
+  // attempt the cross — cross_door is engine-gated and rejects cleanly if it isn't a real doorway.
+  const onRestDoorWalk = async (door) => {
+    if (!Array.isArray(door?.cell)) return;
+    if (selected?.id) await postRestWalk(selected.id, door.cell[0], door.cell[1], "walk-to-door");
+    await crossDoor(door);
+  };
+
   const actionTile = (id, fallbackIcon, fallbackLabel) => {
     const action = actionById(id);
     // #598: the Move tile stays visually "active" while armed (pickingZone), even though no
@@ -356,6 +414,23 @@ function ScreenCombat({ onNavigate, state }) {
 
           {encounter.active ? (
             <CombatMap tokens={tokens} zones={zones} grid={surface?.grid} selected={selected?.id} onSelect={setSelectedToken} onCellMove={onCellMove} onAttack={onAttackToken} canAct={canAct} sceneScope={sceneScope} pickingZone={pickingZone} onZoneMoveTarget={postZoneMove} />
+          ) : restTokens.length && surface?.grid ? (
+            // W2 (#1319) REST-MODE BOARD: outside combat, render the walkable scene grid with the
+            // party standing on it. A walkable-cell click walks the SELECTED member there (engine
+            // walk_to); a door cell walks-then-crosses into the linked room. Only shown when the
+            // scene has an authored grid + rest tokens; otherwise fall back to the door bar + empty
+            // state (byte-identical to today for a gridless location).
+            <RestGridBoard
+              tokens={restTokens}
+              grid={surface?.grid}
+              doors={doors}
+              selected={selected?.id}
+              onSelect={setSelectedToken}
+              onWalk={onRestWalk}
+              onDoorWalk={onRestDoorWalk}
+              busy={Boolean(busyAction)}
+              sceneScope={sceneScope}
+            />
           ) : (
             <React.Fragment>
               {doors.length ? (
@@ -709,6 +784,110 @@ function GridCellToken({ t, selected, isCurrent }) {
       }}>{t.initial || (t.name || "?").slice(0, 1)}</div>
       <div style={{ width: "72%", height: 3, background: "rgba(0,0,0,0.5)", boxShadow: "inset 0 0 0 0.5px rgba(0,0,0,0.6)" }}>
         <div style={{ width: `${Math.round(ratio * 100)}%`, height: "100%", background: hpBarFill(t, isFoe) }} />
+      </div>
+    </div>
+  );
+}
+
+/* W2 (#1319) REST-MODE walk board: the out-of-combat twin of CombatGridBoard. Renders the location's
+   walkable scene grid (grid.cols×rows + per-cell walkability) with the party standing on it at their
+   engine stage_cell (surface.stage.tokens). Clicking a WALKABLE empty cell walks the SELECTED party
+   member there (posts walk_to_cell → engine walk_to paths + writes stage_cell); a DOOR cell walks
+   to the doorway then crosses into the linked room; a TOKEN selects who walks next. The engine is the
+   sole writer + router — this board only POSTS an intent and re-renders the surface that comes back
+   (no client path prediction; the token glides to the engine-confirmed stage_cell via a CSS
+   transition on the next reload). Mirrors CombatGridBoard's walkability derivation exactly. */
+function RestGridBoard({ tokens, grid, doors, selected, onSelect, onWalk, onDoorWalk, busy, sceneScope }) {
+  const cols = Math.max(1, Number(grid && grid.cols) || 16);
+  const rows = Math.max(1, Number(grid && grid.rows) || 10);
+  const at = {};
+  (tokens || []).forEach((t) => {
+    const x = Number(t.x), y = Number(t.y);
+    if (Number.isInteger(x) && Number.isInteger(y)) at[`${x},${y}`] = t;
+  });
+  // Per-cell walkability override + cellDefault fallback — IDENTICAL derivation to CombatGridBoard,
+  // so a wall/prop reads the same blocked in rest as it does in combat (one honest walkability map).
+  const walkability = {};
+  ((grid && Array.isArray(grid.cells)) ? grid.cells : []).forEach((c) => {
+    if (c && Number.isInteger(c.c) && Number.isInteger(c.r) && typeof c.walkable === "boolean") {
+      walkability[`${c.c},${c.r}`] = c.walkable;
+    }
+  });
+  const defaultWalkable = !(grid && grid.cellDefault && grid.cellDefault.walkable === false);
+  const isWalkable = (x, y) => {
+    const key = `${x},${y}`;
+    return Object.prototype.hasOwnProperty.call(walkability, key) ? walkability[key] : defaultWalkable;
+  };
+  // Door cells (the authored doorways) → a door click walks-then-crosses. Keyed by "x,y".
+  const doorAt = {};
+  (doors || []).forEach((d) => {
+    if (Array.isArray(d?.cell) && d.cell.length === 2) doorAt[`${d.cell[0]},${d.cell[1]}`] = d;
+  });
+  const cells = [];
+  for (let y = 0; y < rows; y++) for (let x = 0; x < cols; x++) cells.push({ x, y, t: at[`${x},${y}`] });
+  return (
+    <div style={{
+      position: "relative", width: "100%", height: "calc(100% - 50px)", overflow: "hidden",
+      background:
+        `radial-gradient(ellipse at 50% 40%, rgba(60,30,10,0.2), transparent 70%),
+         linear-gradient(135deg, #3a2418 0%, #25160e 100%)`,
+      boxShadow: "inset 0 0 0 1px var(--w-500), inset 0 0 60px rgba(0,0,0,0.6)",
+      display: "flex", alignItems: "center", justifyContent: "center", padding: 12,
+    }}>
+      {sceneScope ? (
+        <Img scope={sceneScope} label="scene · rest" w="100%" h="100%" fit="cover"
+          style={{ position: "absolute", inset: 0, zIndex: 0, opacity: 0.9 }} />
+      ) : null}
+      <div data-worldos-testid="rest-board" style={{
+        position: "relative", zIndex: 1,
+        display: "grid",
+        gridTemplateColumns: `repeat(${cols}, 1fr)`, gridTemplateRows: `repeat(${rows}, 1fr)`,
+        gap: 1, aspectRatio: `${cols} / ${rows}`, height: "100%", maxWidth: "100%", width: "auto",
+        boxShadow: "inset 0 0 0 1px rgba(176,141,87,0.25)",
+      }}>
+        {cells.map(({ x, y, t }) => {
+          const walkable = isWalkable(x, y);
+          const door = doorAt[`${x},${y}`];
+          // A token selects; a door cell walks-then-crosses; a walkable empty cell walks. Disabled
+          // while a POST is in flight (busy) so a double-click can't fire two walks/crossings.
+          const onActivate = t
+            ? () => onSelect(t.id)
+            : door
+              ? () => { if (!busy) onDoorWalk(door); }
+              : () => { if (!busy && walkable) onWalk(x, y); };
+          const actionable = Boolean(t) || (!busy && (door ? true : walkable));
+          const title = t
+            ? `${t.name}${selected === t.id ? " (selected)" : " — select to walk"}`
+            : door
+              ? `Cross to ${door.toName || "the next room"} →`
+              : (walkable ? `walk → (${x}, ${y})` : "blocked");
+          const restBox = door
+            ? "inset 0 0 0 1px var(--gold-glow, rgba(244,210,123,0.6))"
+            : (walkable ? "inset 0 0 0 0.5px rgba(176,141,87,0.10)" : "inset 0 0 0 0.5px rgba(80,40,30,0.5)");
+          const hoverBg = door ? "rgba(244,210,123,0.18)" : "rgba(244,210,123,0.12)";
+          return (
+            <div key={`${x},${y}`}
+              title={title} aria-label={title}
+              role={actionable ? "button" : undefined}
+              tabIndex={actionable ? 0 : -1}
+              data-worldos-door={door ? "1" : undefined}
+              onClick={onActivate}
+              onKeyDown={(e) => { if (actionable && (e.key === "Enter" || e.key === " ")) { e.preventDefault(); onActivate(); } }}
+              onMouseEnter={(e) => { if (actionable && !t) e.currentTarget.style.background = hoverBg; }}
+              onMouseLeave={(e) => { if (!t) e.currentTarget.style.background = door ? "rgba(244,210,123,0.06)" : "transparent"; }}
+              style={{
+                position: "relative", boxShadow: restBox,
+                background: door ? "rgba(244,210,123,0.06)" : (walkable ? "transparent" : "rgba(20,10,6,0.45)"),
+                cursor: actionable ? "pointer" : "default", outline: "none",
+                transition: "background 0.08s, box-shadow 0.08s",
+                display: "flex", alignItems: "center", justifyContent: "center",
+              }}>
+              {t ? <GridCellToken t={t} selected={selected === t.id} isCurrent={false} /> : (door ? (
+                <span aria-hidden="true" style={{ fontSize: "min(2.6vmin, 18px)", color: "var(--gold-glow, #f4d27b)", opacity: 0.85 }}>⇲</span>
+              ) : null)}
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -1082,6 +1261,7 @@ function BattleLogLine({ l }) {
 Object.assign(window, {
   ScreenCombat,
   CombatMap,
+  RestGridBoard,
   CombatToken,
   CommandCenterPanel,
   ActionTile,

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -115,7 +115,11 @@ _TARGET_ONLY_KINDS = {"travel", "inspect", "examine", "move_to_zone"}
 # Grid-combat player-turn kinds (move_to_cell / on-turn attack / end_turn) are resolved by the
 # ENGINE in-process (not the DM agent): carried by x/y and/or target_id, with the per-kind checks
 # below relaxing the "needs text or name" guard for them.
-_MOVE_FIELDS = ("text", "name", "skill", "target", "weapon", "dc", "x", "y", "target_id", "end_turn", "turn_token")
+# `character_id` (W2 #1319) rides the walk_to_cell rest-mode intent: WHICH party member walks to
+# the clicked cell (the engine's walk_to takes an explicit character_id). It is a plain id string
+# carried alongside x/y — added to the allowlist so the field survives sanitize (the anti-injection
+# allowlist only WIDENS; every existing field is untouched).
+_MOVE_FIELDS = ("text", "name", "skill", "target", "weapon", "dc", "x", "y", "target_id", "character_id", "end_turn", "turn_token")
 _MOVE_MAXLEN = 2000
 
 
@@ -179,6 +183,15 @@ def sanitize_move(raw: object) -> tuple[Optional[dict], str]:
     if kind == "cross_door":
         if not (isinstance(move.get("x"), int) and isinstance(move.get("y"), int)):
             return None, "'cross_door' needs integer 'x' and 'y' (the doorway cell)"
+        return move, ""
+    # `walk_to_cell` (W2 #1319) is the ENGINE-resolved rest-mode click-to-walk intent: it needs a
+    # numeric x AND y target cell (carried alongside, never text) plus the character_id of the party
+    # member who walks. Validated here so a malformed cell/actor rejects before the engine bridge.
+    if kind == "walk_to_cell":
+        if not (isinstance(move.get("x"), int) and isinstance(move.get("y"), int)):
+            return None, "'walk_to_cell' needs integer 'x' and 'y' grid coordinates"
+        if not move.get("character_id"):
+            return None, "'walk_to_cell' needs a 'character_id' (who walks)"
         return move, ""
     # The graphical intents (travel/inspect/examine/move_to_zone) are carried by `target`;
     # everything else needs a `text` or `name` so the DM has something to act on. An `attack`
@@ -1458,6 +1471,47 @@ def _resolve_cross_door(campaign_id: str, move: dict) -> dict:
     except Exception as exc:  # noqa: BLE001 — surface any engine error as a clean rejection
         return {"ok": False, "reason": f"cross failed: {exc}"}
     return {"ok": True, "crossed": result.get("crossed_door")}
+
+
+def _resolve_walk_to(campaign_id: str, move: dict) -> dict:
+    """Resolve a `walk_to_cell` intent (W2 #1319 rest-mode click-to-walk): walk the party member
+    ``character_id`` to rest-grid cell (x, y) via the engine's ``walk_to`` verb (which paths around
+    walls/props/standers, writes Character.stage_cell, and emits the ``rest_walk`` glide beat — all
+    under the engine lock, so the engine stays the SOLE WRITER). Gated on combat being RESOLVED (the
+    grid twin during a fight is move_to_cell). Returns the engine's CONFIRMED ``{ok, walked, path, to,
+    from}`` so the read-only renderer glides the actor along exactly the route the engine routed — the
+    viewer NEVER predicts a client-side path (a second-writer / VISION violation). Rejections (active
+    combat / no scene grid / off-grid / blocked / unreachable) leave NOTHING mutated and return
+    ``{ok:False, reason}``. Mirrors _resolve_cross_door's in-process bridge."""
+    engine = _load_engine_server()
+    if engine is None:
+        return {"ok": False, "reason": "engine unavailable"}
+    try:
+        snap = engine._require(campaign_id)
+    except Exception as exc:  # noqa: BLE001 — surface any engine read error as a clean rejection
+        return {"ok": False, "reason": f"could not read rest state: {exc}"}
+    if snap.combat.active:
+        return {"ok": False, "reason": "combat is active — use move_to_cell (walk_to is the rest-mode verb)"}
+    try:
+        result = engine.walk_to(campaign_id, str(move["character_id"]), int(move["x"]), int(move["y"]))
+    except (KeyError, ValueError, TypeError) as exc:
+        return {"ok": False, "reason": str(exc)}
+    except Exception as exc:  # noqa: BLE001 — surface any engine error as a clean rejection
+        return {"ok": False, "reason": f"walk failed: {exc}"}
+    # walk_to signals a routing refusal (off-grid / blocked / unreachable) via walked:False + a
+    # move_blocked block — surface it as a clean {ok:False} so the client toasts the reason and does
+    # NOT glide. A successful walk carries the engine-confirmed envelope path (incl. the start cell).
+    if not result.get("walked"):
+        reason = (result.get("move_blocked") or {}).get("reason") or "walk rejected"
+        return {"ok": False, "reason": reason, "walked": False}
+    return {
+        "ok": True,
+        "walked": True,
+        "character_id": result.get("character_id"),
+        "from": result.get("from"),
+        "to": result.get("to"),
+        "path": result.get("path") or [],
+    }
 
 
 def _resolve_player_combat_turn(campaign_id: str, move: dict, *, live: bool) -> dict:
@@ -3506,13 +3560,21 @@ def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
         ch = ch if isinstance(ch, dict) else {}
         name = _text(ch.get("name"), cid)
         kind = _text(ch.get("kind"))
-        cell = None
-        if slot < len(cells):
-            cell = cells[slot]
-        elif anchor_cells:
-            cell = anchor_cells[fallback_slot % len(anchor_cells)]
-        elif party_cells:
-            cell = party_cells[fallback_slot % len(party_cells)]
+        # W2 (#1319): a character who has WALKED in rest mode carries an engine-authoritative
+        # Character.stage_cell (walk_to's sole-writer field) — render the token WHERE IT STANDS, not
+        # at its authored spawn cell, so a click-to-move glide lands the token at the confirmed
+        # destination on the next surface reload. ADDITIVE: stage_cell is None until a first walk, so
+        # an un-walked character falls straight through to today's spawn/anchor projection below
+        # (byte-identical). Still a pure PROJECTION of engine-owned state (positionAuthority stays
+        # "derived"); the viewer never writes it.
+        cell = _cell(ch.get("stage_cell"))
+        if cell is None:
+            if slot < len(cells):
+                cell = cells[slot]
+            elif anchor_cells:
+                cell = anchor_cells[fallback_slot % len(anchor_cells)]
+            elif party_cells:
+                cell = party_cells[fallback_slot % len(party_cells)]
         if cell is None:
             return
         tokens.append({
@@ -9487,6 +9549,13 @@ class _Handler(BaseHTTPRequestHandler):
         # travel_to under the engine lock), NOT appended for the DM. Gated on combat being resolved.
         if move.get("kind") == "cross_door":
             self._json(_resolve_cross_door(self.campaign_id, move))
+            return
+        # W2 REST-WALK LANE (#1319): a `walk_to_cell` is engine-resolved in-process (engine.walk_to
+        # paths + writes stage_cell + emits the rest_walk glide beat under the engine lock), NOT
+        # appended for the DM. Gated on combat being resolved (see _resolve_walk_to). Returns the
+        # engine-confirmed path so the browser glides only the routed cells.
+        if move.get("kind") == "walk_to_cell":
+            self._json(_resolve_walk_to(self.campaign_id, move))
             return
         is_combat_cell = move.get("kind") in ("move_to_cell", "end_turn") or (
             move.get("kind") == "attack" and "target_id" in move

--- a/viewer/tests/test_move_intents.py
+++ b/viewer/tests/test_move_intents.py
@@ -160,6 +160,53 @@ class GridCombatMoveKindTests(unittest.TestCase):
         self.assertNotIn("narration", move)
 
 
+class RestWalkMoveKindTests(unittest.TestCase):
+    """W2 (#1350) — the rest-mode `walk_to_cell` intent the ENGINE resolves in-process. Pure
+    sanitize_move checks: it validates x/y (like move_to_cell) PLUS a character_id (who walks),
+    keeps role forced + unknown fields dropped, and is additive (every existing kind unaffected)."""
+
+    def test_walk_to_cell_accepted_with_int_xy_and_character(self):
+        move, reason = server.sanitize_move(
+            {"kind": "walk_to_cell", "x": 5, "y": 2, "character_id": "char_hero"}
+        )
+        self.assertEqual(reason, "")
+        self.assertEqual(move["kind"], "walk_to_cell")
+        self.assertEqual((move["x"], move["y"]), (5, 2))
+        self.assertEqual(move["character_id"], "char_hero")
+        self.assertEqual(move["role"], "player")  # role still forced
+
+    def test_walk_to_cell_coerces_float_cell_to_int(self):
+        move, reason = server.sanitize_move(
+            {"kind": "walk_to_cell", "x": 4.0, "y": 0.0, "character_id": "c"}
+        )
+        self.assertEqual(reason, "")
+        self.assertIsInstance(move["x"], int)
+        self.assertEqual((move["x"], move["y"]), (4, 0))
+
+    def test_walk_to_cell_without_xy_rejected(self):
+        for bad in ({"kind": "walk_to_cell", "character_id": "c"},
+                    {"kind": "walk_to_cell", "x": 2, "character_id": "c"},
+                    {"kind": "walk_to_cell", "text": "over there", "character_id": "c"}):
+            with self.subTest(payload=bad):
+                move, reason = server.sanitize_move(bad)
+                self.assertIsNone(move)
+                self.assertIn("x", reason)
+
+    def test_walk_to_cell_without_character_rejected(self):
+        move, reason = server.sanitize_move({"kind": "walk_to_cell", "x": 3, "y": 3})
+        self.assertIsNone(move)
+        self.assertIn("character_id", reason)
+
+    def test_walk_to_cell_drops_unknown_fields_and_forces_role(self):
+        move, reason = server.sanitize_move(
+            {"kind": "walk_to_cell", "x": 1, "y": 1, "character_id": "c",
+             "role": "dm", "narration": "boom"}
+        )
+        self.assertEqual(reason, "")
+        self.assertEqual(move["role"], "player")
+        self.assertNotIn("narration", move)
+
+
 class DerivedPositionAuthorityTests(unittest.TestCase):
     """#432: zone-derived token x/y must be flagged positionAuthority='derived'."""
 

--- a/viewer/tests/test_scene_at_rest_stage.py
+++ b/viewer/tests/test_scene_at_rest_stage.py
@@ -237,5 +237,35 @@ class SceneAtRestProjectionTests(unittest.TestCase):
         self.assertIn("comp_shade", ids)
 
 
+class SceneAtRestStageCellTests(unittest.TestCase):
+    """W2 (#1350): the rest projection RENDERS a character at its engine-authoritative
+    ``Character.stage_cell`` (walk_to's sole-writer field) when set, so a click-to-move walk lands
+    the token at the confirmed destination on the next surface reload — instead of snapping it back
+    to the authored spawn cell. ADDITIVE: stage_cell is None until a first walk, so an un-walked
+    character projects at its spawn cell exactly as before (byte-identical)."""
+
+    def test_walked_pc_renders_at_stage_cell_not_spawn(self):
+        snap = _rest_snapshot()
+        # pc_hero has WALKED: its engine stage_cell is (2, 3), NOT the party spawn cell (6, 8).
+        snap["characters"]["pc_hero"]["stage_cell"] = [2, 3]
+        by_id = {t["id"]: t for t in _surface(snap)["stage"]["tokens"]}
+        self.assertIn("pc_hero", by_id)
+        self.assertEqual((by_id["pc_hero"]["x"], by_id["pc_hero"]["y"]), (2, 3))
+
+    def test_unwalked_pc_still_renders_at_spawn_cell(self):
+        """No stage_cell == today: the character falls straight through to the spawn projection."""
+        snap = _rest_snapshot()  # pc_hero carries no stage_cell
+        by_id = {t["id"]: t for t in _surface(snap)["stage"]["tokens"]}
+        self.assertEqual((by_id["pc_hero"]["x"], by_id["pc_hero"]["y"]), (6, 8))
+
+    def test_stage_cell_token_stays_a_derived_hint(self):
+        """The engine remains the sole writer: a stage_cell-placed token is still a derived render
+        hint, never authoritative — same discipline as the spawn projection."""
+        snap = _rest_snapshot()
+        snap["characters"]["pc_hero"]["stage_cell"] = [4, 4]
+        by_id = {t["id"]: t for t in _surface(snap)["stage"]["tokens"]}
+        self.assertEqual(by_id["pc_hero"]["positionAuthority"], "derived")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The **UI half of epic #1319** (issue #1350). Engine `walk_to` shipped in #1341; renderer glide machinery in #1345. This adds rest-mode click-to-move + door-cell walk-through in the browser viewer, plus the lane EVAL deferred from #1341 by architect ruling.

## What shipped

**`viewer/server.py`**
- `sanitize_move`: validate the `walk_to_cell` intent (needs int `x`/`y` + `character_id`); `character_id` added to the field allowlist (widen-only; anti-injection allowlist intact).
- `_resolve_walk_to`: engine-resolve `walk_to_cell` **in-process** (mirrors `_resolve_cross_door`) — calls `engine.walk_to` under the engine lock (sole writer), returns the **engine-confirmed** path; gated on combat resolved; routed in `do_POST` like `cross_door`.
- `_scene_stage`: render a rest token at its engine `Character.stage_cell` when set (additive fallback to the authored spawn cell when `None`), so a walk lands the token at the confirmed destination on the next surface reload.

**`viewer/openworlds/screen-combat.jsx`**
- `RestGridBoard`: the out-of-combat twin of `CombatGridBoard`. A walkable-cell click walks the **selected** party member (`POST /move walk_to_cell`); a **door** cell walks-to-the-doorway then `cross_door` into the linked room; a token click selects who walks. Reuses the exact combat walkability derivation + cell-click idiom (no new deps/frameworks). Pure consumer — no client path prediction.

**`qa/walk_click_replay.py`** — the #1350 lane EVAL
- A light HTTP replay (no DM / no LLM / no Playwright) that seeds a 2-room rest campaign, boots the **real** viewer, and drives `POST /move` + `/combat-surface` + `/events` reads exactly as the browser does.

## Replay eval evidence (all 15 asserts green)
- **A1 path legality** — a legal walk returns `ok:True` with a contiguous engine-routed path (start→target, chebyshev-1 steps); an into-a-wall walk and an off-grid walk are both **rejected** (`ok:False`) — the viewer never invents a route.
- **A2 rest_walk beat** — the walk lands a `rest_walk` beat in `/events`, projected as envelope verb `walk` / `anim_hint: "glide"` carrying the engine cells under `result.path`.
- **A3 rendered cell == engine stage_cell** — after the walk the `/combat-surface` rest token renders AT the engine's `stage_cell`.
- **A4 door walk-through** — a door-cell click (walk onto the doorway → `cross_door`) ends in the **linked** room, which renders its own scene grid.

## Tests
- `qa/walk_click_replay.py`: **15/15 asserts green** against a locally-run viewer.
- New unit tests: `test_move_intents.py` (`RestWalkMoveKindTests`, 5) + `test_scene_at_rest_stage.py` (`SceneAtRestStageCellTests`, 3).
- Focused viewer pytest: **125 passed** (move-intents + scene-at-rest + combat-grid + openworlds-static) + **14 passed** (player-turn-bridge + combat-surface + events-envelope).
- Engine `test_walk_to.py`: **17 passed** (unchanged — engine not touched).
- `qa/fast_gate.sh`: **257 passed**.

## Invariants held
- **Engine sole writer** — the viewer only posts intents; `walk_to`/`cross_door` mutate under the engine lock.
- **Renderer pure consumer / VISION** — the browser glides only engine-confirmed paths; it renders the engine `stage_cell` after reload (no client prediction).
- **Text tier byte-identical** — the `_scene_stage` change is additive (`stage_cell` preferred only when set, else the identical spawn projection); byte-identity tests still green.
- **Combat mode untouched** — the rest board only renders when `!encounter.active`; `walk_to` refuses while combat is active.
- **No new persisted state** beyond `stage_cell` (#1341's).

Closes #1350.