### PR TITLE
[W4-engine] living stage: no-teleport rest↔combat cell continuity (#1321)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -15,6 +15,7 @@ import difflib
 import fcntl
 import functools
 import json
+import logging
 import os
 import random
 import re
@@ -4042,6 +4043,59 @@ def _gate_combat_verb(c: "Campaign", actor: "Character", *, verb: str, consumes:
         )
 
 
+def _seed_combat_cells_from_stage(c: Campaign) -> list[str]:
+    """W4 (#1321) NO-TELEPORT: seed each combatant's grid cell (``Combatant.x/y``) from its
+    ``Character.stage_cell`` so a fight STARTS from where everyone was standing at rest — no
+    actor jumps between the rest board and the tactical board.
+
+    Called by ``start_combat`` only when its ``seed_from_stage`` param is True (default False ⇒
+    this never runs ⇒ today's placement, byte-for-byte). Gates-read-gauges holds: combat READS
+    stage at entry; the write-back to stage_cell happens at ``end_combat``.
+
+    Guards (all additive; any miss ⇒ leave that combatant unplaced, exactly as today):
+      * grid must be enabled AND its extents must MATCH the location's scene_grid
+        (the epic's grid-mismatch ruling — legacy campaigns degrade gracefully, WARN-logged);
+      * only combatants WITH a stage_cell are seeded (foes lacking one stay unplaced ⇒ the
+        renderer/DM places them as today — never fails the combat start over placement);
+      * a stage_cell out of the grid extents, or already claimed by an earlier-seeded
+        combatant, is skipped (never traps two tokens on one cell).
+
+    SOLE-WRITER-safe: the engine writes its own combat state from its own stage data. Returns
+    the ids actually seeded (for surfacing). Caller holds the lock + persists."""
+    if not c.combat.grid_enabled:
+        return []
+    loc = c.locations.get(c.current_location_id) if c.current_location_id else None
+    grid = getattr(loc, "scene_grid", None) if loc is not None else None
+    if grid is None:
+        return []
+    # Grid-mismatch ruling (#1321 addendum, HIGH): seed ONLY when the combat grid extents equal
+    # the scene_grid extents — otherwise the stage cells index a different coordinate space and a
+    # seed WOULD teleport. Degrade to today's spawn behavior (unplaced) + a WARN line.
+    if (c.combat.grid_width, c.combat.grid_height) != (int(grid.grid.cols), int(grid.grid.rows)):
+        logging.getLogger(__name__).warning(
+            "start_combat(seed_from_stage): combat grid %sx%s != scene_grid %sx%s at %r — "
+            "skipping stage seeding (legacy/degraded placement).",
+            c.combat.grid_width, c.combat.grid_height,
+            int(grid.grid.cols), int(grid.grid.rows), c.current_location_id,
+        )
+        return []
+    w, h = c.combat.grid_width, c.combat.grid_height
+    claimed: set[tuple[int, int]] = set()
+    seeded: list[str] = []
+    for cb in c.combat.order:
+        ch = c.characters.get(cb.character_id)
+        sc = getattr(ch, "stage_cell", None) if ch is not None else None
+        if sc is None:
+            continue  # foes / never-walked members stay unplaced (today's behavior)
+        x, y = int(sc[0]), int(sc[1])
+        if not (0 <= x < w and 0 <= y < h) or (x, y) in claimed:
+            continue  # out of extents or already taken — don't teleport/stack
+        cb.x, cb.y = x, y
+        claimed.add((x, y))
+        seeded.append(cb.character_id)
+    return seeded
+
+
 def _derive_grid_from_scene(c: Campaign) -> None:
     """gfx M-B (#1194): if the campaign's CURRENT location carries a SceneGrid, switch the
     just-started fight onto that grid and auto-derive its impassable cells (walls + prop
@@ -4083,12 +4137,9 @@ def start_combat(
     campaign_id: str,
     combatant_ids: StrListArg,
     surpriser_ids: OptStrListArg = None,
+    seed_from_stage: bool = False,
 ) -> dict:
-    """Begin combat: roll initiative (1d20 + initiative_bonus) for each combatant
-    and build the turn order (desc, ties broken by DEX modifier then input order).
-    Pass the character ids of everyone in the fight. For an ambush pass
-    surpriser_ids=[attackers]: the engine rolls Stealth vs passive Perception; the
-    surprised roll initiative with Disadvantage (SRD 5.2). See `surprise` in the return."""
+    """Begin combat: roll initiative (1d20 + initiative_bonus) per combatant; build the turn order (desc, DEX-mod then input tiebreaks). Pass every fighter's id. For an ambush, pass surpriser_ids=[attackers]; the surprised roll Initiative with Disadvantage (in `surprise`). seed_from_stage=True opens combat where each combatant rested."""
     if not combatant_ids:
         raise ValueError("combatant_ids must be non-empty")
     surpriser_ids = [sid for sid in (surpriser_ids or []) if sid in combatant_ids]
@@ -4156,6 +4207,13 @@ def start_combat(
         # absent when the current location has no scene_grid (grid_enabled stays False == today's
         # zone/theater combat, byte-for-byte unchanged).
         _derive_grid_from_scene(c)
+        # W4 (#1321) NO-TELEPORT: when asked, seed combatant grid cells from each character's
+        # rest position (stage_cell) so the fight opens where everyone stood. Additive: default
+        # seed_from_stage=False ⇒ this is skipped ⇒ placement is byte-for-byte today's. Runs AFTER
+        # _derive_grid_from_scene so grid_enabled/extents are set for the guard to read.
+        seeded_from_stage: list[str] = []
+        if seed_from_stage:
+            seeded_from_stage = _seed_combat_cells_from_stage(c)
         save_campaign(c)
         view = _combat_view(c)
         # Surface the surprise edge in the runtime view so the DM resolves the opener
@@ -4266,6 +4324,11 @@ def start_combat(
                 outlook = _outlook_for_xps(_party_levels(c), monster_xps)
                 if outlook.get("must_offer_out") or outlook.get("band") == "deadly":
                     view["outlook"] = outlook
+        # W4 NO-TELEPORT: surface who was seeded onto their rest cell so the DM knows the
+        # opener is IN PLACE (and the renderer trusts the engine cells over a fresh placement).
+        # Additive — absent unless seed_from_stage seeded at least one combatant.
+        if seeded_from_stage:
+            view["seeded_from_stage"] = seeded_from_stage
         # Surface whose turn it is at combat-start and make clear they must act BEFORE
         # calling next_turn (the root cause of Round-1 skips: DM reads start_combat.current
         # as already-done and immediately calls next_turn).
@@ -7271,6 +7334,21 @@ def end_combat(campaign_id: str, resolution: str = "") -> dict:
                 # fight ended with foes alive (resolves the continuity-break behavioral gate).
                 payload["resolution"] = res
             _log_combat_event(c, end_text, payload)
+        # W4 (#1321) NO-TELEPORT (exit half): write each SURVIVING combatant's final grid cell
+        # back to its Character.stage_cell so the party stays where the fight ENDED — the next
+        # rest board opens on the combat-end positions, no snap back to a spawn. Computed from
+        # the order BEFORE the reset. Additive: only combatants actually placed on the grid
+        # (x/y set — i.e. a grid fight, typically one that was seed_from_stage-seeded or moved on
+        # the grid) get a write-back; a zone/theater fight leaves x/y None ⇒ NO stage_cell write,
+        # byte-for-byte today's behavior. The dead are skipped (a corpse has no rest position).
+        # This IS the engine writing its own sole-writer field from its own combat state.
+        for cb in c.combat.order:
+            if cb.x is None or cb.y is None:
+                continue
+            ch = c.characters.get(cb.character_id)
+            if ch is None or ch.dead or ch.current_hp <= 0:
+                continue
+            ch.stage_cell = (int(cb.x), int(cb.y))
         c.combat = Combat()
         save_campaign(c)
         return result

--- a/servers/engine/tests/test_living_stage.py
+++ b/servers/engine/tests/test_living_stage.py
@@ -1,0 +1,268 @@
+"""W4 (#1321) The Living Stage — the NO-TELEPORT continuity between rest and combat.
+
+Combat becomes a MODE of the stage, not a separate screen: a fight starts from where everyone
+was standing (Character.stage_cell → Combatant.x/y) and, at end_combat, writes the survivors'
+final cells back to stage_cell so the party stays where the fight ended. No actor jumps.
+
+INVARIANTS pinned here (mirroring test_walk_to.py's idiom):
+  * additive / default-off — seed_from_stage=False (the default) is BYTE-IDENTICAL to today:
+    combatants stay unplaced on the grid (x/y None) and end_combat writes NO stage_cell. The
+    round-trip byte-identity test below FAILS if the default ever seeds/writes.
+  * engine sole-writer — the seed reads stage_cell (set by walk_to); end_combat writes it. Both
+    happen in-engine under the campaign lock; the viewer only projects.
+  * gates-read-gauges — combat READS stage at entry, WRITES only at exit.
+  * grid-mismatch ruling — seeding activates ONLY when the combat grid extents match the
+    location's scene_grid; on mismatch it degrades to today's (unplaced) placement.
+
+Reuses the W2 wall-column rest fixture idiom (test_walk_to.py / test_combat_scene_obstacles.py).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import server
+from scene_grid import (
+    SceneGrid,
+    SceneGridSpec,
+    SceneCell,
+    SceneCellDefault,
+    SceneProp,
+)
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────────────
+
+
+def _wall_column_room(location_id: str = "loc") -> SceneGrid:
+    """A 5x3 scene with a solid wall down column x=2 (rows 1..2) — same geometry as the W2
+    walk_to fixture, so the rest board and the derived combat grid are the SAME 5x3 grid."""
+    cells = [SceneCell(c=2, r=r, type="wall", walkable=False) for r in (1, 2)]
+    props = [SceneProp(id="crate", kind="crates", cells=[(4, 2)], anchor_cell=(4, 2))]
+    cells.append(SceneCell(c=4, r=2, type="prop", walkable=False, prop_ref="crate"))
+    return SceneGrid(
+        scene_id=f"w:{location_id}", location_id=location_id, kind="dungeon",
+        grid=SceneGridSpec(cols=5, rows=3, cell_size_ft=5),
+        cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
+        cells=cells, props=props,
+    )
+
+
+@pytest.fixture
+def staged(tmp_path, monkeypatch):
+    """A campaign whose current location carries the 5x3 wall-column scene, a Hero at (0,0) and
+    an Ally at (1,0) (their rest positions), plus a Goblin foe with NO stage_cell."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("W4 living stage")["id"]
+    loc_id = server.add_location(cid, "The Rest Chamber")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=30)["id"]
+    ally = server.create_character(cid, "Ally", kind="companion", max_hp=20)["id"]
+    goblin = server.create_character(cid, "Goblin", kind="monster", max_hp=7)["id"]
+    c = server._require(cid)
+    c.locations[loc_id].scene_grid = _wall_column_room(loc_id)
+    c.characters[hero].stage_cell = (0, 0)
+    c.characters[ally].stage_cell = (1, 0)
+    # goblin has NO stage_cell — a foe the DM staged, unplaced at rest.
+    server.save_campaign(c)
+    return cid, hero, ally, goblin, loc_id
+
+
+# ── (1) NO-TELEPORT entry: combat cells == prior rest stage_cells ─────────────────────
+
+
+def test_seed_from_stage_opens_combat_on_rest_cells(staged):
+    cid, hero, ally, goblin, _loc = staged
+    view = server.start_combat(cid, [hero, ally, goblin], seed_from_stage=True)
+    c = server._require(cid)
+
+    def cell(char_id):
+        cb = next(cb for cb in c.combat.order if cb.character_id == char_id)
+        return (cb.x, cb.y)
+
+    # Party members seeded ONTO their exact rest cells — no teleport.
+    assert cell(hero) == (0, 0)
+    assert cell(ally) == (1, 0)
+    # The foe had no stage_cell → stays unplaced (today's behavior; never fails the start).
+    assert cell(goblin) == (None, None)
+    # The engine surfaces who it seeded so the DM/renderer trusts the in-place opener.
+    assert set(view.get("seeded_from_stage", [])) == {hero, ally}
+
+
+def test_seed_from_stage_matches_stage_cells_exactly(staged):
+    """Directly assert the eval gate: EVERY seeded combatant's combat-entry cell equals the
+    character's stage_cell as it stood at rest — the no-teleport contract, cell-for-cell."""
+    cid, hero, ally, goblin, _loc = staged
+    before = {
+        h: tuple(server._require(cid).characters[h].stage_cell)
+        for h in (hero, ally)
+    }
+    server.start_combat(cid, [hero, ally, goblin], seed_from_stage=True)
+    c = server._require(cid)
+    for cb in c.combat.order:
+        rest = before.get(cb.character_id)
+        if rest is None:
+            continue  # the foe, unplaced
+        assert (cb.x, cb.y) == rest, f"{cb.character_id} teleported: {(cb.x, cb.y)} != rest {rest}"
+
+
+# ── (2) NO-TELEPORT exit: post-combat rest cells == combat-end cells ──────────────────
+
+
+def test_end_combat_writes_survivors_final_cells_back_to_stage(staged):
+    cid, hero, ally, goblin, _loc = staged
+    server.start_combat(cid, [hero, ally, goblin], seed_from_stage=True)
+    # The Hero repositions during the fight (engine-authoritative grid move).
+    server.move_to_coords(cid, hero, 0, 2)
+    c = server._require(cid)
+    hero_end = next(cb for cb in c.combat.order if cb.character_id == hero)
+    assert (hero_end.x, hero_end.y) == (0, 2)  # moved on the grid
+
+    server.end_combat(cid, resolution="the goblin fled")
+    c = server._require(cid)
+    # The party stays where the fight ENDED — stage_cell now carries the combat-end cells.
+    assert tuple(c.characters[hero].stage_cell) == (0, 2)   # moved-to cell persisted
+    assert tuple(c.characters[ally].stage_cell) == (1, 0)   # never moved → unchanged
+
+
+def test_end_combat_skips_the_dead(staged):
+    """A downed combatant has no rest position — its cell is NOT written back to stage_cell."""
+    cid, hero, ally, goblin, _loc = staged
+    server.start_combat(cid, [hero, ally, goblin], seed_from_stage=True)
+    c = server._require(cid)
+    # Kill the ally in place (engine death), leave it on its grid cell.
+    c.characters[ally].current_hp = 0
+    c.characters[ally].dead = True
+    server.save_campaign(c)
+    server.end_combat(cid)
+    c = server._require(cid)
+    # The living hero keeps its rest position; the dead ally's stage_cell is left untouched
+    # (still its pre-combat seed — the write-back skipped it).
+    assert tuple(c.characters[hero].stage_cell) == (0, 0)
+    assert tuple(c.characters[ally].stage_cell) == (1, 0)
+
+
+def test_full_loop_rest_to_combat_to_rest_continuity(staged):
+    """The scripted NO-TELEPORT loop end to end: rest (walk) → combat (seed) → combat move →
+    rest (write-back). Assert continuity at BOTH seams with no actor jump."""
+    cid, hero, ally, goblin, _loc = staged
+    # REST: the Hero walks to a new rest cell (walk_to is the sole writer of stage_cell).
+    out = server.walk_to(cid, hero, 4, 0)
+    assert out["walked"] is True
+    rest_cells = {
+        h: tuple(server._require(cid).characters[h].stage_cell) for h in (hero, ally)
+    }
+    assert rest_cells[hero] == (4, 0)
+
+    # COMBAT ENTRY: cells == the rest cells (no teleport in).
+    server.start_combat(cid, [hero, ally, goblin], seed_from_stage=True)
+    c = server._require(cid)
+    entry = {cb.character_id: (cb.x, cb.y) for cb in c.combat.order}
+    assert entry[hero] == rest_cells[hero]
+    assert entry[ally] == rest_cells[ally]
+
+    # COMBAT MOVE + EXIT: survivors' rest cells == their combat-end cells (no teleport out).
+    server.move_to_coords(cid, ally, 3, 0)
+    c = server._require(cid)
+    end_cells = {
+        cb.character_id: (cb.x, cb.y) for cb in c.combat.order if cb.x is not None
+    }
+    server.end_combat(cid, resolution="cleared")
+    c = server._require(cid)
+    for char_id, cell in end_cells.items():
+        assert tuple(c.characters[char_id].stage_cell) == cell, (
+            f"{char_id} teleported out: rest {c.characters[char_id].stage_cell} != end {cell}"
+        )
+
+
+# ── (3) additive default: seed_from_stage=False is byte-identical to today ─────────────
+
+
+def test_default_does_not_seed_grid_cells(staged):
+    """The DEFAULT (seed_from_stage omitted) leaves combatants unplaced on the grid — today's
+    behavior, byte-for-byte. FAILS if the default ever starts seeding from stage_cell."""
+    cid, hero, ally, goblin, _loc = staged
+    server.start_combat(cid, [hero, ally, goblin])  # no seed_from_stage
+    c = server._require(cid)
+    for cb in c.combat.order:
+        assert (cb.x, cb.y) == (None, None), f"{cb.character_id} was seeded without seed_from_stage"
+
+
+def test_default_end_combat_writes_no_stage_cell(staged):
+    """A default (unseeded) fight leaves x/y None → end_combat writes NO stage_cell. The party's
+    rest positions are exactly what they were before the fight (byte-for-byte today's behavior)."""
+    cid, hero, ally, goblin, _loc = staged
+    before = {
+        h: tuple(server._require(cid).characters[h].stage_cell) for h in (hero, ally)
+    }
+    server.start_combat(cid, [hero, ally, goblin])  # default: no seeding
+    server.end_combat(cid, resolution="done")
+    c = server._require(cid)
+    assert tuple(c.characters[hero].stage_cell) == before[hero]
+    assert tuple(c.characters[ally].stage_cell) == before[ally]
+
+
+def test_default_start_combat_view_omits_seeded_key(staged):
+    """The additive `seeded_from_stage` key is ABSENT on a default fight (no key delta)."""
+    cid, hero, ally, goblin, _loc = staged
+    view = server.start_combat(cid, [hero, ally, goblin])
+    assert "seeded_from_stage" not in view
+
+
+def test_default_snapshot_round_trips_byte_identical(staged):
+    """A default fight's snapshot round-trips byte-identically — no stage_cell null-emission and
+    no phantom grid seeding leaks into the dump (the omit-none contract holds through combat)."""
+    cid, hero, ally, goblin, _loc = staged
+    server.start_combat(cid, [hero, ally, goblin])
+    c = server._require(cid)
+    raw = c.model_dump_json()
+    from models import Campaign
+    restored = Campaign.model_validate_json(raw)
+    assert restored.model_dump_json() == raw
+    # the foe never had a stage_cell → the key stays ABSENT (not null) through a combat cycle.
+    dumped = json.loads(raw)
+    assert "stage_cell" not in dumped["characters"][goblin]
+
+
+# ── (4) grid-mismatch ruling: seeding degrades gracefully (unplaced) ──────────────────
+
+
+def test_grid_mismatch_degrades_to_unplaced(staged, monkeypatch):
+    """When the derived combat grid extents DON'T match the scene_grid (the epic's grid-mismatch
+    ruling), seed_from_stage does NOT seed — it degrades to today's (unplaced) placement rather
+    than teleporting onto a mismatched coordinate space."""
+    cid, hero, ally, goblin, loc_id = staged
+    c = server._require(cid)
+
+    # Force the derived grid to disagree with the scene_grid by shrinking the combat extents
+    # after derivation (simulating a legacy/degraded grid). We patch _derive_grid_from_scene to
+    # set mismatched extents so the seed guard trips.
+    real_derive = server._derive_grid_from_scene
+
+    def _mismatched(camp):
+        real_derive(camp)
+        if camp.combat.grid_enabled:
+            camp.combat.grid_width = 99  # != scene_grid.cols (5) → mismatch
+    monkeypatch.setattr(server, "_derive_grid_from_scene", _mismatched)
+
+    view = server.start_combat(cid, [hero, ally, goblin], seed_from_stage=True)
+    c = server._require(cid)
+    for cb in c.combat.order:
+        assert (cb.x, cb.y) == (None, None), "mismatched grid must NOT seed (would teleport)"
+    assert "seeded_from_stage" not in view
+
+
+def test_out_of_extents_stage_cell_is_skipped(staged):
+    """A stage_cell outside the grid extents is skipped (never seeds an off-grid/overlapping
+    cell) — the guard protects against a teleport onto an invalid coordinate."""
+    cid, hero, ally, goblin, loc_id = staged
+    c = server._require(cid)
+    c.characters[hero].stage_cell = (10, 10)  # off the 5x3 grid
+    server.save_campaign(c)
+    server.start_combat(cid, [hero, ally, goblin], seed_from_stage=True)
+    c = server._require(cid)
+    hero_cb = next(cb for cb in c.combat.order if cb.character_id == hero)
+    ally_cb = next(cb for cb in c.combat.order if cb.character_id == ally)
+    assert (hero_cb.x, hero_cb.y) == (None, None)  # out-of-extents → unplaced
+    assert (ally_cb.x, ally_cb.y) == (1, 0)        # the valid one still seeds

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3660,6 +3660,12 @@ def build_combat_surface(
         "title": _text(snapshot.get("title"), campaign_id or "Open Worlds"),
         "world": _text(snapshot.get("world_id"), "unknown"),
         "dayLabel": _openworlds_day_label(snapshot),
+        # W4 (#1321) THE LIVING STAGE — day/night lighting token from the campaign clock, so the
+        # combat/rest board re-tints with the time of day (dawn/day/dusk/night) exactly as the
+        # World Map's ClockDial does. CLOCK-DRIVEN (reads the engine's time_of_day off the
+        # snapshot via _openworlds_time_phase — the same normalizer the atlas surface uses), so
+        # the lighting can never disagree with the campaign clock. Additive presentation-only key.
+        "timePhase": _openworlds_time_phase(snapshot),
         "location": location,
         "encounter": {
             "active": combat_active,

--- a/viewer/tests/test_scene_at_rest_stage.py
+++ b/viewer/tests/test_scene_at_rest_stage.py
@@ -43,6 +43,10 @@ _LEGACY_KEYS = {
     "encounter", "grid", "lastPath", "impassable", "doors", "occluders", "tokens", "initiative",
     "zones", "selectedTokenId", "actionEconomy", "commandCenter", "actionBar", "battleLog",
     "live", "is_live_view", "can_act", "state_authority", "write_lane",
+    # W4 (#1321) The Living Stage — the clock-driven day/night lighting token. Additive
+    # presentation-only key (see build_combat_surface); folded into the established set so the
+    # `stage`-is-the-only-NEW-key guard still trips on any UNEXPECTED (non-additive) key change.
+    "timePhase",
 }
 
 


### PR DESCRIPTION
## W4 — The Living Stage (engine): no-teleport rest↔combat continuity

Epic #1321 / Act II roadmap §4b. Depends on W1 (#1318 stage_cell) + W2 (#1319 walk_to writes stage_cell), both merged.

Combat becomes a MODE of the stage, not a separate screen: a fight starts from where everyone was standing and ends back at rest, plus a clock-driven day/night lighting token surfaced for the renderer.

### Engine (`servers/engine/server.py`)
- **`start_combat`** gains an additive `seed_from_stage: bool = False`. When `True`, the new `_seed_combat_cells_from_stage` seeds each combatant's grid cell (`Combatant.x/y`) from its `Character.stage_cell` — the fight opens IN PLACE. **Default `False` ⇒ the seeder never runs ⇒ placement is byte-for-byte today's.** Guards (all additive; any miss ⇒ that combatant stays unplaced, exactly as today):
  - grid must be enabled AND its extents MATCH the location's `scene_grid` (the epic's grid-mismatch ruling — legacy campaigns degrade gracefully + a WARN line);
  - only combatants **with** a stage_cell are seeded (foes lacking one stay unplaced ⇒ never fails the combat start over placement);
  - a stage_cell out of extents or already claimed is skipped (never teleports/stacks tokens).
- **`end_combat`** writes each **surviving** (alive, on-grid) combatant's final cell back to `Character.stage_cell` so the party stays where the fight ended. A zone/theater fight leaves `x/y` None ⇒ **no write** ⇒ today's behavior. The dead are skipped.
- Surfaces `seeded_from_stage` (additive; present only when it seeded ≥1).

### Viewer (`viewer/server.py`)
- `build_combat_surface` gains `timePhase` — the clock-driven day/night lighting token (via `_openworlds_time_phase`, the same normalizer the atlas surface uses so it can never disagree with the campaign clock). Additive, presentation-only.

### Tests
- **`servers/engine/tests/test_living_stage.py`** — the NO-TELEPORT gate (11 tests): combat-entry cells == prior rest stage_cells; post-combat rest cells == combat-end cells; the full scripted rest→combat→move→rest loop; additive-default byte-identity (no seeding / no write-back / no `seeded_from_stage` key / snapshot round-trips byte-identical); grid-mismatch + out-of-extents degradation; dead-skip.
- `viewer/tests/test_scene_at_rest_stage.py` — folded `timePhase` into the established key set so the "stage is the only NEW key" byte-identity guard still trips on any UNEXPECTED (non-additive) key change.

### Invariants
- **Engine sole-writer** preserved: the seed reads stage_cell (set by walk_to); end_combat writes it — both in-engine under `campaign_lock`. Viewer only projects.
- **Additive-by-default**: no `seed_from_stage` / no `stage_cell` ⇒ today's behavior, asserted byte-identical.
- **Combat gate + existing placement untouched** when the param is absent.
- **Schema-budget guard green** (`start_combat` docstring compressed to a single line to stay under the 120 KB `list_tools` budget).

### Verification
- `qa/fast_gate.sh` (Tier-0): **257 passed**.
- Engine combat-adjacent sweep: **1047 passed**.
- Full viewer suite (CI-style): **843 passed, 8 skipped**.
- `test_tool_schema_budget.py`: **green** (120000-byte budget held).

### Notes / deviations
- No new **behavioral** `chk()` in `qa/BEHAVIORAL_GATE_TAXONOMY.json`: the eval gate is a **deterministic engine test** per the epic addendum (the blind-playtest loop eval belongs to W5). The taxonomy checks are all transcript/play-behavior signals — a no-teleport engine invariant doesn't fit that shape, so it ships as `test_living_stage.py`.
- Mid-combat cross_door/travel is already REFUSED while `combat.active` (existing gate; per the addendum, out of W4 scope).
- The one visual-evidence render pair (rest frame + combat frame) named in the addendum is a renderer-lane artifact, not an engine deliverable — not included here.

Do NOT merge without the standard CI + CodeRabbit gate.