### PR TITLE
[W3-UI] NPC click-to-talk + approach + dialogue-at-actor (#1363)

### DIFF
--- a/qa/walk_click_replay.py
+++ b/qa/walk_click_replay.py
@@ -23,6 +23,10 @@ ASSERTS (the acceptance bundle for #1350):
       surface reload glides the token to the confirmed destination (no client prediction).
   A4  DOOR WALK-THROUGH — clicking a door cell (walk_to_cell onto the doorway, then cross_door)
       ends in the LINKED room: /combat-surface reports the new current location + its own grid.
+  A5  CLICK-TO-TALK (W3 #1363) — a present NPC renders as a rest token tagged rest_role "npc";
+      posting `parley_approach` walks the lead PC ADJACENT (engine generate_parley_options
+      approach=True → walk_to), lands a rest_walk glide beat, and the Dialogue screen's
+      /parley-surface?npc=<id> opens the parley AT the actor with the NPC's stage_cell echoed.
 
 Engine = SOLE WRITER: this script only SEEDS (via server.* under the engine lock) and then drives
 the viewer over HTTP; it never writes campaign state directly during the replay.
@@ -109,11 +113,22 @@ def seed(state_dir: str) -> dict:
         campaign_id=CID, name="Aldric", kind="player", race="human", class_name="fighter", level=3,
         apply_srd_defaults=True, add_to_party=True,
     )
-    # place the hero on a known start cell (no combat — a pure rest scene).
+    # W3 (#1363): a present NON-party NPC staged in room A — the click-to-TALK interlocutor. Anchored
+    # at the current location so _scene_stage projects it as a rest token (rest_role "npc").
+    npc = server.create_character(
+        campaign_id=CID, name="Innkeeper Bram", kind="npc", max_hp=12,
+    )
+    server.set_attitude(CID, npc["id"], attitude="indifferent", value=0)
+    # place the hero + NPC on known start cells (no combat — a pure rest scene). The NPC sits at
+    # (6,1) across the room; the hero at (1,4). approach-to-talk must walk the hero adjacent. (6,1)
+    # is clear of A1's walk target (6,4) so the two beats don't collide.
     c = server._require(CID)
     c.characters[hero["id"]].stage_cell = (1, 4)
+    c.characters[npc["id"]].stage_cell = (6, 1)
+    c.characters[npc["id"]].location_id = room_a["id"]
+    c.characters[npc["id"]].met = True
     server.save_campaign(c)
-    return {"room_a": room_a["id"], "room_b": room_b["id"], "hero_id": hero["id"]}
+    return {"room_a": room_a["id"], "room_b": room_b["id"], "hero_id": hero["id"], "npc_id": npc["id"]}
 
 
 # ── HTTP helpers against the REAL viewer ───────────────────────────────────────────────────────
@@ -159,6 +174,17 @@ def _rest_token(surface: dict, cid: str) -> dict | None:
         if t.get("id") == cid:
             return t
     return None
+
+
+def _parley_surface(base: str, npc_id: str) -> dict:
+    """The read-model the Dialogue screen fetches after a click-to-talk approach: /parley-surface
+    bound to the clicked NPC (the ?npc=<id> the JSX appends). Carries the actor's sheet-correct
+    skill slots + the npc block with the engine's stage_cell echo (dialogue-at-actor metadata)."""
+    return _get(base, f"/parley-surface?campaign={CID}&npc={npc_id}")
+
+
+def _chebyshev(a: tuple[int, int], b: tuple[int, int]) -> int:
+    return max(abs(a[0] - b[0]), abs(a[1] - b[1]))
 
 
 # ── the assertions ─────────────────────────────────────────────────────────────────────────────
@@ -226,6 +252,50 @@ def run(base: str, ids: dict) -> None:
     _check(tok1 is not None and (tok1["x"], tok1["y"]) == target,
            "A3 rendered rest token == engine stage_cell after the walk",
            detail=f"got {tok1 and (tok1.get('x'), tok1.get('y'))}, want {target}")
+
+    # A5 (W3 #1363): CLICK-TO-TALK — clicking a present NPC on the rest board APPROACHES it. Posting
+    # a `parley_approach` intent walks the lead PC adjacent to the NPC (the engine's
+    # generate_parley_options(approach=True) reuses walk_to), then the Dialogue screen fetches
+    # /parley-surface?npc=<id> — which opens the parley AT the actor with the NPC's stage metadata.
+    npc = ids["npc_id"]
+    npc_cell = (6, 1)
+    # the NPC renders as a rest token tagged rest_role "npc" (a click-to-talk target, not a mover).
+    npc_tok = _rest_token(surf1, npc)
+    _check(npc_tok is not None and npc_tok.get("rest_role") == "npc"
+           and (npc_tok["x"], npc_tok["y"]) == npc_cell,
+           "A5 the present NPC renders as a rest token (rest_role 'npc') at its stage cell",
+           detail=f"got {npc_tok}")
+    ev_before_talk = len(_get(base, f"/events?campaign={CID}&since=0").get("entries", []))
+    approached = _post_move(base, {"kind": "parley_approach", "target_id": npc, "character_id": hero})
+    _check(approached.get("ok") is True and approached.get("walked") is True,
+           "A5 parley_approach is accepted and the engine walked the PC adjacent",
+           detail=json.dumps(approached))
+    dest = tuple(approached.get("to") or ())
+    _check(len(dest) == 2 and _chebyshev(dest, npc_cell) == 1,
+           "A5 the PC ended up ADJACENT (Chebyshev 1) to the NPC", detail=f"to={dest} npc={npc_cell}")
+    # the walk landed a rest_walk 'walk'/'glide' beat, exactly like a click-to-move (engine path).
+    evs2 = _get(base, f"/events?campaign={CID}&since=0").get("entries", [])
+    _check(len(evs2) > ev_before_talk, "A5 the approach landed a new engine beat",
+           detail=f"{ev_before_talk}→{len(evs2)}")
+    talk_walk = [e for e in evs2 if e.get("verb") == "walk"]
+    _check(bool(talk_walk) and (talk_walk[-1].get("result") or {}).get("path"),
+           "A5 the approach beat is a rest_walk carrying the engine path (glide)")
+    # engine sole-writer: the mover's rendered rest token now sits at the confirmed adjacent cell.
+    surf_talk = _get(base, f"/combat-surface?campaign={CID}")
+    hero_tok = _rest_token(surf_talk, hero)
+    _check(hero_tok is not None and (hero_tok["x"], hero_tok["y"]) == dest,
+           "A5 the mover's rest token == engine stage_cell after the approach",
+           detail=f"got {hero_tok and (hero_tok.get('x'), hero_tok.get('y'))}, want {dest}")
+    # the Dialogue screen's read-model opens AT the actor: the parley binds THIS NPC and echoes its
+    # stage cell (dialogue-at-actor), and the actor's skill slots are present (a real parley menu).
+    parley = _parley_surface(base, npc)
+    _check((parley.get("npc") or {}).get("id") == npc,
+           "A5 the parley surface binds the clicked NPC", detail=json.dumps(parley.get("npc")))
+    _check((parley.get("npc") or {}).get("stage_cell") == list(npc_cell),
+           "A5 the parley echoes the NPC stage_cell (dialogue-at-actor)",
+           detail=str((parley.get("npc") or {}).get("stage_cell")))
+    _check(bool(parley.get("skills")),
+           "A5 the parley opens with the actor's sheet-correct skill options")
 
     # A4: DOOR WALK-THROUGH — walk onto the doorway, then cross into the linked room.
     door_walk = _post_move(base, {"kind": "walk_to_cell", "character_id": hero, "x": DOOR[0], "y": DOOR[1]})

--- a/viewer/openworlds/screen-combat.jsx
+++ b/viewer/openworlds/screen-combat.jsx
@@ -27,7 +27,7 @@ function tokenScope(t) {
   return t.id ? "portrait-" + t.id : "";
 }
 
-function ScreenCombat({ onNavigate, state }) {
+function ScreenCombat({ onNavigate, state, setState }) {
   const campaigns = Array.isArray(state?.campaigns) ? state.campaigns : [];
   const activeCampaign =
     campaigns.find((c) => c.id === state?.activeCampaign) ||
@@ -363,6 +363,42 @@ function ScreenCombat({ onNavigate, state }) {
     await crossDoor(door);
   };
 
+  // W3 (#1320) REST-MODE click-to-TALK: clicking a present NPC on the rest board APPROACHES it —
+  // POST a `parley_approach` intent, which the engine resolves in-process (generate_parley_options
+  // approach=True walks the lead PC adjacent via walk_to, then opens the parley AT the actor). The
+  // viewer is a pure consumer: it posts the intent + re-loads the surface (so the walked tokens
+  // glide to the engine-confirmed cells), then stashes the NPC id and navigates to the Dialogue
+  // screen — which fetches /parley-surface?npc=<id> and stages the speaker at its cell. Same /move
+  // lane + busyRef double-submit guard as the rest walk. Only ever called outside combat.
+  const postParleyApproach = async (npcId) => {
+    if (!npcId) return;
+    if (busyRef.current) return; // synchronous double-click guard
+    busyRef.current = true;
+    setBusyAction("approach");
+    try {
+      const response = await fetch("/move", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "parley_approach", target_id: npcId, character_id: selected?.id || "", campaign: surface?.campaign_id || campaignId }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || payload.ok === false) throw new Error(payload.reason || `approach ${response.status}`);
+      await loadSurface();
+      // Stash the interlocutor so the Dialogue screen binds /parley-surface to THIS NPC (header +
+      // stage_cell/facing). A plain state slot — no persisted state; the engine already wrote the walk.
+      if (typeof setState === "function") setState((s) => ({ ...s, activeParleyNpc: npcId }));
+      onNavigate("dialogue");
+      return payload;
+    } catch (error) {
+      toast({ kind: "danger", title: "Could not approach", body: error?.message || "The viewer could not reach /move." });
+      return { ok: false };
+    } finally {
+      busyRef.current = false;
+      setBusyAction("");
+    }
+  };
+  const onApproachNpc = (npcId) => postParleyApproach(npcId);
+
   const actionTile = (id, fallbackIcon, fallbackLabel) => {
     const action = actionById(id);
     // #598: the Move tile stays visually "active" while armed (pickingZone), even though no
@@ -428,6 +464,7 @@ function ScreenCombat({ onNavigate, state }) {
               onSelect={setSelectedToken}
               onWalk={onRestWalk}
               onDoorWalk={onRestDoorWalk}
+              onApproachNpc={onApproachNpc}
               busy={Boolean(busyAction)}
               sceneScope={sceneScope}
             />
@@ -797,7 +834,7 @@ function GridCellToken({ t, selected, isCurrent }) {
    sole writer + router — this board only POSTS an intent and re-renders the surface that comes back
    (no client path prediction; the token glides to the engine-confirmed stage_cell via a CSS
    transition on the next reload). Mirrors CombatGridBoard's walkability derivation exactly. */
-function RestGridBoard({ tokens, grid, doors, selected, onSelect, onWalk, onDoorWalk, busy, sceneScope }) {
+function RestGridBoard({ tokens, grid, doors, selected, onSelect, onWalk, onDoorWalk, onApproachNpc, busy, sceneScope }) {
   const cols = Math.max(1, Number(grid && grid.cols) || 16);
   const rows = Math.max(1, Number(grid && grid.rows) || 10);
   const at = {};
@@ -848,16 +885,25 @@ function RestGridBoard({ tokens, grid, doors, selected, onSelect, onWalk, onDoor
         {cells.map(({ x, y, t }) => {
           const walkable = isWalkable(x, y);
           const door = doorAt[`${x},${y}`];
-          // A token selects; a door cell walks-then-crosses; a walkable empty cell walks. Disabled
-          // while a POST is in flight (busy) so a double-click can't fire two walks/crossings.
+          // W3 (#1320): a present-NPC token (rest_role "npc") is a click-to-TALK target — clicking
+          // it APPROACHES (the engine walks the lead PC adjacent, then opens the parley), NOT a
+          // select. A party token (rest_role "party", or an un-marked pre-W3 token) still selects
+          // who walks next. Both are team "ally", so the engine's rest_role marker is what tells
+          // them apart.
+          const isNpc = Boolean(t) && t.rest_role === "npc";
+          // A party token selects; an NPC token approaches-to-talk; a door cell walks-then-crosses;
+          // a walkable empty cell walks. Disabled while a POST is in flight (busy) so a double-click
+          // can't fire two approaches/walks/crossings.
           const onActivate = t
-            ? () => onSelect(t.id)
+            ? (isNpc ? () => { if (!busy) onApproachNpc(t.id); } : () => onSelect(t.id))
             : door
               ? () => { if (!busy) onDoorWalk(door); }
               : () => { if (!busy && walkable) onWalk(x, y); };
           const actionable = Boolean(t) || (!busy && (door ? true : walkable));
           const title = t
-            ? `${t.name}${selected === t.id ? " (selected)" : " — select to walk"}`
+            ? (isNpc
+                ? `Talk to ${t.name} →`
+                : `${t.name}${selected === t.id ? " (selected)" : " — select to walk"}`)
             : door
               ? `Cross to ${door.toName || "the next room"} →`
               : (walkable ? `walk → (${x}, ${y})` : "blocked");

--- a/viewer/openworlds/screen-dialogue.jsx
+++ b/viewer/openworlds/screen-dialogue.jsx
@@ -30,6 +30,10 @@ function ScreenDialogue({ onNavigate, state, setState }) {
         state,
       )
     : "";
+  // W3 (#1320): the interlocutor the player clicked-to-talk on the rest board (stashed by
+  // ScreenCombat's approach). Binds /parley-surface to THAT NPC so the header names it and the
+  // speaker is staged at its cell (npc.stage_cell/facing). Absent -> today's freeform/anchor parley.
+  const parleyNpc = state?.activeParleyNpc || "";
   const [surface, setSurface] = React.useState(null);
   const [difficulty, setDifficulty] = React.useState("medium");
   const [history, setHistory] = React.useState([]);
@@ -38,7 +42,8 @@ function ScreenDialogue({ onNavigate, state, setState }) {
 
   const loadSurface = React.useCallback(async (isCancelled = () => false) => {
     const sep = surfaceQuery ? "&" : "?";
-    const url = `/parley-surface${surfaceQuery}${sep}difficulty=${encodeURIComponent(difficulty)}`;
+    const npcParam = parleyNpc ? `&npc=${encodeURIComponent(parleyNpc)}` : "";
+    const url = `/parley-surface${surfaceQuery}${sep}difficulty=${encodeURIComponent(difficulty)}${npcParam}`;
     try {
       const response = await fetch(url, { cache: "no-store" });
       if (!response.ok) throw new Error(`parley surface ${response.status}`);
@@ -50,7 +55,7 @@ function ScreenDialogue({ onNavigate, state, setState }) {
       if (isCancelled()) return;
       setStatus(error?.message || "unavailable");
     }
-  }, [surfaceQuery, difficulty]);
+  }, [surfaceQuery, difficulty, parleyNpc]);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -225,6 +230,27 @@ function ParleyMenu({ surface, slots, difficulty, setDifficulty, history, setHis
                     {npc.attitude_value > 0 ? "+" : ""}{npc.attitude_value}
                   </span>
                 )}
+              </div>
+            )}
+            {/* W3 (#1320): dialogue-AT-the-actor readout. When the parley bound an on-stage NPC
+                (approach-to-talk staged it at its rest cell), echo the engine's stage_cell (+ the
+                party-relative facing) so the conversation reads as spatial — the speaker stands
+                WHERE the player walked up to, not a disembodied portrait. Present only when the
+                engine attached stage metadata (a click-to-talk approach); absent for a freeform
+                parley, so the header is byte-identical to today otherwise. Pure projection. */}
+            {Array.isArray(npc?.stage_cell) && npc.stage_cell.length === 2 && (
+              <div style={{
+                display: "inline-flex", alignItems: "center", gap: 6,
+                padding: "4px 12px",
+                background: "linear-gradient(180deg, var(--w-100), var(--w-300))",
+                boxShadow: "inset 0 0 0 1px var(--w-500)",
+              }}>
+                <span className="eyebrow" style={{ color: "var(--b-300)", letterSpacing: "0.16em", fontSize: 9 }}>
+                  On stage
+                </span>
+                <span style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-600)" }}>
+                  ({npc.stage_cell[0]}, {npc.stage_cell[1]}){npc.facing ? ` · ${npc.facing}` : ""}
+                </span>
               </div>
             )}
           </div>

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -108,6 +108,7 @@ _MOVE_KINDS = {
     "travel", "inspect", "examine", "move_to_zone", "move_to_cell", "end_turn",
     "cross_door",  # M-E: cross an authored doorway to the linked room-unit (engine-resolved)
     "walk_to_cell",  # W2 #1319: rest-mode click-to-walk (engine walk_to; carried by x/y)
+    "parley_approach",  # W3 #1320: rest-mode click-to-talk (engine generate_parley_options approach)
 }
 # Kinds whose payload is carried by `target` alone (no free `text`/`name`) — the graphical
 # intents. Used to relax the "needs text or name" guard below for these click-driven moves.
@@ -192,6 +193,15 @@ def sanitize_move(raw: object) -> tuple[Optional[dict], str]:
             return None, "'walk_to_cell' needs integer 'x' and 'y' grid coordinates"
         if not move.get("character_id"):
             return None, "'walk_to_cell' needs a 'character_id' (who walks)"
+        return move, ""
+    # `parley_approach` (W3 #1320) is the ENGINE-resolved rest-mode click-to-TALK intent: it names
+    # the interlocutor NPC via `target_id` (the tracked NPC the player clicked). The engine's
+    # generate_parley_options(approach=True) walks the lead PC adjacent (via walk_to) then opens the
+    # parley — so the only required field is WHO to talk to. `character_id` (the mover) is optional:
+    # the engine defaults to the lead PC. Neither is text, so validate here before the engine bridge.
+    if kind == "parley_approach":
+        if not move.get("target_id"):
+            return None, "'parley_approach' needs a 'target_id' (the NPC to talk to)"
         return move, ""
     # The graphical intents (travel/inspect/examine/move_to_zone) are carried by `target`;
     # everything else needs a `text` or `name` so the DM has something to act on. An `attack`
@@ -1511,6 +1521,62 @@ def _resolve_walk_to(campaign_id: str, move: dict) -> dict:
         "from": result.get("from"),
         "to": result.get("to"),
         "path": result.get("path") or [],
+    }
+
+
+def _resolve_parley_approach(campaign_id: str, move: dict) -> dict:
+    """Resolve a `parley_approach` intent (W3 #1320 rest-mode click-to-TALK): the player clicked a
+    present NPC on the rest board — WALK the lead PC adjacent to that NPC, THEN open the parley AT
+    the actor. The whole approach is the engine's ``generate_parley_options(approach=True)`` (which
+    internally reuses ``walk_to`` — the SOLE writer of ``stage_cell`` — under the engine lock, then
+    projects the post-walk options), so the viewer stays a pure CONSUMER: it never routes a path or
+    positions a token itself; it just re-fetches ``/parley-surface?npc=<id>`` afterwards, which
+    reads the moved cells the engine wrote. Mirrors _resolve_walk_to's in-process bridge.
+
+    Returns ``{ok, npc_id, walked, to, path}`` — ``walked`` echoes whether the engine actually took
+    a walk beat (False when already adjacent, or when the approach degraded to a freeform parley:
+    no stage cell / no scene grid / combat / unreachable — the engine's own MED-addendum fallback).
+    ``ok`` stays True in every non-error case (the parley always opens, positioned or not); an
+    unknown NPC or a hard engine error is a clean ``{ok:False, reason}``. Gated on combat being
+    RESOLVED — an approach during a fight would only ever degrade to freeform, so reject early with
+    a clear reason rather than silently no-op."""
+    engine = _load_engine_server()
+    if engine is None:
+        return {"ok": False, "reason": "engine unavailable"}
+    try:
+        snap = engine._require(campaign_id)
+    except Exception as exc:  # noqa: BLE001 — surface any engine read error as a clean rejection
+        return {"ok": False, "reason": f"could not read rest state: {exc}"}
+    if snap.combat.active:
+        return {"ok": False, "reason": "combat is active — talk after the fight"}
+    npc_id = str(move["target_id"])
+    if npc_id not in snap.characters:
+        return {"ok": False, "reason": f"unknown NPC {npc_id!r}"}
+    # `character_id` (the mover) is optional — the engine defaults to the lead PC; pass it through
+    # only when the client named one so an actor with no PC still degrades cleanly.
+    actor_id = str(move.get("character_id") or "")
+    try:
+        # approach=True walks the actor adjacent (via walk_to, under the engine lock) then returns
+        # the post-walk parley snapshot. We consume only the approach echo — the browser re-fetches
+        # the full /parley-surface for the dialogue render (single source of truth).
+        result = engine.generate_parley_options(
+            campaign_id, actor_id=actor_id, npc_id=npc_id, approach=True,
+        )
+    except (KeyError, ValueError, TypeError) as exc:
+        return {"ok": False, "reason": str(exc)}
+    except Exception as exc:  # noqa: BLE001 — surface any engine error as a clean rejection
+        return {"ok": False, "reason": f"approach failed: {exc}"}
+    # `approach` is present only when the engine actually walked (or found the party already
+    # adjacent); absent means it degraded to a freeform parley — the dialogue still opens, just not
+    # repositioned. Echo the walk result so the client can log/animate the glide.
+    approach = result.get("approach") if isinstance(result, dict) else None
+    walked = bool(approach.get("walked")) if isinstance(approach, dict) else False
+    return {
+        "ok": True,
+        "npc_id": npc_id,
+        "walked": walked,
+        "to": approach.get("to") if isinstance(approach, dict) else None,
+        "path": (approach.get("path") if isinstance(approach, dict) else None) or [],
     }
 
 
@@ -3555,7 +3621,7 @@ def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
 
     tokens: list[dict] = []
 
-    def _emit(cid: str, cells: list[tuple[int, int]], slot: int, fallback_slot: int) -> None:
+    def _emit(cid: str, cells: list[tuple[int, int]], slot: int, fallback_slot: int, rest_role: str) -> None:
         ch = chars.get(cid)
         ch = ch if isinstance(ch, dict) else {}
         name = _text(ch.get("name"), cid)
@@ -3590,14 +3656,21 @@ def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
             # state — same discipline as the combat tokens (#432). The engine stays sole writer.
             "positionAuthority": "derived",
             "pose": "idle",
+            # W3 (#1320): which lane a rest token belongs to — "party" (a walkable mover the
+            # click-to-walk board sends to walk_to) vs "npc" (a present, non-party interlocutor the
+            # board opens a click-to-TALK approach on). Both are team "ally" (npc/companion kind ->
+            # ally), so `team` alone can't tell a talk target from a walkable party member; this
+            # additive marker does. ADDITIVE: a consumer that ignores it reads the token exactly as
+            # before.
+            "rest_role": rest_role,
         })
 
     fb = 0
     for i, cid in enumerate(party_ids):
-        _emit(cid, party_cells, i, fb)
+        _emit(cid, party_cells, i, fb, "party")
         fb += 1
     for j, cid in enumerate(present_npcs):
-        _emit(cid, npc_cells, j, fb)
+        _emit(cid, npc_cells, j, fb, "npc")
         fb += 1
 
     return {"mode": mode, "tokens": tokens}
@@ -9616,6 +9689,13 @@ class _Handler(BaseHTTPRequestHandler):
         # engine-confirmed path so the browser glides only the routed cells.
         if move.get("kind") == "walk_to_cell":
             self._json(_resolve_walk_to(self.campaign_id, move))
+            return
+        # W3 CLICK-TO-TALK LANE (#1320): a `parley_approach` is engine-resolved in-process —
+        # generate_parley_options(approach=True) walks the lead PC adjacent (via walk_to, under the
+        # engine lock) then opens the parley AT the actor. NOT appended for the DM; gated on combat
+        # being resolved (see _resolve_parley_approach). The browser then re-fetches /parley-surface.
+        if move.get("kind") == "parley_approach":
+            self._json(_resolve_parley_approach(self.campaign_id, move))
             return
         is_combat_cell = move.get("kind") in ("move_to_cell", "end_turn") or (
             move.get("kind") == "attack" and "target_id" in move

--- a/viewer/tests/test_move_intents.py
+++ b/viewer/tests/test_move_intents.py
@@ -207,6 +207,40 @@ class RestWalkMoveKindTests(unittest.TestCase):
         self.assertNotIn("narration", move)
 
 
+class ParleyApproachMoveKindTests(unittest.TestCase):
+    """W3 (#1363) — the rest-mode `parley_approach` (click-to-talk) intent the ENGINE resolves
+    in-process (generate_parley_options approach=True). Pure sanitize_move checks: it needs a
+    `target_id` (the NPC to talk to), keeps role forced + unknown fields dropped, and is additive."""
+
+    def test_parley_approach_accepted_with_target_id(self):
+        move, reason = server.sanitize_move(
+            {"kind": "parley_approach", "target_id": "npc_bram", "character_id": "char_hero"}
+        )
+        self.assertEqual(reason, "")
+        self.assertEqual(move["kind"], "parley_approach")
+        self.assertEqual(move["target_id"], "npc_bram")
+        self.assertEqual(move["character_id"], "char_hero")  # optional mover rides through
+        self.assertEqual(move["role"], "player")  # role still forced
+
+    def test_parley_approach_character_id_is_optional(self):
+        move, reason = server.sanitize_move({"kind": "parley_approach", "target_id": "npc_bram"})
+        self.assertEqual(reason, "")
+        self.assertEqual(move["target_id"], "npc_bram")
+
+    def test_parley_approach_without_target_rejected(self):
+        move, reason = server.sanitize_move({"kind": "parley_approach", "character_id": "c"})
+        self.assertIsNone(move)
+        self.assertIn("target_id", reason)
+
+    def test_parley_approach_drops_unknown_fields_and_forces_role(self):
+        move, reason = server.sanitize_move(
+            {"kind": "parley_approach", "target_id": "npc_bram", "role": "dm", "narration": "boom"}
+        )
+        self.assertEqual(reason, "")
+        self.assertEqual(move["role"], "player")
+        self.assertNotIn("narration", move)
+
+
 class DerivedPositionAuthorityTests(unittest.TestCase):
     """#432: zone-derived token x/y must be flagged positionAuthority='derived'."""
 

--- a/viewer/tests/test_scene_at_rest_stage.py
+++ b/viewer/tests/test_scene_at_rest_stage.py
@@ -131,6 +131,11 @@ class SceneAtRestProjectionTests(unittest.TestCase):
         # Rest tokens are idle-posed derived hints, never authoritative.
         self.assertEqual(by_id["npc_keeper"]["pose"], "idle")
         self.assertEqual(by_id["npc_keeper"]["positionAuthority"], "derived")
+        # W3 (#1363): each rest token carries a rest_role so the board tells a walkable party mover
+        # from a click-to-talk NPC target (both are team "ally"). The party PC is "party"; a
+        # present non-party NPC is "npc".
+        self.assertEqual(by_id["pc_hero"]["rest_role"], "party")
+        self.assertEqual(by_id["npc_keeper"]["rest_role"], "npc")
 
     def test_npc_at_another_location_is_not_placed(self):
         stage = _surface(_rest_snapshot())["stage"]


### PR DESCRIPTION
Closes #1363. The UI half of W3 (epic #1320) — rest-mode NPC click-to-talk in the browser viewer, mirroring the merged W2-UI glide idiom (#1358) and consuming the merged W3-engine approach machinery (#1344: \`generate_parley_options(approach=True)\` + parley stage metadata).

## What
1. **Present NPCs as clickable talk targets** — \`_scene_stage\` already emitted NPC rest tokens (#1358); this adds an additive \`rest_role\` marker (\`"party"\`|\`"npc"\`) so the board tells a walkable party mover from a click-to-TALK NPC target (both are team \`"ally"\`). Pure projection.
2. **Approach-to-talk sink** — \`viewer/server.py\` gains \`_resolve_parley_approach\` + a \`parley_approach\` intent (kind allowlist + sanitize validation + \`do_POST\` dispatch). In-process bridge mirroring \`_resolve_walk_to\`: it calls \`engine.generate_parley_options(approach=True)\` under the engine lock (which walks the lead PC adjacent via \`walk_to\` — the sole writer of \`stage_cell\` — then opens the parley). Pure consumer, no client path prediction, rest-only (gated on \`!combat.active\`).
3. **JSX wiring** — \`RestGridBoard\` NPC-token click fires \`onApproachNpc\`; \`ScreenCombat\` posts the intent, reloads the surface (the token glides to the engine-confirmed cell), stashes the NPC id in app state, and navigates to Dialogue. No new deps.
4. **Dialogue at the actor** — \`ScreenDialogue\` binds \`/parley-surface?npc=<id>\` to the clicked NPC and adds an additive on-stage cell/facing readout. The merged #1344 parley surface already echoes \`npc.stage_cell\`/\`facing\`, so the actor-cell metadata was in place.

## Invariants
- Viewer = pure consumer (engine-confirmed only; the approach writes \`stage_cell\` only via the engine's \`walk_to\`).
- No new persisted state; combat mode untouched (rest-only); no new deps.
- Text-tier byte-identity: an approach posts the identical \`generate_parley_options\` the DM/text tier sees.

## Eval / tests
- **qa/walk_click_replay.py A5** (extended, the light HTTP replay — no DM/LLM): click NPC → \`parley_approach\` accepted → engine walk beat lands (\`rest_walk\` glide) → PC ends **adjacent** (Chebyshev 1) → mover's rest token == engine \`stage_cell\` → \`/parley-surface?npc=<id>\` opens **at the actor** with the NPC's \`stage_cell\` echoed + skill options. **ALL ASSERTS GREEN** (A1-A5).
- viewer/tests/test_move_intents.py — \`parley_approach\` sanitize (target_id required, optional mover, role forced, unknown fields dropped). **31 passed**.
- viewer/tests/test_scene_at_rest_stage.py — \`rest_role\` marker on party vs. NPC tokens. **green**.
- \`qa/fast_gate.sh\` — **257 passed**. Engine \`test_parley_approach.py\` (merged, unchanged) — 12 passed.

Do NOT merge — orchestrator review.