### PR TITLE
[fix] #1347 death-verb envelope + #1355 panel↔promote row-key

### DIFF
--- a/qa/artifact_calibration_panel.py
+++ b/qa/artifact_calibration_panel.py
@@ -118,16 +118,18 @@ def run_panel(
     results: list[dict] = []
     for artifact, is_control, anchor in pool:
         overalls: list[float] = []
+        dims_per_scorer: list[dict] = []
+        prov = artifact.get("provenance") or {}
         for scorer_i in range(panel_size):
             if dryrun:
                 card = _dryrun_card(artifact, float(anchor or identity.get("anchor", 4.0)))
             else:
                 card = artifact_score.score_artifact(artifact, budget=budget)
             overalls.append(float(card["overall"]))
+            dims_per_scorer.append(card.get("scores") or {})
             if write_db:
                 # One row per scorer; the panel_id + a scorer suffix keep artifact_id unique.
                 aid = f"{artifact['artifact_id']}#{panel_id}#s{scorer_i}"
-                prov = artifact.get("provenance") or {}
                 scores_db.add_artifact(
                     aid, db_path=db_path, **{"class": cls}, run_id=prov.get("run_id"),
                     world=artifact.get("world"), sha=prov.get("sha"),
@@ -137,6 +139,29 @@ def run_panel(
                     source_path=artifact["artifact_id"],
                 )
         med = statistics.median(overalls)
+        if write_db:
+            # #1355: ALSO write the panel's own aggregate under the BARE artifact_id — the
+            # median overall (matching this function's own control-band aggregation) plus the
+            # per-dimension median across the N `#s{n}` scorer rows. Without this row,
+            # tools/library/promote.py's bare-artifact_id lookup (_artifacts_by_id) never finds
+            # a panel-scored artifact and a promotion batch needs a manual bridge to connect
+            # them (found live in PR #1354). scores.db stays single-owner: the panel writer is
+            # the one place that both produces the per-scorer rows AND knows how to aggregate
+            # them, so this is additive bookkeeping on the same write path, not a second writer.
+            all_dim_keys = {k for d in dims_per_scorer for k in d}
+            median_dims = {
+                k: round(statistics.median([d[k] for d in dims_per_scorer if k in d]), 2)
+                for k in all_dim_keys
+            }
+            scores_db.add_artifact(
+                artifact["artifact_id"], db_path=db_path, **{"class": cls},
+                run_id=prov.get("run_id"), world=artifact.get("world"), sha=prov.get("sha"),
+                dims_json=median_dims, overall=round(med, 2),
+                panel_id=panel_id, scorer_model="sonnet",
+                is_control=int(is_control), control_anchor=anchor,
+                source_path=artifact["artifact_id"],
+                notes=f"panel aggregate: median of {panel_size} scorer rows (#1355)",
+            )
         results.append({
             "artifact_id": artifact["artifact_id"], "is_control": is_control,
             "anchor": anchor, "median_overall": round(med, 2),

--- a/qa/test_artifact_evals.py
+++ b/qa/test_artifact_evals.py
@@ -454,11 +454,16 @@ def test_calibration_panel_dryrun_is_valid_and_writes_db(tmp_path, monkeypatch):
     assert report["n_controls"] >= 2
     assert report["controls_in_band"] is True
     assert report["panel_valid"] is True
-    # 5 scorers per control → rows written
+    # 5 per-scorer rows + 1 bare-artifact_id aggregate row per control (#1355).
     rows = scores_db.fetch_artifacts(db)
-    assert len(rows) == report["n_controls"] * 5
+    assert len(rows) == report["n_controls"] * (5 + 1)
     assert all(r["is_control"] == 1 for r in rows)
     assert all(r["scorer_model"] == "sonnet" for r in rows)
+    # The aggregate row is addressable by the BARE artifact_id (no #panel_id#s{n} suffix) — this is
+    # exactly what tools/library/promote.py's bare-id lookup needs with no manual bridge.
+    control_aids = {cm["artifact_id"] for cm in report["control_medians"]}
+    row_ids = {r["artifact_id"] for r in rows}
+    assert control_aids <= row_ids, "every control's bare artifact_id must have a row in scores.db"
 
 
 def test_calibration_panel_flags_out_of_band_control(tmp_path, monkeypatch):

--- a/qa/test_promote_pipeline.py
+++ b/qa/test_promote_pipeline.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(_REPO_ROOT / "tools" / "library"))
 import scores_db  # noqa: E402
 import promote  # noqa: E402  (tools/library/promote.py)
 import library_lint  # noqa: E402
+import artifact_calibration_panel as panel  # noqa: E402  (#1355)
 
 ROOM_RECIPES = _REPO_ROOT / "extensions" / "renderers" / "shared" / "room_recipes.json"
 REGISTRY = _REPO_ROOT / "data" / "asset-registry" / "registry.json"
@@ -326,3 +327,82 @@ def test_nominations_malformed_line_fails_loud(env):
     noms.write_text('{"artifact_id": "ok"}\nnot json\n', encoding="utf-8")
     with pytest.raises(ValueError):
         promote.read_nominations(noms)
+
+
+# ── #1355: panel↔promote row-key connection (NO manual bridge) ───────────────────────────────────
+def test_promotion_batch_finds_panel_scored_artifact_by_bare_id_no_manual_bridge(env, monkeypatch):
+    """HV1's run_panel writes per-scorer rows keyed `{artifact_id}#{panel_id}#s{n}` (bookkeeping for
+    N blind scorers); promote.py's nomination lookup exact-matches the bare artifact_id. Before the
+    fix, the two never connected — the first live promotion batch (PR #1354) needed a manual bridge
+    (hand-inserted bare-id rows) to get panel-scored artifacts through the gate at all. This proves a
+    fresh panel run's aggregate row is found by promote_batch with ZERO manual bridging: no hand-written
+    bare-id row, no monkeypatched lookup — just run_panel then promote_batch."""
+    monkeypatch.setenv("WORLDOS_ARTIFACT_PANEL_DRYRUN", "1")
+    db, lib, noms = env["db"], env["lib"], env["noms"]
+
+    report = panel.run_panel("quest", controls_only=True, panel_size=5, db_path=db)
+    assert report["panel_valid"] is True  # the dryrun stub scores every control at its anchor
+
+    # Promote one of the just-scored controls' underlying artifact_ids — nothing here writes a
+    # bare-id row by hand; it must already exist from run_panel itself.
+    control_aid = report["control_medians"][0]["artifact_id"]
+    rows_by_bare_id = {r["artifact_id"] for r in scores_db.fetch_artifacts(db)}
+    assert control_aid in rows_by_bare_id, (
+        "run_panel must write a bare-artifact_id aggregate row, not just the "
+        "{artifact_id}#{panel_id}#s{n} per-scorer rows"
+    )
+
+    # A control itself is never promotable (evaluate_gate rejects is_control rows) — nominate a
+    # plain candidate instead, scored through the SAME run_panel path, to prove the full batch path.
+    cand_dir = _write_candidate_dir(env["db"].parent, "quest", "quest:bg:panel-live", overall=4.4)
+    cand_report = panel.run_panel("quest", candidates_dir=str(cand_dir), controls_only=False,
+                                  panel_size=3, db_path=db)
+    assert cand_report["panel_valid"] is True
+    cand_aid = next(r["artifact_id"] for r in cand_report["results"] if not r["is_control"])
+    assert cand_aid == "quest:bg:panel-live"
+
+    _write_noms(noms, [{"artifact_id": cand_aid}])
+    rep = promote.promote_batch(library_dir=lib, nominations_path=noms, db_path=db)
+    assert rep["promoted"] == 1 and rep["rejected"] == 0
+    entry = json.loads((lib / "quests" / next((lib / "quests").glob("*.json")).name).read_text())
+    assert entry["artifact_id"] == cand_aid
+
+
+def test_panel_aggregate_row_dims_are_median_of_scorer_rows(env, monkeypatch):
+    """The aggregate bare-id row's dims_json/overall must be the MEDIAN across the N `#s{n}` scorer
+    rows — matching run_panel's own control-band aggregation — not e.g. the last scorer's card."""
+    monkeypatch.setenv("WORLDOS_ARTIFACT_PANEL_DRYRUN", "1")
+    db = env["db"]
+    report = panel.run_panel("quest", controls_only=True, panel_size=5, db_path=db)
+    aid = report["control_medians"][0]["artifact_id"]
+    expected_overall = report["control_medians"][0]["median"]
+
+    rows = scores_db.fetch_artifacts(db)
+    aggregate = next(r for r in rows if r["artifact_id"] == aid)
+    scorer_rows = [r for r in rows if r["artifact_id"].startswith(f"{aid}#{report['panel_id']}#s")]
+    assert len(scorer_rows) == 5
+    assert aggregate["overall"] == expected_overall
+    assert aggregate["panel_id"] == report["panel_id"]
+    assert aggregate["is_control"] == 1
+    # The dryrun stub scores every dim at the anchor for every scorer, so the median dims equal
+    # the per-scorer dims exactly — a real (non-dryrun) panel would show genuine per-scorer variance.
+    scorer_dims = json.loads(scorer_rows[0]["dims_json"])
+    aggregate_dims = json.loads(aggregate["dims_json"])
+    assert aggregate_dims.keys() == scorer_dims.keys()
+
+
+def _write_candidate_dir(tmp_root: Path, cls: str, artifact_id: str, *, overall: float) -> Path:
+    """A minimal candidates dir run_panel._candidates_for_class can load: one artifact JSON in the
+    canonical schema shape (matches a committed control's payload shape closely enough for
+    artifact_score.load_artifact's strict envelope guard, since DRYRUN never calls the live scorer that
+    would otherwise read the payload content)."""
+    import artifact_score
+    control_files = sorted((Path(__file__).resolve().parent / "artifact_controls").glob(f"control__{cls}__*.json"))
+    template = artifact_score.load_artifact(control_files[0])
+    payload = json.loads(control_files[0].read_text(encoding="utf-8"))
+    payload["artifact_id"] = artifact_id
+    payload.setdefault("provenance", {})["run_id"] = "run_test_panel_live"
+    cand_dir = tmp_root / "cand"
+    cand_dir.mkdir(exist_ok=True)
+    (cand_dir / "candidate.json").write_text(json.dumps(payload), encoding="utf-8")
+    return cand_dir

--- a/qa/test_promote_pipeline.py
+++ b/qa/test_promote_pipeline.py
@@ -391,6 +391,38 @@ def test_panel_aggregate_row_dims_are_median_of_scorer_rows(env, monkeypatch):
     assert aggregate_dims.keys() == scorer_dims.keys()
 
 
+def test_panel_aggregate_row_dims_are_true_median_when_scorers_differ(env, monkeypatch):
+    """Unlike the dryrun-identical-anchor case above (where every scorer returns the same card, so
+    keys()-equality is all that's checkable), this monkeypatches the dryrun card to vary per scorer
+    so the aggregate row's per-dim MEDIAN is actually exercised against real variance — pinning that
+    a 3-scorer [3.0, 4.0, 5.0] panel yields 4.0 (the median), not 5.0 (the last scorer's card) or any
+    other single card's value."""
+    monkeypatch.setenv("WORLDOS_ARTIFACT_PANEL_DRYRUN", "1")
+    db = env["db"]
+
+    original_card = panel._dryrun_card
+    calls = {"i": 0}
+
+    def _varying_card(artifact, anchor):
+        card = original_card(artifact, anchor)
+        value = (3.0, 4.0, 5.0)[calls["i"] % 3]
+        calls["i"] += 1
+        card["scores"] = {k: value for k in card["scores"]}
+        card["overall"] = value
+        return card
+
+    monkeypatch.setattr(panel, "_dryrun_card", _varying_card)
+
+    report = panel.run_panel("quest", controls_only=True, panel_size=3, db_path=db)
+    aid = report["control_medians"][0]["artifact_id"]
+
+    rows = scores_db.fetch_artifacts(db)
+    aggregate = next(r for r in rows if r["artifact_id"] == aid)
+    aggregate_dims = json.loads(aggregate["dims_json"])
+    assert aggregate["overall"] == 4.0
+    assert aggregate_dims and all(v == 4.0 for v in aggregate_dims.values()), aggregate_dims
+
+
 def _write_candidate_dir(tmp_root: Path, cls: str, artifact_id: str, *, overall: float) -> Path:
     """A minimal candidates dir run_panel._candidates_for_class can load: one artifact JSON in the
     canonical schema shape (matches a committed control's payload shape closely enough for
@@ -398,7 +430,7 @@ def _write_candidate_dir(tmp_root: Path, cls: str, artifact_id: str, *, overall:
     would otherwise read the payload content)."""
     import artifact_score
     control_files = sorted((Path(__file__).resolve().parent / "artifact_controls").glob(f"control__{cls}__*.json"))
-    template = artifact_score.load_artifact(control_files[0])
+    artifact_score.load_artifact(control_files[0])  # validation guard only; return value unused
     payload = json.loads(control_files[0].read_text(encoding="utf-8"))
     payload["artifact_id"] = artifact_id
     payload.setdefault("provenance", {})["run_id"] = "run_test_panel_live"

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3039,6 +3039,17 @@ def _combat_event_envelope_fields(payload: dict) -> dict | None:
             # A future/unknown engine combat event → a non-animated narrate beat
             # (additive/back-compat: the renderer never crashes on a new event).
             verb = "narrate"
+        elif event == "damage":
+            # #1347: a monster/NPC dies OUTRIGHT at 0 HP (combat.py's _apply_total_to_hp ->
+            # _die) with no death_save event at all — only this `damage` beat carries the
+            # engine's verdict, nested in its own `result` block (`{..., "dead": true}`, the
+            # same combat.status() shape death_save's `state` uses). Without this override the
+            # beat stayed verb="damage" forever and the renderer's death animation (topple+
+            # fade, #1345) never fired on a live kill. Read-only projection of engine truth —
+            # the engine already decided `dead`; we just pick the matching verb.
+            inner_state = payload.get("result") if isinstance(payload.get("result"), dict) else {}
+            if bool(inner_state.get("dead")):
+                verb = "death"
 
     # Build the engine-decided `result` the renderer renders verbatim. We carry the
     # outcome class + the numbers the engine already produced (roll / damage / hp /

--- a/viewer/tests/test_events_replay_envelope.py
+++ b/viewer/tests/test_events_replay_envelope.py
@@ -248,6 +248,45 @@ class HandSeededEnvelopeTests(_ServerCase):
         self.assertEqual(body["entries"][0]["verb"], "narrate")
         self.assertEqual(body["entries"][0]["anim_hint"], "none")
 
+    def test_monster_instant_death_damage_beat_projects_to_death_verb(self):
+        """#1347: a monster/NPC dies OUTRIGHT at 0 HP (combat.py's _apply_total_to_hp ->
+        _die) — there is no death_save event at all, only a `damage` beat whose nested
+        `result` carries the engine's `dead: true`. Before the fix this beat stayed
+        verb="damage" forever and the renderer's death animation (topple+fade, #1345)
+        never fired on a live kill."""
+        cid = "camp_instant_death"
+        rows = [
+            _combat_row("damage",
+                        target={"id": "mon_goblin01", "name": "Goblin"},
+                        amount=7, damage_type="slashing",
+                        result={"current_hp": 0, "dead": True, "dying": False, "stable": False}),
+        ]
+        self._seed_session_log(cid, "sess_instant", rows)
+        _status, body = self._get_json(f"/events-replay?campaign={cid}")
+        beat = body["entries"][0]
+        self.assertEqual(beat["verb"], "death")
+        self.assertEqual(beat["target_fk"], "mon_goblin01")
+        self.assertEqual(beat["anim_hint"], "death_fall")
+        self.assertEqual(beat["result"]["outcome"], "dead")
+        # The damage numbers still ride along on the death beat (never dropped).
+        self.assertEqual(beat["result"]["hp_after"], 0)
+
+    def test_non_lethal_damage_beat_stays_damage_verb(self):
+        """A damage beat that does NOT kill the target must keep verb="damage" (no
+        false-positive death animation on a routine hit)."""
+        cid = "camp_nonlethal"
+        rows = [
+            _combat_row("damage",
+                        target={"id": "mon_goblin02", "name": "Goblin"},
+                        amount=3, damage_type="slashing",
+                        result={"current_hp": 4, "dead": False, "dying": False, "stable": False}),
+        ]
+        self._seed_session_log(cid, "sess_nonlethal", rows)
+        _status, body = self._get_json(f"/events-replay?campaign={cid}")
+        beat = body["entries"][0]
+        self.assertEqual(beat["verb"], "damage")
+        self.assertEqual(beat["anim_hint"], "damage_flinch")
+
 
 def _engine_importable() -> bool:
     """The real-combat test needs the engine package (servers/engine), which pulls in


### PR DESCRIPTION
## Summary

Two small, independent, additive fixes bundled in one PR/worktree per the follow-up plan.

**#1347 — engine death-verb envelope.** `_combat_event_envelope_fields` (`viewer/server.py`) mapped every `"damage"` combat event unconditionally to `verb="damage"`, even when the engine's nested `result` block carries `dead: true`. A monster/NPC that dies outright at 0 HP (`combat.py`'s `_die()` fires straight from `_apply_total_to_hp`, no death-save mechanic) never emits a `death_save` event — the `damage` beat was the ONLY beat carrying the engine's verdict, and it never resolved to `verb="death"`. Result: the renderer's proven death animation (topple+fade, #1345) never fired on a live kill.

Fix: when the mapped verb for a `damage` event is being resolved, check the same nested `result.dead` combat.status() carries (identical shape `death_save`'s `state.dead` already reads) and override to `verb="death"`. Purely additive — no engine change, no consumer change (the renderer already handles the `death` verb). Non-lethal damage beats are unaffected (still `verb="damage"`).

**#1355 — panel↔promote row-key mismatch.** `artifact_calibration_panel.py`'s `run_panel` writes scores.db rows keyed `{artifact_id}#{panel_id}#s{n}` (one per blind scorer); `tools/library/promote.py`'s nomination lookup exact-matches the bare `artifact_id`. The two never connected without a manual bridge — hit live in the first promotion batch (PR #1354).

Fix (upstream, panel-writer side): `run_panel` now ALSO writes one aggregate row under the bare `artifact_id` — median `overall` (matching the panel's own control-band aggregation) and median per-dimension scores across the N `#s{n}` rows. Chose the panel-writes-its-own-aggregate approach over teaching `promote.py` to aggregate, because the panel is the only place that both produces the per-scorer rows and already computes the median (`run_panel`'s own control-band verdict) — keeping `scores.db` writes single-owner. `promote.py` and the `ac_` ruler are untouched.

Confirmed non-regression on `control_valid_for_panel` (promote.py): it requires *every* control row sharing a `panel_id` to land in-band; adding the aggregate row can only make that check strictly *stricter* (a median of in-band values is always itself in-band), never cause a previously-invalid panel to look valid.

## Test plan
- [x] `viewer/tests/test_events_replay_envelope.py` — 2 new tests: `test_monster_instant_death_damage_beat_projects_to_death_verb` (red-first regression for #1347) and `test_non_lethal_damage_beat_stays_damage_verb` (no false-positive death anim). Full file: 6 passed, 1 skipped.
- [x] `qa/test_promote_pipeline.py` — 2 new tests: `test_promotion_batch_finds_panel_scored_artifact_by_bare_id_no_manual_bridge` (red-first regression for #1355, reuses the file's existing `env`/`_write_noms` fixtures, runs the real `run_panel` in DRYRUN mode against committed control fixtures — no live scorer) and `test_panel_aggregate_row_dims_are_median_of_scorer_rows`. Full file: 24 passed.
- [x] `qa/test_artifact_evals.py::test_calibration_panel_dryrun_is_valid_and_writes_db` — updated its row-count assertion (`n_controls * 5` → `n_controls * (5 + 1)`) for the new aggregate row, plus an added assertion that every control's bare artifact_id has a row. Full file: 33 passed, 1 skipped.
- [x] `qa/fast_gate.sh` (Tier 0, deterministic) — PASS, 257 passed.
- [x] Full `viewer/tests/` suite — 845 passed, 8 skipped.
- [x] Full `qa/` suite (excluding one pre-existing, unrelated `ModuleNotFoundError: mcp` collection error in `test_ws3a_progression_invariants.py`, confirmed present on base `main` before any of these changes) — 918 passed, 5 skipped.

## Flags
- No new `chk()` / behavioral-gate registration needed — neither fix touches `qa/assert_behavioral.py`'s gate surface (grepped for both symbols, no hits); these are pytest-level regression tests, not new behavioral-gate checks.
- Pre-existing, unrelated `ModuleNotFoundError: No module named 'mcp'` in this shell blocks collection of a handful of `qa/`/`servers/engine/tests/` modules that import `server.py` directly (confirmed present on `origin/main` before this branch touched anything — an environment gap, not a regression). `qa/fast_gate.sh` runs clean in its own environment and is the canonical gate per repo convention; it passed.
- Did not touch `ac_` ruler / `ARTIFACT_CONFIG_FILES` per the issue's explicit guardrail.