### PR TITLE
[HV2] extractor quality: NPC dialogue-snippet mining + quest wrap-up capture (#1329)

### DIFF
--- a/data/library/artifact_schema.json
+++ b/data/library/artifact_schema.json
@@ -60,9 +60,28 @@
       "properties": {
         "id": {"type": "string"},
         "name": {"type": "string"},
+        "description": {
+          "type": "string",
+          "description": "OPTIONAL (HV2 additive, #1329). The quest's own summary text (Quest.description) — the hook/premise the Questwright rubric scores for stakes. Absent/empty when the source quest carried no description."
+        },
         "objectives": {"type": "array", "items": {"type": "string"}},
         "completed_objectives": {"type": "array", "items": {"type": "string"}},
         "resolution_status": {"type": "string"},
+        "resolution": {
+          "type": "object",
+          "description": "OPTIONAL (HV2 additive, #1329). The quest's narrative wrap-up / outcome context so the panel can score consequence_weight and narrative completeness on a resolved quest, not just its objective spine. Absent when the quest never resolved AND no closing beats were mined.",
+          "properties": {
+            "status": {"type": "string"},
+            "evolves_to": {"type": "string"},
+            "callback_in_days": {"type": "integer"},
+            "wrap_up": {
+              "type": "array",
+              "maxItems": 5,
+              "items": {"type": "string"},
+              "description": "Up to 5 closing narration beats from the transcript that describe this quest's resolution/outcome/consequence."
+            }
+          }
+        },
         "evolves_to": {"type": "string"},
         "consequences": {"type": "array", "items": {"type": "object"}}
       }

--- a/qa/artifact_snapshot_reader.py
+++ b/qa/artifact_snapshot_reader.py
@@ -70,7 +70,9 @@ def extract(
 
     out: list[dict] = []
     if "quest" in classes:
-        out += hv2.extract_quests(snapshot, provenance_base, world)
+        # No transcript in a thin calibration read → empty text blocks (wrap_up comes back [], graceful
+        # per _quest_wrap_up's own contract) — mirrors the NPC call's empty-text-blocks fallback below.
+        out += hv2.extract_quests(snapshot, provenance_base, world, [])
     if "npc" in classes:
         # No transcript in a thin calibration read → empty text blocks (dialogue_snippets come back []).
         out += hv2.extract_npcs(snapshot, provenance_base, world, [])

--- a/qa/export_campaign_artifacts.py
+++ b/qa/export_campaign_artifacts.py
@@ -277,7 +277,10 @@ def _quest_wrap_up(quest_title: str, text_blocks: list[str], limit: int = _MAX_Q
         low = title_pat.sub(" ", blk).lower()
         if not any(cue in low for cue in _RESOLUTION_CUES):
             continue
-        beat = blk if len(blk) <= 600 else blk[:599] + "…"
+        # Same cap as the NPC voice-line/dialogue-snippet truncation above (_npc_dialogue_snippets,
+        # _npc_voice_lines) — one consistent payload-size ceiling across the extractor, not a
+        # second one-off limit.
+        beat = blk if len(blk) <= 400 else blk[:399] + "…"
         key = beat.lower()
         if key in seen:
             continue

--- a/qa/export_campaign_artifacts.py
+++ b/qa/export_campaign_artifacts.py
@@ -36,7 +36,36 @@ from typing import Optional
 
 _ROOT = Path(__file__).resolve().parent.parent
 _MAX_DIALOGUE_SNIPPETS = 5
+_MAX_QUEST_WRAPUP = 5
 _ARTICLES = {"the", "a", "an"}
+
+# A quoted span of NPC speech: straight or curly DOUBLE quotes, or CURLY single quotes. The
+# straight single-quote (') is deliberately NOT a delimiter — in prose it is overwhelmingly a
+# possessive/contraction ("Kervan's", "doesn't"), so treating it as a quote boundary captures
+# garbage fragments. Curly typographic single quotes ('…') are unambiguous speech and kept.
+_QUOTE_RE = re.compile(r"[\"“]([^\"”]{2,400})[\"”]|[‘]([^‘’]{2,400})[’]")
+# Speech-attribution verbs that mark a quote as a character SPEAKING (vs the narrator merely
+# mentioning them). Matches the DM prose conventions seen in real transcripts ("...", Roe says /
+# Sefa: "..." / he growls). Deliberately narration-agnostic on tense/person.
+_SPEECH_VERBS = (
+    "say", "says", "said", "ask", "asks", "asked", "reply", "replies", "replied",
+    "growl", "growls", "growled", "whisper", "whispers", "whispered", "mutter", "mutters",
+    "muttered", "snap", "snaps", "snapped", "hiss", "hisses", "hissed", "call", "calls",
+    "called", "bark", "barks", "barked", "rasp", "rasps", "rasped", "drawl", "drawls",
+    "drawled", "murmur", "murmurs", "murmured", "sigh", "sighs", "sighed", "spit", "spits",
+    "spat", "roar", "roars", "roared", "add", "adds", "added", "continue", "continues",
+    "demand", "demands", "demanded", "purr", "purrs", "purred", "sneer", "sneers", "sneered",
+    "offer", "offers", "offered", "tell", "tells", "told", "answer", "answers", "answered",
+)
+# Resolution language that marks a narration beat as a quest's WRAP-UP (its outcome/consequence),
+# so the closing beats — not every mid-quest mention — are what land in the quest payload.
+_RESOLUTION_CUES = (
+    "resolv", "complet", "finish", "conclud", "outcome", "consequence", "aftermath", "settle",
+    "in the end", "at last", "closed", "sealed the", "the deal", "repaid", "repay", "avenged",
+    "betray", "the price", "the cost", "spared", "killed", "died", "dead", "survived", "saved",
+    "abandon", "failed", "fell through", "kept the", "broke the", "delivered", "returned the",
+    "the reward", "vengeance", "reckoning", "the debt",
+)
 
 
 # ── engine + distill imports (read-only) ─────────────────────────────────────────────────────
@@ -141,6 +170,121 @@ def _npc_dialogue_snippets(name: str, text_blocks: list[str], limit: int = _MAX_
             out.append(blk if len(blk) <= 400 else blk[:399] + "…")
             if len(out) >= limit:
                 break
+    return out
+
+
+def _quote_spans(block: str) -> list[tuple[int, int, str]]:
+    """Every quoted span in a narration block as (start, end, text). Handles straight and curly
+    double/single quotes. The offsets let the attribution check look at the words immediately
+    around a quote (who is speaking) rather than the whole block."""
+    spans: list[tuple[int, int, str]] = []
+    for m in _QUOTE_RE.finditer(block):
+        txt = m.group(1) if m.group(1) is not None else m.group(2)
+        # Strip markdown emphasis markers (* _) that bracket italicised in-fiction speech and
+        # collapse internal whitespace, so the captured line is the clean spoken text.
+        cleaned = " ".join(txt.replace("*", " ").replace("_", " ").split()) if txt else ""
+        # Keep only quotes with real words (>=2 word chars) — a bare fragment like a name tag or a
+        # stray punctuation quote isn't a spoken line.
+        if len(re.findall(r"\w", cleaned)) >= 2:
+            spans.append((m.start(), m.end(), cleaned))
+    return spans
+
+
+_SPEECH_VERB_RE = re.compile(r"\b(?:%s)\b" % "|".join(_SPEECH_VERBS), re.IGNORECASE)
+
+
+def _attributed_to(block: str, span: tuple[int, int, str], name_pat: re.Pattern) -> bool:
+    """True when the quoted span at `span` is attributed to the NPC whose first name matches
+    `name_pat`. Attribution reads TIGHT in DM prose — `"...", Roe says` (name+verb right after the
+    close-quote) or `Sefa says: "..."` (name+verb right before the open-quote) — so we require the
+    NPC name AND a speech verb to co-occur in a SHORT window on ONE side of the quote (~45 chars),
+    not merely somewhere in the surrounding paragraph. This is the difference between an IN-VOICE
+    line the NPC spoke and a block that only NAMES the NPC in third-person scene/combat narration
+    (the old mention-matcher's false positive, which caps voice_distinctiveness under the rubric),
+    and it stops a quote from being mis-attributed to a second NPC merely named elsewhere in the
+    same paragraph."""
+    start, end, _ = span
+    after = block[end:end + 60]
+    before = block[max(0, start - 60):start]
+    for side in (after, before):
+        if name_pat.search(side) and _SPEECH_VERB_RE.search(side):
+            return True
+    return False
+
+
+def _npc_voice_lines(name: str, text_blocks: list[str], limit: int = _MAX_DIALOGUE_SNIPPETS) -> list[str]:
+    """Up to `limit` IN-VOICE quoted lines this NPC actually SPOKE in the campaign — the thing the
+    NPC rubric rewards (voice_distinctiveness: 'could an actor hear how they talk?'). A quoted span
+    is kept only when the NPC's (leading-article-stripped) first name and a speech-attribution verb
+    both sit in the window around the quote, so third-person narration that merely mentions the NPC
+    (the old matcher's false positives — combat rosters, scene-setting) is excluded. Deduped in
+    first-seen order; a silent NPC (no attributed quotes) returns [] and stays a valid artifact."""
+    if not name:
+        return []
+    # Match ANY significant name token (first OR last), so both `"...", Corren says` and
+    # `"...", Hask says` attribute to "Corren Hask". Articles and 1-char tokens are dropped so a
+    # name like "The Emperor" matches on "Emperor", never the near-ubiquitous article.
+    tokens = [w for w in name.split() if w.lower() not in _ARTICLES and len(w) > 1]
+    if not tokens:
+        tokens = [name.split()[0]]
+    name_pat = re.compile(r"\b(?:%s)\b" % "|".join(re.escape(t) for t in tokens), re.IGNORECASE)
+    out: list[str] = []
+    seen: set[str] = set()
+    for blk in text_blocks:
+        for span in _quote_spans(blk):
+            _, _, quote = span
+            if not _attributed_to(blk, span, name_pat):
+                continue
+            # Drop a fragment that opens mid-sentence (lowercase first letter) — that's a slice of
+            # narration spliced through a quote mark, not a fresh spoken line. A quote opening with
+            # a capital, a digit, or opening punctuation (— … ') reads as real delivered speech.
+            head = quote.lstrip("—–-…‘'\"“ ")
+            if head and head[0].isalpha() and not head[0].isupper():
+                continue
+            line = quote if len(quote) <= 400 else quote[:399] + "…"
+            key = line.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(line)
+            if len(out) >= limit:
+                return out
+    return out
+
+
+def _quest_wrap_up(quest_title: str, text_blocks: list[str], limit: int = _MAX_QUEST_WRAPUP) -> list[str]:
+    """Up to `limit` closing narration beats that describe THIS quest's resolution/outcome — the
+    wrap-up context the Questwright rubric scores for consequence_weight / narrative completeness.
+    A beat qualifies only when it names the quest (leading-article-stripped title token match) AND
+    carries resolution language (_RESOLUTION_CUES), so mid-quest mentions don't dilute the outcome.
+    Deduped in first-seen order; a quest with no mined wrap-up beats returns [] (graceful)."""
+    title = (quest_title or "").strip()
+    if not title:
+        return []
+    tokens = [t for t in re.findall(r"[A-Za-z][A-Za-z'’]+", title) if t.lower() not in _ARTICLES]
+    if not tokens:
+        return []
+    title_pat = re.compile(r"\b(?:%s)\b" % "|".join(re.escape(t) for t in tokens), re.IGNORECASE)
+    out: list[str] = []
+    seen: set[str] = set()
+    for blk in text_blocks:
+        if not title_pat.search(blk):
+            continue
+        # Scan for resolution cues with the quest TITLE tokens masked out, so a cue phrase that is
+        # merely part of the title itself ("the price"/"the debt" inside a title like "The Price of
+        # Silence") never counts as resolution language — the beat must carry an outcome word of
+        # its OWN, not echo the quest name.
+        low = title_pat.sub(" ", blk).lower()
+        if not any(cue in low for cue in _RESOLUTION_CUES):
+            continue
+        beat = blk if len(blk) <= 600 else blk[:599] + "…"
+        key = beat.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(beat)
+        if len(out) >= limit:
+            break
     return out
 
 
@@ -265,19 +409,31 @@ def _quest_consequences(quest_id: str, quest_title: str, consequences: list) -> 
     return out
 
 
-def extract_quests(campaign: dict, provenance_base, world: str) -> list[dict]:
+def extract_quests(campaign: dict, provenance_base, world: str, text_blocks: list[str]) -> list[dict]:
     artifacts = []
     quests = campaign.get("quests") or {}
     consequences = campaign.get("consequences") or []
     for qid, q in quests.items():
+        title = q.get("title", "")
+        # Narrative wrap-up (HV2 #1329): the quest's OWN description (Quest.description, previously
+        # dropped) plus the closing transcript beats that describe its outcome — the resolution
+        # context the Questwright rubric scores for consequence_weight / narrative completeness.
+        wrap_up = _quest_wrap_up(title, text_blocks)
         payload = {
             "id": q.get("id", qid),
-            "name": q.get("title", ""),
+            "name": title,
+            "description": q.get("description", ""),
             "objectives": q.get("objectives", []),
             "completed_objectives": q.get("completed_objectives", []),
             "resolution_status": q.get("status", ""),
+            "resolution": {
+                "status": q.get("status", ""),
+                "evolves_to": q.get("evolves_to", ""),
+                "callback_in_days": q.get("callback_in_days", 0),
+                "wrap_up": wrap_up,
+            },
             "evolves_to": q.get("evolves_to", ""),
-            "consequences": _quest_consequences(qid, q.get("title", ""), consequences),
+            "consequences": _quest_consequences(qid, title, consequences),
         }
         artifacts.append(
             _envelope(f"quest:{campaign['id']}:{qid}", "quest", world, provenance_base(), payload)
@@ -313,7 +469,13 @@ def extract_npcs(campaign: dict, provenance_base, world: str, text_blocks: list[
             "personality": personality,
             "attitude_arc": {"start": start_val, "end": end_val},
             "final_status": _npc_final_status(c),
-            "dialogue_snippets": _npc_dialogue_snippets(c.get("name", ""), text_blocks),
+            # IN-VOICE quoted lines the NPC actually SPOKE (HV2 #1329). The rubric rewards a
+            # VOICED NPC and forces voice_distinctiveness <= 2 on "described-not-voiced" — so we
+            # deliberately DON'T fall back to the old mention-based proxy, which harvested
+            # third-person combat/scene narration (a party roster line naming the NPC is NOT its
+            # voice). A silent NPC surfaces [] and stays a valid artifact (graceful), rather than
+            # carrying noise that actively HURTS the panel score.
+            "dialogue_snippets": _npc_voice_lines(c.get("name", ""), text_blocks),
         }
         artifacts.append(_envelope(f"npc:{campaign['id']}:{cid}", "npc", world, provenance_base(), payload))
     return artifacts
@@ -419,7 +581,7 @@ def build_artifacts(
 
     text_blocks = _dm_player_text_blocks(transcript_lines)
     return {
-        "quests": extract_quests(campaign_dict, provenance_base, world),
+        "quests": extract_quests(campaign_dict, provenance_base, world, text_blocks),
         "npcs": extract_npcs(campaign_dict, provenance_base, world, text_blocks),
         "locations": extract_locations(campaign_dict, provenance_base, world, sg_module, campaign_id),
         "encounters": extract_encounters(campaign_dict, provenance_base, world, transcript_lines),

--- a/qa/test_export_campaign_artifacts.py
+++ b/qa/test_export_campaign_artifacts.py
@@ -91,14 +91,23 @@ def _golden_campaign() -> Campaign:
 
 
 def _golden_transcript_lines() -> list[str]:
-    """A minimal stream-json transcript: one DM narration block mentioning "Corvin" (so the
-    dialogue-snippet matcher has something to find) plus a start_combat/end_combat pair."""
+    """A minimal stream-json transcript: one DM narration block with an IN-VOICE attributed quote
+    from Corvin (so the voice-line miner has an attributable line), a quest wrap-up beat that names
+    the quest AND carries resolution language, plus a start_combat/end_combat pair."""
     events = [
         {
             "type": "assistant",
             "message": {
                 "content": [
-                    {"type": "text", "text": "Corvin Dresh leans in close: 'You have my crates?'"}
+                    {"type": "text", "text": "\"You have my crates?\" Corvin Dresh asks, leaning in close."}
+                ]
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "In the end, Dresh's Lost Wagon is resolved: the crates are returned and the debt repaid."}
                 ]
             },
         },
@@ -173,9 +182,18 @@ def test_golden_fixture_exact_expected_json(golden):
     assert quest["payload"] == {
         "id": "quest-wagon",
         "name": "Dresh's Lost Wagon",
+        "description": "",
         "objectives": ["Find the wagon", "Return the crates"],
         "completed_objectives": ["Find the wagon"],
         "resolution_status": "active",
+        "resolution": {
+            "status": "active",
+            "evolves_to": "",
+            "callback_in_days": 0,
+            "wrap_up": [
+                "In the end, Dresh's Lost Wagon is resolved: the crates are returned and the debt repaid."
+            ],
+        },
         "evolves_to": "",
         "consequences": [
             {"id": "conseq-wagon-1", "trigger_day": 5, "text": "Dresh's Lost Wagon: the checkpoint doubles its watch."}
@@ -191,7 +209,7 @@ def test_golden_fixture_exact_expected_json(golden):
     assert npc["payload"]["voice_id"] == "npc-merchant"
     assert npc["payload"]["attitude_arc"] == {"start": 0, "end": 15}
     assert npc["payload"]["final_status"] == "active"
-    assert npc["payload"]["dialogue_snippets"] == ["Corvin Dresh leans in close: 'You have my crates?'"]
+    assert npc["payload"]["dialogue_snippets"] == ["You have my crates?"]
     assert npc["payload"]["personality"]["personality"].startswith("A nervous merchant")
 
     loc_files = sorted((campaign_out / "locations").glob("*.json"))
@@ -426,6 +444,91 @@ def test_dialogue_snippets_word_boundary_no_substring_false_positive():
     """First name 'Boo' must not match 'book' (word-boundary, not bare substring)."""
     blocks = ["She opens a dusty book.", "Boo squeaks in Minsc's pocket."]
     assert eca._npc_dialogue_snippets("Boo", blocks) == ["Boo squeaks in Minsc's pocket."]
+
+
+# ── in-voice dialogue mining (HV2 #1329): the quality lever ──────────────────────────────────
+def test_voice_lines_extracts_attributed_quote_not_narration():
+    """An NPC that SPOKE carries the IN-VOICE quoted line, not the surrounding third-person prose.
+    The attribution can precede ("Sefa says: ...") or follow ("...", Roe says) the quote."""
+    blocks = [
+        '"You have my crates?" Corvin asks, leaning in close.',
+        'Sefa says, low and fast: "Take the coin and forget my name."',
+    ]
+    assert eca._npc_voice_lines("Corvin Dresh", blocks) == ["You have my crates?"]
+    assert eca._npc_voice_lines("Sefa", blocks) == ["Take the coin and forget my name."]
+
+
+def test_voice_lines_excludes_third_person_mention_without_speech():
+    """A block that NAMES the NPC in combat/scene narration but is NOT them speaking must NOT be
+    harvested — this is the measured false positive (a party-roster line 'Party (Maren 31/31)...')
+    that the old mention-matcher wrongly kept, capping voice_distinctiveness under the rubric."""
+    blocks = [
+        "Party (Aldric 40/40, Maren 31/31) and all three hostiles confirmed in the cellar.",
+        "Maren steps back as the ghoul lunges.",  # named, no quote, no speech verb
+    ]
+    assert eca._npc_voice_lines("Maren", blocks) == []
+
+
+def test_voice_lines_requires_both_name_and_quote_proximity():
+    """A quote NOT attributed to the NPC (another speaker in the window) isn't the NPC's line."""
+    blocks = ['"Get back!" the captain barks at his men.']
+    assert eca._npc_voice_lines("Corvin", blocks) == []
+
+
+def test_voice_lines_deduped_and_capped():
+    """Repeated identical lines dedupe; the result is capped at five distinct lines."""
+    blocks = ['"Again," Corvin says.'] * 3 + [f'"Line {i} spoken now," Corvin says.' for i in range(6)]
+    out = eca._npc_voice_lines("Corvin", blocks)
+    assert out[0] == "Again,"
+    assert len(out) == 5
+    assert len(out) == len(set(out))
+
+
+def test_voice_lines_curly_quotes_supported():
+    blocks = ["“The debt is mine to settle,” Drast says, not a question."]
+    assert eca._npc_voice_lines("Drast", blocks) == ["The debt is mine to settle,"]
+
+
+def test_voice_lines_drops_mid_sentence_fragment():
+    """A quote opening lowercase is a narration slice spliced through a quote mark, not a fresh
+    spoken line — it is dropped even when name+verb are adjacent (the double-attribution defect)."""
+    blocks = ['Corren says something about "that the tidy-book man is enjoying this far too much."']
+    assert eca._npc_voice_lines("Corren", blocks) == []
+
+
+def test_voice_lines_straight_single_quote_possessive_not_captured():
+    """A straight apostrophe (possessive/contraction) is NOT a quote delimiter, so a block with no
+    real double/curly-quoted speech yields nothing — 'Kervan's hand ... doesn't' is not a line."""
+    blocks = ["Kervan's hand is still out, and he doesn't look away, Kervan says nothing."]
+    assert eca._npc_voice_lines("Kervan", blocks) == []
+
+
+def test_voice_lines_silent_npc_returns_empty():
+    """A silent NPC (never speaks a quoted line) returns [] — a valid, graceful artifact."""
+    assert eca._npc_voice_lines("Ghost", ["The room is empty and cold."]) == []
+    assert eca._npc_voice_lines("", ['"hello," someone says.']) == []
+
+
+# ── quest wrap-up mining (HV2 #1329) ─────────────────────────────────────────────────────────
+def test_quest_wrap_up_captures_resolution_beat():
+    """A closing beat that names the quest AND carries resolution language is captured."""
+    blocks = [
+        "The party sets out toward the Lower City.",  # mid-quest mention, no resolution cue
+        "In the end, The Price of Silence is resolved: Oln's debt is repaid and the ledger burned.",
+    ]
+    out = eca._quest_wrap_up("The Price of Silence", blocks)
+    assert out == ["In the end, The Price of Silence is resolved: Oln's debt is repaid and the ledger burned."]
+
+
+def test_quest_wrap_up_ignores_mid_quest_mention_without_resolution_cue():
+    blocks = ["Bresser Oln is somewhere in the Lower City, the Price of Silence still open."]
+    assert eca._quest_wrap_up("The Price of Silence", blocks) == []
+
+
+def test_quest_wrap_up_empty_when_never_resolved():
+    """A quest with no closing beats returns [] (graceful) — not every quest wraps up on-screen."""
+    assert eca._quest_wrap_up("The Four Hundred", ["Rumours of the Four Hundred drift through the market."]) == []
+    assert eca._quest_wrap_up("", ["anything resolved here"]) == []
 
 
 # ── combat scanner edge cases (dangling / consecutive / rejected / string-arg) ─────────────────


### PR DESCRIPTION
## Why

The first LIVE promotion batch (PR #1354, merged) scored 11 extracted artifacts and promoted **only 1**. The rejections were legible: several NPC extracts carried **empty/thin `dialogue_snippets`**, and quests lacked **narrative wrap-up** context — so they failed the promotion gate on those grounds. Raising extraction QUALITY directly raises the promotable fraction (the flywheel's throughput). Follow-up on epic #1329 / the HV3 first-promotion finding.

## What changed

**1. NPC dialogue — extract the VOICE, not the narration.**
`dialogue_snippets` now mines **in-voice quoted lines the NPC actually SPOKE**: a quoted span (straight/curly double quotes, curly single) is kept only when the NPC's name (first OR last token) AND a speech-attribution verb sit tight (~60 chars) around the quote. The old matcher kept *any* narration block mentioning the name — combat rosters (`Party (Aldric 40/40, Maren 31/31)...`), scene-setting — which is the **"described-not-voiced"** failure that forces `voice_distinctiveness ≤ 2` under `qa/rubric_artifact_npc.md`. Markdown emphasis is stripped, mid-sentence fragments and possessive-apostrophe false quotes are filtered, and a **silent NPC returns `[]`** (graceful).

**2. Quest wrap-up / resolution context.**
Quest payload gains additive **`description`** (`Quest.description`, previously dropped) and a **`resolution`** object `{status, evolves_to, callback_in_days, wrap_up[]}`, where `wrap_up` mines the closing transcript beats that **name the quest AND carry resolution language** (outcome/consequence cues, with the quest's own title tokens masked out so a title like *The Price of Silence* doesn't self-trigger the `the price` cue). This is the outcome context `qa/rubric_artifact_quest.md` scores for `consequence_weight` / narrative completeness.

**3. Schema — additive-only.**
`data/library/artifact_schema.json`: `quest_payload` gains optional `description` + `resolution`; envelope, per-class required keys, and `provenance.source` (HV1's optional field) are unchanged. HV2's merged schema stays canonical.

## Invariants
- **Read-only on play-state** (unchanged): loads snapshots, never saves.
- **Additive schema only**; both new quest fields optional, old artifacts round-trip.
- Extractor stays a sibling of `export_scene_grid.py`; offline-testable (fabricated transcript fixtures, no live LLM).

## Before / after (5 real campaigns, re-extracted read-only)

| campaign | NPC snippets (old→new) | quest wrap_up | quest description |
|---|---|---|---|
| baseline-rc1 | 2→3 | 1 | 1 |
| glm-arc-bg1 | 6→5 | 1 | 1 |
| claude-v2-2 | 3→4 | 1 | 1 |
| claude-v2-3 | 2→2 | 1 | 1 |
| glm-duo-h | 2→0 | 0 | 1 |
| **totals (62 NPCs / 5 quests)** | **15→14 present** | **0→4** | **0→5** |

The NPC *count* is ~flat, but the CONTENT flips from combat-roster noise (`Party confirmed: Aldric (40/40)...`) to genuine in-voice lines (`"I'd rather we pull together," Wyll` / `"Lord Wyll. Sir. Begging your pardon."` / `"So I don't want your gold..."`). Quest wrap-up + description go from **absent** to present on nearly every quest — new signal the promotion panel can score. (glm-duo-h's 2→0 were false-positive combat mentions correctly dropped.)

## Tests
- `qa/test_export_campaign_artifacts.py`: **36 passed** (was 15) — `-p no:xdist`. In-voice attribution (pre/post), third-person + possessive-apostrophe exclusion, mid-sentence-fragment drop, dedup+cap, curly quotes, quest wrap-up cue matching + title-token cue masking, graceful empty/silent cases; golden fixture updated for the new fields.
- `qa/fast_gate.sh`: **T0 PASS (257 passed)**.
- `ruff check`: clean.
- `jsonschema`: 43 real extracted artifacts validate against envelope + per-class payload defs (additive fields accepted).

Do **not** merge — orchestrator runs the live promotion panel. Part of #1329.