### PR TITLE
[HV5] nightly harvest scoring + library_metrics (the flywheel's own eval) (#1327)

### DIFF
--- a/qa/library_metrics.py
+++ b/qa/library_metrics.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""library_metrics.py — HV5 flywheel's own eval: a snapshot of the harvest loop's own health
+(docs/roadmap/PRODUCT-ROADMAP.md §4c HV5, epic #1327, slice 2 of the flywheel-ops sprint).
+
+WHY THIS EXISTS
+---------------
+The epic names this explicitly: "THE FLYWHEEL'S OWN EVAL: the %library-sourced vs lens-scores
+trend — 'less AI dependence' as a measured claim." Everything else in the HV-series scores PLAY
+QUALITY (runs) or CONTENT QUALITY (artifacts); this module scores the LOOP ITSELF — how big the
+library has grown, how much of it is actually being reused, how often a nomination clears the
+promotion gate, and (once HV4 wires per-run attribution) what fraction of a run's beats came from
+the library instead of fresh AI generation.
+
+WHAT IT DOES
+------------
+Reads (never writes) the promoted `library/` pack + its processed-log, and appends ONE snapshot row
+to the additive `library_metrics` table in qa/scores.db via qa/scores_db.add_library_metrics — its
+SOLE writer (mirrors "promote.py is the sole writer of runs/artifacts" for its own tables). Reads:
+
+  * library/**/*.json (every class subdir: quests/npcs/locations/encounters/rooms) for
+    {size_total, size_by_class, size_by_tier, Σreuse_count} — a pure directory scan, no schema
+    coupling beyond the `class`/`tier`/`reuse_count` keys tools/library/promote.py's build_entry
+    already writes onto every entry.
+  * library/.promoted.jsonl (promote.py's PROCESSED_LOG — one line per {artifact_id, verdict, tier,
+    at}) for {promoted_total, rejected_total, promotion_pass_rate}. Absent/empty log -> pass_rate
+    is None (no batch has run yet; NOT zero — zero would falsely claim "every batch failed").
+
+pct_library_sourced is intentionally left None/omittable here: attributing a RUN's beats to
+"library-sourced vs fresh-gen" is HV4 wiring (questgen._derive_hooks' library candidate source,
+roadmap §4c "needs HV3") that does not exist yet in this repo state. snapshot_library() accepts an
+explicit override so a future HV4-aware caller can pass a measured value without this module
+guessing at one — leaving it unset is the correct, honest "not measured this snapshot" state (the
+same discipline scores_db already uses for every additive, not-yet-wired column).
+
+DISCIPLINE
+----------
+* READ-ONLY over library/ — never a second writer of promote.py's pack (no entry is edited/moved).
+* Additive: scores.db writes go ONLY through qa/scores_db.py's add_library_metrics (never hand-
+  rolled SQL here or anywhere else).
+* Idempotent scan (a pure directory read); NOT idempotent as a WRITE — each invocation intentionally
+  appends a NEW snapshot row (a time-series of "library health over time", the same shape as
+  scores_db.trends_json gives for runs). Running this twice in a row with an unchanged library/
+  simply records two identical readings a few seconds apart — that is the correct trend behavior,
+  not a bug to dedup away.
+* Offline-safe: pure filesystem + sqlite reads/writes, no LLM, no subprocess, no network.
+
+USAGE
+-----
+    python3 qa/library_metrics.py [--library library/] [--db qa/scores.db] [--sha <short-sha>]
+                                  [--pct-library-sourced 0.0-1.0] [--notes TEXT] [--render]
+                                  [--dry-run]
+
+``--render`` also regenerates qa/library_metrics_ledger.md after the snapshot (mirrors --render on
+scores_db.py's own CLI). ``--dry-run`` computes + prints the snapshot payload but appends nothing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+QA_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = QA_DIR.parent
+sys.path.insert(0, str(QA_DIR))
+import scores_db  # noqa: E402
+
+DEFAULT_LIBRARY_DIR = _REPO_ROOT / "library"
+PROCESSED_LOG_NAME = ".promoted.jsonl"  # matches tools/library/promote.py's PROCESSED_LOG constant
+
+# Mirrors tools/library/promote.py's ENTRY_CLASSES / _CLASS_TO_SUBDIR (kept as a local literal
+# rather than importing promote.py, so this reader never depends on the writer's import surface —
+# a pure filesystem scan needs only the subdir names, which are part of the on-disk CONTRACT, not
+# an implementation detail that could drift silently).
+_CLASS_SUBDIRS: tuple[str, ...] = ("quests", "npcs", "locations", "encounters", "rooms")
+_VALID_TIERS: tuple[str, ...] = ("experimental", "stable", "canonical")
+
+
+# ---------------------------------------------------------------------------
+# library/ directory scan (read-only)
+# ---------------------------------------------------------------------------
+def scan_library(library_dir: Path | str) -> dict:
+    """Read every entry under library/<class>s/*.json and roll up size + tier + reuse counters.
+
+    Returns {size_total, size_by_class: {cls: n}, size_by_tier: {tier: n}, reuse_count_sum}. A
+    missing library_dir, or one with no class subdirs yet, yields all-zero counters (an empty/not-
+    yet-promoted library is a valid, measurable state — not an error). A malformed entry JSON is
+    counted toward size_total (it undeniably occupies a library slot) but contributes 0 to
+    reuse_count_sum and is NOT counted under any tier (an unreadable tier is unknown, not
+    "experimental" by default — that would misrepresent the tier distribution)."""
+    library_dir = Path(library_dir)
+    size_by_class: dict[str, int] = {}
+    size_by_tier: dict[str, int] = {t: 0 for t in _VALID_TIERS}
+    reuse_sum = 0
+    total = 0
+
+    if not library_dir.exists():
+        return {
+            "size_total": 0,
+            "size_by_class": {},
+            "size_by_tier": dict(size_by_tier),
+            "reuse_count_sum": 0,
+        }
+
+    for subdir in _CLASS_SUBDIRS:
+        d = library_dir / subdir
+        if not d.is_dir():
+            continue
+        cls_name = subdir[:-1]  # "quests" -> "quest", "rooms" -> "room", etc.
+        for entry_path in sorted(d.glob("*.json")):
+            total += 1
+            size_by_class[cls_name] = size_by_class.get(cls_name, 0) + 1
+            try:
+                entry = json.loads(entry_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue  # counted in size_total above; unreadable beyond that
+            if not isinstance(entry, dict):
+                continue
+            tier = entry.get("tier")
+            if tier in size_by_tier:
+                size_by_tier[tier] += 1
+            rc = entry.get("reuse_count")
+            if isinstance(rc, (int, float)):
+                reuse_sum += rc
+
+    return {
+        "size_total": total,
+        "size_by_class": size_by_class,
+        "size_by_tier": size_by_tier,
+        "reuse_count_sum": int(reuse_sum),
+    }
+
+
+# ---------------------------------------------------------------------------
+# promotion pass-rate (library/.promoted.jsonl — promote.py's own processed-log)
+# ---------------------------------------------------------------------------
+def scan_promotion_log(library_dir: Path | str) -> dict:
+    """Read library/.promoted.jsonl and roll up {promoted_total, rejected_total, pass_rate}.
+
+    Tolerant reader: a malformed line is skipped (never raises — a metrics snapshot must not fail
+    because one historical batch line got corrupted). Verdicts other than "promoted"/"rejected"
+    (e.g. "skipped-unscored" / "score-failed", if a future writer ever appends those here) are
+    counted in neither bucket and do not affect the pass-rate denominator — the rate is
+    specifically "of the artifacts a batch actually GATED, how many passed", not "of everything
+    ever attempted". An absent or empty log yields pass_rate=None (no batch has run yet) rather
+    than 0.0 (which would falsely read as "every batch failed")."""
+    p = Path(library_dir) / PROCESSED_LOG_NAME
+    promoted = 0
+    rejected = 0
+    if p.exists():
+        for line in p.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(rec, dict):
+                continue
+            verdict = rec.get("verdict")
+            if verdict == "promoted":
+                promoted += 1
+            elif verdict == "rejected":
+                rejected += 1
+
+    gated = promoted + rejected
+    pass_rate = (promoted / gated) if gated > 0 else None
+    return {"promoted_total": promoted, "rejected_total": rejected, "promotion_pass_rate": pass_rate}
+
+
+# ---------------------------------------------------------------------------
+# the snapshot writer
+# ---------------------------------------------------------------------------
+def snapshot_library(
+    *,
+    library_dir: Path | str = DEFAULT_LIBRARY_DIR,
+    db_path: Path | str = scores_db.DB_PATH,
+    library_sha: Optional[str] = None,
+    pct_library_sourced: Optional[float] = None,
+    notes: Optional[str] = None,
+    dry_run: bool = False,
+) -> dict:
+    """Compute one library-health reading and append it via scores_db.add_library_metrics.
+
+    Returns the computed payload dict (the exact fields passed to add_library_metrics, plus
+    ``row_id`` when written). Under ``dry_run`` nothing is written and ``row_id`` is omitted — a
+    pure preview of what the snapshot WOULD record (mirrors nightly_harvest.py's / promote.py's own
+    --dry-run contract: compute, report, write nothing).
+    """
+    library_dir = Path(library_dir)
+    counts = scan_library(library_dir)
+    promo = scan_promotion_log(library_dir)
+
+    payload: dict[str, Any] = {
+        "library_sha": library_sha,
+        "size_total": counts["size_total"],
+        "size_by_class_json": counts["size_by_class"],
+        "size_by_tier_json": counts["size_by_tier"],
+        "reuse_count_sum": counts["reuse_count_sum"],
+        "promotion_pass_rate": promo["promotion_pass_rate"],
+        "promoted_total": promo["promoted_total"],
+        "rejected_total": promo["rejected_total"],
+        "pct_library_sourced": pct_library_sourced,
+        "source_path": str(library_dir),
+        "notes": notes,
+    }
+
+    if dry_run:
+        return payload
+
+    row_id = scores_db.add_library_metrics(db_path=db_path, **payload)
+    payload["row_id"] = row_id
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--library", default=str(DEFAULT_LIBRARY_DIR), help="library/ pack root to snapshot")
+    p.add_argument("--db", default=str(scores_db.DB_PATH), help="path to scores.db")
+    p.add_argument("--sha", default=None, help="short git SHA of the repo state this snapshot reads")
+    p.add_argument("--pct-library-sourced", type=float, default=None,
+                   help="0.0-1.0 %% of a run's beats sourced from library/ (HV4 wiring; omit if unmeasured)")
+    p.add_argument("--notes", default=None)
+    p.add_argument("--render", action="store_true",
+                   help="also regenerate qa/library_metrics_ledger.md after the snapshot")
+    p.add_argument("--dry-run", action="store_true",
+                   help="compute + print the snapshot payload; append nothing")
+    args = p.parse_args(argv)
+
+    payload = snapshot_library(
+        library_dir=args.library, db_path=args.db, library_sha=args.sha,
+        pct_library_sourced=args.pct_library_sourced, notes=args.notes, dry_run=args.dry_run,
+    )
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+    if args.render and not args.dry_run:
+        scores_db.render_library_metrics_markdown(args.db)
+        print(f"rendered {scores_db.LIBRARY_METRICS_MD_PATH}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/nightly_harvest.py
+++ b/qa/nightly_harvest.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""nightly_harvest.py — HV5 nightly batch artifact scorer (docs/roadmap/PRODUCT-ROADMAP.md §4c HV5,
+epic #1327, slice 2 of the flywheel-ops sprint).
+
+WHY THIS EXISTS
+---------------
+qa/nominate.py (slice 1, PR #1342) appends candidates to qa/nominations.jsonl on the duo HOT PATH —
+zero extra runs, zero added wall-clock. Per the epic, artifact SCORING is explicitly DEFERRED to a
+nightly batch: "Artifact scoring runs in a NIGHTLY BATCH, never inline — duo wall-clock unchanged."
+This module is that batch. It:
+
+  1. reads the accumulated qa/nominations.jsonl (every line nominate.py has ever appended),
+  2. finds nominations whose artifact_id has NO scored row in the `artifacts` table (qa/scores.db) —
+     "unscored" mirrors promote.py's own definition (row missing OR row.overall is None),
+  3. scores each one via HV1's plain callable panel entrypoint
+     (qa/artifact_score.score_artifact_panel) — the SAME seam promote.py's score_if_unscored calls,
+     so there is exactly ONE place a live LLM panel call happens in the harvest loop,
+  4. records the result via scores_db.add_artifact (artifact_score does this internally), and
+  5. is safe to run unattended (idempotent, resumable, bounded) via an OWN processed-log distinct
+     from tools/library/promote.py's ``.promoted.jsonl`` (this batch's job is SCORING; promotion is a
+     separate, later, human-cadence step over the now-scored rows — see promote.py --batch).
+
+THIS SCRIPT NEVER RUNS LIVE IN A TEST. Every test in qa/test_nightly_harvest.py monkeypatches
+``score_artifact_panel`` (or ``artifact_score.score_artifact`` transitively) to a fabricated stub —
+mirrors qa/test_promote_pipeline.py's ``test_score_if_unscored_is_isolated_from_promotion_path``
+discipline. Actual nightly runs (a live LLM panel) are the orchestrator's job, never CI/pytest.
+
+BOUNDED + RESUMABLE + IDEMPOTENT
+---------------------------------
+* ``--max-per-run`` (default 20) caps how many artifacts ONE invocation scores — an unattended cron
+  must never fan out unboundedly against a spiky queue. Leftover unscored nominations simply wait for
+  the next nightly tick (resumable: no work is lost, nothing is double-counted).
+* A scoring failure (score.sh sentinel / RuntimeError / any exception) for one artifact is caught and
+  recorded as "failed" in this module's own log — it does NOT abort the batch (one bad artifact must
+  never block the rest of the night's queue), and a "failed" artifact is retried on the NEXT run (it
+  is deliberately NOT added to the skip-set) rather than permanently stuck.
+* Idempotent: an artifact_id that already has a scored ``artifacts`` row (overall is not None) is
+  always skipped, regardless of this module's own log — the scores table itself is the source of
+  truth for "already scored" (the same check promote.py's score_if_unscored path relies on).
+* A nomination whose artifact_id cannot be resolved to a loadable artifact JSON (missing
+  ``source_path``, file gone, JSON malformed, or a class/id mismatch) is recorded as "load-failed" and
+  skipped — it never aborts the batch.
+
+CONTRACT (matches qa/nominate.py's record shape + promote.py's reader)
+-----------------------------------------------------------------------
+Reads qa/nominations.jsonl (one JSON object per line; required key ``artifact_id``, optional
+``source_path``). A nomination with no ``source_path`` cannot be scored here (there is nothing to
+load) and is recorded as "load-failed" — the same conservative failure mode promote.py's
+score_if_unscored uses for a missing source_path.
+
+DISCIPLINE
+----------
+* Reads qa/nominations.jsonl + qa/scores.db (``artifacts`` table); writes ONLY new `artifacts` rows
+  (via artifact_score.record_artifact_score) + this module's own JSONL progress log. NEVER touches
+  ``library/`` — promotion stays promote.py's sole responsibility, run separately (and later) once
+  rows here are scored.
+* Additive: an empty or fully-scored queue is a no-op (exit 0, nothing written).
+* OFFLINE-SAFE by construction for every test: the live-scoring call is a single seam
+  (``score_artifact_panel``) that tests replace with a fabricated stub.
+
+USAGE
+-----
+    python3 qa/nightly_harvest.py [--nominations qa/nominations.jsonl] [--db qa/scores.db]
+                                  [--max-per-run 20] [--budget 1.50] [--panel-id ID]
+                                  [--log qa/nightly_harvest_log.jsonl] [--dry-run]
+
+``--dry-run`` reports what WOULD be scored (the resolved, capped work list) and writes nothing (no
+scoring call, no db row, no log line) — the offline preview mirrors promote.py's --dry-run contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+QA_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(QA_DIR))
+import scores_db  # noqa: E402
+
+DEFAULT_NOMINATIONS = QA_DIR / "nominations.jsonl"
+DEFAULT_LOG = QA_DIR / "nightly_harvest_log.jsonl"
+DEFAULT_MAX_PER_RUN = 20
+DEFAULT_BUDGET = "1.50"
+
+
+# ---------------------------------------------------------------------------
+# nomination queue reader (tolerant — mirrors nominate.py's own malformed-line handling, NOT
+# promote.py's fail-loud reader: a nightly batch must never abort on one bad historical line)
+# ---------------------------------------------------------------------------
+def read_nominations(path: Path | str) -> list[dict]:
+    """Read qa/nominations.jsonl -> a list of nomination dicts (one per non-blank, well-formed line).
+
+    A missing file yields [] (nothing nominated yet -> nothing to score). A malformed line is
+    SKIPPED (not raised) — this batch runs unattended over a queue nominate.py has appended to for
+    an arbitrary stretch of time, and one corrupt historical line must never block every future
+    night's scoring."""
+    p = Path(path)
+    if not p.exists():
+        return []
+    out: list[dict] = []
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "artifact_id" in obj:
+            out.append(obj)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# "already scored" check — mirrors promote.py's own definition (row missing OR overall is None)
+# ---------------------------------------------------------------------------
+def _scored_ids(db_path: Path | str) -> set[str]:
+    """artifact_ids that already carry a scored row (``overall`` is not None) in the artifacts table."""
+    return {r["artifact_id"] for r in scores_db.fetch_artifacts(db_path) if r.get("overall") is not None}
+
+
+# ---------------------------------------------------------------------------
+# this module's own resumable progress log (distinct from promote.py's library/.promoted.jsonl —
+# that log tracks PROMOTION outcomes; this one tracks SCORING attempts made by this batch)
+# ---------------------------------------------------------------------------
+def _append_log(log_path: Path, artifact_id: str, verdict: str, *, overall: Optional[float] = None,
+               error: Optional[str] = None) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    rec: dict[str, Any] = {
+        "artifact_id": artifact_id, "verdict": verdict,
+        "at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    if overall is not None:
+        rec["overall"] = overall
+    if error:
+        rec["error"] = error[:500]
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec, sort_keys=True) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# artifact load (mirrors artifact_score.load_artifact's shape checks + promote.py's mismatch guard)
+# ---------------------------------------------------------------------------
+def _load_nomination_artifact(nomination: dict) -> dict:
+    """Load + validate the artifact JSON a nomination points at. Raises ValueError on any problem
+    (missing source_path, unreadable file, malformed JSON, or an artifact_id mismatch) — the caller
+    catches this and records "load-failed" rather than letting one bad nomination abort the batch."""
+    aid = nomination["artifact_id"]
+    src = nomination.get("source_path")
+    if not src:
+        raise ValueError(f"nomination {aid!r} carries no 'source_path' — nothing to load/score")
+    import artifact_score  # local import: keeps this module import-clean when artifact_score is absent
+    artifact = artifact_score.load_artifact(Path(src))
+    if artifact.get("artifact_id") != aid:
+        raise ValueError(
+            f"source_path {src!r} loaded artifact_id {artifact.get('artifact_id')!r}, "
+            f"expected {aid!r} from the nomination — refusing to score a mismatched artifact"
+        )
+    return artifact
+
+
+# ---------------------------------------------------------------------------
+# the batch driver
+# ---------------------------------------------------------------------------
+def harvest_batch(
+    *,
+    nominations_path: Path | str = DEFAULT_NOMINATIONS,
+    db_path: Path | str = scores_db.DB_PATH,
+    max_per_run: int = DEFAULT_MAX_PER_RUN,
+    budget: str = DEFAULT_BUDGET,
+    panel_id: Optional[str] = None,
+    scorer_model: str = "sonnet",
+    log_path: Path | str = DEFAULT_LOG,
+    dry_run: bool = False,
+) -> dict:
+    """Score every UNSCORED nomination, up to ``max_per_run``. Returns a batch report dict.
+
+    Pure w.r.t. everything except: (a) new `artifacts` rows via score_artifact_panel for each
+    artifact actually scored, and (b) an appended line per attempt in ``log_path`` — neither happens
+    under ``dry_run`` (a pure preview of the capped work list, writing nothing, scoring nothing).
+
+    Idempotent: an artifact_id already carrying a scored row (``overall`` is not None) is always
+    skipped, regardless of ``log_path``'s history — the `artifacts` table itself is truth for
+    "already scored". Resumable: nominations beyond ``max_per_run`` are simply left for the next
+    call (nothing here marks them as failed/skipped-forever). Non-fatal: a single artifact's
+    load or scoring failure is caught, logged, and does not stop the rest of the batch.
+    """
+    noms = read_nominations(nominations_path)
+    already_scored = _scored_ids(db_path)
+
+    # De-dup by artifact_id within this batch's candidate list (a nominations.jsonl may carry the
+    # same artifact_id more than once across separate nominate.py runs) — score it at most once.
+    seen: set[str] = set()
+    candidates: list[dict] = []
+    for nom in noms:
+        aid = nom["artifact_id"]
+        if aid in already_scored or aid in seen:
+            continue
+        seen.add(aid)
+        candidates.append(nom)
+
+    work = candidates[:max_per_run]
+    remaining = len(candidates) - len(work)
+
+    report: dict[str, Any] = {
+        "nominations_total": len(noms),
+        "already_scored": len(noms) - len(candidates) if noms else 0,
+        "candidates_unscored": len(candidates),
+        "scored": 0,
+        "load_failed": 0,
+        "score_failed": 0,
+        "remaining_for_next_run": max(remaining, 0),
+        "dry_run": dry_run,
+        "details": [],
+    }
+
+    if dry_run:
+        report["would_score"] = [c["artifact_id"] for c in work]
+        return report
+
+    import artifact_score  # module-level object so tests can monkeypatch score_artifact_panel on it
+
+    log_path = Path(log_path)
+    for nom in work:
+        aid = nom["artifact_id"]
+        try:
+            artifact = _load_nomination_artifact(nom)
+        except (ValueError, OSError, json.JSONDecodeError) as e:
+            report["load_failed"] += 1
+            report["details"].append({"artifact_id": aid, "verdict": "load-failed", "error": str(e)})
+            _append_log(log_path, aid, "load-failed", error=str(e))
+            continue
+
+        try:
+            card = artifact_score.score_artifact_panel(
+                artifact, budget=budget, panel_id=panel_id, scorer_model=scorer_model,
+                source_path=nom.get("source_path"), db_path=db_path,
+            )
+        except Exception as e:  # noqa: BLE001 — one artifact's scoring failure must never abort the batch
+            report["score_failed"] += 1
+            report["details"].append({"artifact_id": aid, "verdict": "score-failed", "error": str(e)})
+            _append_log(log_path, aid, "score-failed", error=str(e))
+            continue
+
+        overall = card.get("overall")
+        report["scored"] += 1
+        report["details"].append({"artifact_id": aid, "verdict": "scored", "overall": overall})
+        _append_log(log_path, aid, "scored", overall=overall)
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--nominations", default=str(DEFAULT_NOMINATIONS))
+    p.add_argument("--db", default=str(scores_db.DB_PATH))
+    p.add_argument("--max-per-run", type=int, default=DEFAULT_MAX_PER_RUN,
+                   help="cap on artifacts scored by ONE invocation (default 20; the queue's "
+                        "remainder waits for the next nightly tick — never fans out unboundedly)")
+    p.add_argument("--budget", default=DEFAULT_BUDGET, help="per-scorer USD budget passed to score.sh")
+    p.add_argument("--panel-id", default=None, help="calibration-panel id to stamp on every row scored "
+                                                     "this batch (None = a lone, non-panel score per "
+                                                     "artifact—never control-valid on its own)")
+    p.add_argument("--scorer-model", default="sonnet")
+    p.add_argument("--log", default=str(DEFAULT_LOG), help="this batch's own resumable progress log")
+    p.add_argument("--dry-run", action="store_true",
+                   help="report the capped work list; score nothing, write nothing")
+    args = p.parse_args(argv)
+
+    if args.max_per_run < 0:
+        p.error(f"--max-per-run must be >= 0 (got {args.max_per_run})")
+
+    report = harvest_batch(
+        nominations_path=args.nominations, db_path=args.db, max_per_run=args.max_per_run,
+        budget=args.budget, panel_id=args.panel_id, scorer_model=args.scorer_model,
+        log_path=args.log, dry_run=args.dry_run,
+    )
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 0  # a nightly batch always exits 0, even with zero scored (mirrors promote.py --batch)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/nightly_harvest.py
+++ b/qa/nightly_harvest.py
@@ -190,15 +190,28 @@ def harvest_batch(
     load or scoring failure is caught, logged, and does not stop the rest of the batch.
     """
     noms = read_nominations(nominations_path)
-    already_scored = _scored_ids(db_path)
+    if dry_run and not Path(db_path).exists():
+        # A --dry-run preview against a not-yet-existing db has nothing scored yet — skip opening
+        # (and thereby schema-initializing) a file dry-run promises to leave untouched on disk.
+        # (An existing db_path — the real nightly-cron case — is always opened so would_score
+        # stays accurate against real scoring history.)
+        already_scored: set[str] = set()
+    else:
+        already_scored = _scored_ids(db_path)
 
     # De-dup by artifact_id within this batch's candidate list (a nominations.jsonl may carry the
     # same artifact_id more than once across separate nominate.py runs) — score it at most once.
+    # already_scored_count is tracked SEPARATELY from the seen-based intra-batch dedup below, so a
+    # same-batch duplicate of an UNSCORED artifact_id is never misreported as "already scored".
     seen: set[str] = set()
     candidates: list[dict] = []
+    already_scored_count = 0
     for nom in noms:
         aid = nom["artifact_id"]
-        if aid in already_scored or aid in seen:
+        if aid in already_scored:
+            already_scored_count += 1
+            continue
+        if aid in seen:
             continue
         seen.add(aid)
         candidates.append(nom)
@@ -208,7 +221,7 @@ def harvest_batch(
 
     report: dict[str, Any] = {
         "nominations_total": len(noms),
-        "already_scored": len(noms) - len(candidates) if noms else 0,
+        "already_scored": already_scored_count,
         "candidates_unscored": len(candidates),
         "scored": 0,
         "load_failed": 0,

--- a/qa/scores_db.py
+++ b/qa/scores_db.py
@@ -567,6 +567,11 @@ def add_library_metrics(
         if _jv is not None and not isinstance(_jv, str):
             fields[_jcol] = json.dumps(_jv, ensure_ascii=False, sort_keys=True)
 
+    for _pcol in ("promotion_pass_rate", "pct_library_sourced"):
+        _pv = fields.get(_pcol)
+        if _pv is not None and not (0.0 <= float(_pv) <= 1.0):
+            raise ValueError(f"{_pcol} must be in [0.0, 1.0], got {_pv!r}")
+
     cols = [c for c in LIBRARY_METRICS_COLUMNS if c in fields]
     vals = [fields[c] for c in cols]
     placeholders = ", ".join("?" for _ in cols)

--- a/qa/scores_db.py
+++ b/qa/scores_db.py
@@ -252,6 +252,46 @@ def _artifact_coltype(col: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# The `library_metrics` table (HV5 slice 2, #1327): the flywheel's OWN eval.
+# ---------------------------------------------------------------------------
+# ADDITIVE and SEPARATE from both `runs` and `artifacts`: this table tracks the HEALTH of the
+# harvest loop itself (library size, reuse, promotion pass-rate), not any single scored run or
+# artifact. Sole writer is qa/library_metrics.py's snapshot_library() (mirrors "add_run is the sole
+# writer of runs" / "add_artifact is the sole writer of artifacts"). One row per SNAPSHOT — taken
+# whenever the owner/cadence wants a reading (nightly, weekly curation, or ad hoc); trend the size/
+# reuse/pass-rate/library-sourced numbers across snapshots exactly like trends_json does for runs.
+# No ruler stamp (ac_/sc_/lc_): this table doesn't SCORE anything — it measures the library's own
+# state, which needs no rubric-version fence.
+LIBRARY_METRICS_COLUMNS: tuple[str, ...] = (
+    "ts",                      # ISO8601 timestamp the snapshot was taken (UTC where known)
+    "library_sha",             # short git SHA of the repo state the snapshot was read at (NULL if unknown)
+    "size_total",              # total entry count across every class/tier in library/
+    "size_by_class_json",      # JSON {quest: N, npc: N, location: N, encounter: N, room: N}
+    "size_by_tier_json",       # JSON {experimental: N, stable: N, canonical: N}
+    "reuse_count_sum",         # Σ reuse_count over every entry (HV4's "less AI dependence" numerator)
+    "promotion_pass_rate",     # promoted / (promoted + rejected) over promote.py's processed-log,
+                               # 0.0-1.0, NULL if the log is absent/empty (no batch run yet)
+    "promoted_total",          # count of "promoted" lines in library/.promoted.jsonl
+    "rejected_total",          # count of "rejected" lines in library/.promoted.jsonl
+    "pct_library_sourced",     # % of a run's beats sourced from library/ vs freshly AI-generated,
+                               # 0.0-1.0, NULL if not measured this snapshot (HV4 wiring; additive)
+    "source_path",             # where the snapshot's evidence lives (library dir path read)
+    "notes",                   # free-text context / caveats
+)
+
+_LIBRARY_METRICS_REAL_COLS = {"promotion_pass_rate", "pct_library_sourced"}
+_LIBRARY_METRICS_INT_COLS = {"size_total", "reuse_count_sum", "promoted_total", "rejected_total"}
+
+
+def _library_metrics_coltype(col: str) -> str:
+    if col in _LIBRARY_METRICS_REAL_COLS:
+        return "REAL"
+    if col in _LIBRARY_METRICS_INT_COLS:
+        return "INTEGER"
+    return "TEXT"
+
+
+# ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
 def connect(db_path: Path | str = DB_PATH) -> sqlite3.Connection:
@@ -275,6 +315,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         if col not in existing:
             conn.execute(f'ALTER TABLE runs ADD COLUMN "{col}" {_coltype(col)}')
     _ensure_artifacts_schema(conn)
+    _ensure_library_metrics_schema(conn)
     conn.commit()
 
 
@@ -293,6 +334,26 @@ def _ensure_artifacts_schema(conn: sqlite3.Connection) -> None:
         for col in ARTIFACT_COLUMNS:
             if col not in existing:
                 conn.execute(f'ALTER TABLE artifacts ADD COLUMN "{col}" {_artifact_coltype(col)}')
+
+
+def _ensure_library_metrics_schema(conn: sqlite3.Connection) -> None:
+    """Create the `library_metrics` table if missing; additively ALTER in any new
+    LIBRARY_METRICS_COLUMNS. Purely additive: on an existing db this ONLY creates a new table (and
+    back-fills any new column) — it never alters `runs` or `artifacts`. Unlike those two tables,
+    snapshots have no natural single-column key (a library can be snapshotted many times), so the
+    row id is a plain autoincrementing integer, not a caller-supplied PK."""
+    cols_ddl = ",\n  ".join(f'"{c}" {_library_metrics_coltype(c)}' for c in LIBRARY_METRICS_COLUMNS)
+    conn.execute(
+        f'CREATE TABLE IF NOT EXISTS library_metrics (\n'
+        f'  "id" INTEGER PRIMARY KEY AUTOINCREMENT,\n  {cols_ddl}\n)'
+    )
+    existing = {r["name"] for r in conn.execute('PRAGMA table_info(library_metrics)')}
+    if existing:  # table already existed → back-fill any newly-added columns
+        for col in LIBRARY_METRICS_COLUMNS:
+            if col not in existing:
+                conn.execute(
+                    f'ALTER TABLE library_metrics ADD COLUMN "{col}" {_library_metrics_coltype(col)}'
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -468,6 +529,66 @@ def fetch_artifacts(db_path: Path | str = DB_PATH) -> list[dict]:
     try:
         rows = conn.execute(
             "SELECT * FROM artifacts ORDER BY ts DESC, artifact_id DESC"
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# The one append helper every future LIBRARY_METRICS snapshot should call (HV5 slice 2, #1327)
+# ---------------------------------------------------------------------------
+def add_library_metrics(
+    *,
+    db_path: Path | str = DB_PATH,
+    **fields: Any,
+) -> int:
+    """Append ONE library-health snapshot row to the additive `library_metrics` table.
+
+    Mirrors :func:`add_run` / :func:`add_artifact`'s validation discipline, but writes the SEPARATE
+    `library_metrics` table and NEVER touches `runs` or `artifacts`. Pass any subset of
+    :data:`LIBRARY_METRICS_COLUMNS` as keyword args. Unknown keys raise (a typo is caught, not
+    silently dropped). ``size_by_class_json`` / ``size_by_tier_json`` may be passed as dicts and are
+    JSON-encoded automatically. ``ts`` defaults to now (UTC, ISO8601) if omitted. Unlike ``runs``/
+    ``artifacts``, there is no caller-supplied id — every call INSERTS a new row (a snapshot never
+    replaces a prior one; the row id is autoincrement). Returns the new row's integer id.
+    """
+    unknown = set(fields) - set(LIBRARY_METRICS_COLUMNS)
+    if unknown:
+        raise ValueError(
+            f"unknown field(s) {sorted(unknown)}; valid: {sorted(LIBRARY_METRICS_COLUMNS)}"
+        )
+
+    if fields.get("ts") is None:
+        fields["ts"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    for _jcol in ("size_by_class_json", "size_by_tier_json"):
+        _jv = fields.get(_jcol)
+        if _jv is not None and not isinstance(_jv, str):
+            fields[_jcol] = json.dumps(_jv, ensure_ascii=False, sort_keys=True)
+
+    cols = [c for c in LIBRARY_METRICS_COLUMNS if c in fields]
+    vals = [fields[c] for c in cols]
+    placeholders = ", ".join("?" for _ in cols)
+    quoted = ", ".join(f'"{c}"' for c in cols)
+
+    own = isinstance(db_path, (str, os.PathLike))
+    conn = connect(db_path) if own else db_path  # type: ignore[arg-type]
+    try:
+        cur = conn.execute(f"INSERT INTO library_metrics ({quoted}) VALUES ({placeholders})", vals)
+        conn.commit()
+        return int(cur.lastrowid)
+    finally:
+        if own:
+            conn.close()
+
+
+def fetch_library_metrics(db_path: Path | str = DB_PATH) -> list[dict]:
+    """Return all `library_metrics` snapshot rows as dicts, newest-first (ts desc, then id desc)."""
+    conn = connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT * FROM library_metrics ORDER BY ts DESC, id DESC"
         ).fetchall()
         return [dict(r) for r in rows]
     finally:
@@ -754,6 +875,69 @@ def render_artifacts_markdown(db_path: Path | str = DB_PATH,
             v = r.get(key)
             if key == "is_control" and v is not None:
                 v = "control" if int(v) else ""
+            cells.append(_fmt(v))
+        out.append("| " + " | ".join(cells) + " |")
+    out.append("")
+    text = "\n".join(out)
+    Path(md_path).write_text(text, encoding="utf-8")
+    return text
+
+
+LIBRARY_METRICS_MD_PATH = QA_DIR / "library_metrics_ledger.md"
+
+_LIBRARY_METRICS_MD_COLS = [
+    ("ts", "When"),
+    ("library_sha", "SHA"),
+    ("size_total", "Size"),
+    ("size_by_class_json", "By class"),
+    ("size_by_tier_json", "By tier"),
+    ("reuse_count_sum", "Σreuse"),
+    ("promotion_pass_rate", "Promo pass%"),
+    ("promoted_total", "Promoted"),
+    ("rejected_total", "Rejected"),
+    ("pct_library_sourced", "Lib-sourced%"),
+    ("source_path", "Source"),
+    ("notes", "Notes"),
+]
+
+
+def render_library_metrics_markdown(db_path: Path | str = DB_PATH,
+                                    md_path: Path | str = LIBRARY_METRICS_MD_PATH) -> str:
+    """Deterministic Markdown mirror of the `library_metrics` table (HV5 slice 2, #1327). Separate
+    from both the runs ledger and the artifacts ledger — THE FLYWHEEL'S OWN EVAL: how big the library
+    is, how much it's reused, how often promotion passes, and (once HV4 wires it) what fraction of a
+    run's beats came from the library instead of fresh AI generation — the "less AI dependence" trend
+    the epic names, read as a number over time instead of eyeballed."""
+    rows = fetch_library_metrics(db_path)
+    out: list[str] = []
+    out.append("# WorldOS Library Metrics Ledger — the flywheel's own eval")
+    out.append("")
+    out.append(
+        "> **Auto-generated from `qa/scores.db` (`library_metrics` table) — do not hand-edit.** "
+        "Regenerate with `python3 qa/scores_db.py --render-library-metrics`. Rows are appended via "
+        "`qa/scores_db.add_library_metrics(...)`, called by `qa/library_metrics.py`'s "
+        "`snapshot_library()` (its sole writer). One row per SNAPSHOT of the harvest loop's own "
+        "health — library size, Σreuse_count, promotion pass-rate, and (once HV4 wires it) "
+        "%library-sourced beats per run."
+    )
+    out.append(
+        "> **Promo pass%** = promoted / (promoted + rejected) over "
+        "`library/.promoted.jsonl` (promote.py's processed-log); blank when no batch has run yet. "
+        "**Lib-sourced%** stays blank until HV4 wires per-run library-vs-fresh-gen attribution — "
+        "an unset column here is today's expected state, not a bug."
+    )
+    out.append(f"> Rows: **{len(rows)}** · rendered {datetime.now(timezone.utc).isoformat(timespec='seconds')}")
+    out.append("")
+    header = "| " + " | ".join(label for _, label in _LIBRARY_METRICS_MD_COLS) + " |"
+    sep = "|" + "|".join("---" for _ in _LIBRARY_METRICS_MD_COLS) + "|"
+    out.append(header)
+    out.append(sep)
+    for r in rows:
+        cells = []
+        for key, _ in _LIBRARY_METRICS_MD_COLS:
+            v = r.get(key)
+            if key in ("promotion_pass_rate", "pct_library_sourced") and v is not None:
+                v = f"{float(v) * 100:.0f}%"
             cells.append(_fmt(v))
         out.append("| " + " | ".join(cells) + " |")
     out.append("")
@@ -1202,6 +1386,15 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--artifact-id", dest="artifact_id", default=None)
     for col in ARTIFACT_COLUMNS:
         p.add_argument(f"--artifact-{col.replace('_', '-')}", dest=f"artifact__{col}", default=None)
+    # --- HV5 library_metrics table (separate; --libmetric-<col> flags) ---
+    p.add_argument("--add-library-metrics", action="store_true",
+                   help="append one library-health snapshot from the --libmetric-* flags below")
+    p.add_argument("--list-library-metrics", action="store_true",
+                   help="print library_metrics rows (newest first) as JSON")
+    p.add_argument("--render-library-metrics", action="store_true",
+                   help="regenerate qa/library_metrics_ledger.md from the library_metrics table")
+    for col in LIBRARY_METRICS_COLUMNS:
+        p.add_argument(f"--libmetric-{col.replace('_', '-')}", dest=f"libmetric__{col}", default=None)
     return p
 
 
@@ -1247,6 +1440,21 @@ def main(argv: Optional[list[str]] = None) -> int:
     if args.list_artifacts:
         print(json.dumps(fetch_artifacts(db), indent=2, ensure_ascii=False))
 
+    if args.add_library_metrics:
+        lfields = {c: getattr(args, f"libmetric__{c}") for c in LIBRARY_METRICS_COLUMNS
+                  if getattr(args, f"libmetric__{c}") is not None}
+        for c in _LIBRARY_METRICS_REAL_COLS:
+            if c in lfields:
+                lfields[c] = float(lfields[c])
+        for c in _LIBRARY_METRICS_INT_COLS:
+            if c in lfields:
+                lfields[c] = int(lfields[c])
+        new_id = add_library_metrics(db_path=db, **lfields)
+        print(f"added library_metrics snapshot id={new_id}")
+
+    if args.list_library_metrics:
+        print(json.dumps(fetch_library_metrics(db), indent=2, ensure_ascii=False))
+
     if args.render:
         render_markdown(db)
         print(f"rendered {MD_PATH} ({len(fetch_rows(db))} rows)")
@@ -1254,6 +1462,10 @@ def main(argv: Optional[list[str]] = None) -> int:
     if args.render_artifacts:
         render_artifacts_markdown(db)
         print(f"rendered {ARTIFACTS_MD_PATH} ({len(fetch_artifacts(db))} rows)")
+
+    if args.render_library_metrics:
+        render_library_metrics_markdown(db)
+        print(f"rendered {LIBRARY_METRICS_MD_PATH} ({len(fetch_library_metrics(db))} rows)")
 
     if args.compare:
         print(compare_rc(db, rc=args.rc, include_rc_surface=args.compare_rc_surface))
@@ -1281,7 +1493,9 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     if not any([args.init, args.add, args.list, args.render, args.compare,
                 args.trends_json, args.reconcile, args.release_verdict_rri,
-                args.add_artifact, args.list_artifacts, args.render_artifacts]):
+                args.add_artifact, args.list_artifacts, args.render_artifacts,
+                args.add_library_metrics, args.list_library_metrics,
+                args.render_library_metrics]):
         _build_parser().print_help()
     return 0
 

--- a/qa/test_library_metrics.py
+++ b/qa/test_library_metrics.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""test_library_metrics.py — HV5 library_metrics table + snapshot writer (epic #1327, slice 2).
+
+Covers two things:
+  1. qa/scores_db.py's additive `library_metrics` table (schema, add_library_metrics,
+     fetch_library_metrics, render_library_metrics_markdown) — mirrors
+     qa/test_artifact_evals.py's schema round-trip coverage for the `artifacts` table.
+  2. qa/library_metrics.py's scan_library / scan_promotion_log / snapshot_library — a pure
+     filesystem + sqlite reader/writer over a FABRICATED library/ tree (never the committed
+     library/ or qa/scores.db). Pure-stdlib; no LLM, no subprocess, no network. Run:
+
+    uv run --directory servers/engine python -m pytest ../../qa/test_library_metrics.py -q -p no:xdist
+or:
+    python3 -m pytest qa/test_library_metrics.py -q -p no:xdist
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+QA_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(QA_DIR))
+
+import scores_db  # noqa: E402
+import library_metrics  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# scores_db.py schema additions
+# ---------------------------------------------------------------------------
+def test_library_metrics_coltype_mapping():
+    assert scores_db._library_metrics_coltype("size_total") == "INTEGER"
+    assert scores_db._library_metrics_coltype("reuse_count_sum") == "INTEGER"
+    assert scores_db._library_metrics_coltype("promotion_pass_rate") == "REAL"
+    assert scores_db._library_metrics_coltype("pct_library_sourced") == "REAL"
+    assert scores_db._library_metrics_coltype("library_sha") == "TEXT"
+    assert scores_db._library_metrics_coltype("size_by_class_json") == "TEXT"
+
+
+def test_add_library_metrics_and_fetch_roundtrip(tmp_path):
+    db = tmp_path / "t.db"
+    row_id = scores_db.add_library_metrics(
+        db_path=db, library_sha="abc1234", size_total=5,
+        size_by_class_json={"quest": 3, "npc": 2}, size_by_tier_json={"stable": 5},
+        reuse_count_sum=12, promotion_pass_rate=0.8, promoted_total=4, rejected_total=1,
+        source_path="library/", notes="test snapshot",
+    )
+    assert isinstance(row_id, int)
+    rows = scores_db.fetch_library_metrics(db)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["library_sha"] == "abc1234"
+    assert r["size_total"] == 5
+    assert json.loads(r["size_by_class_json"]) == {"quest": 3, "npc": 2}
+    assert json.loads(r["size_by_tier_json"]) == {"stable": 5}
+    assert r["reuse_count_sum"] == 12
+    assert r["promotion_pass_rate"] == 0.8
+    assert r["ts"] is not None  # auto-stamped
+
+
+def test_add_library_metrics_rejects_unknown_field(tmp_path):
+    with pytest.raises(ValueError):
+        scores_db.add_library_metrics(db_path=tmp_path / "t.db", bogus=1)
+
+
+def test_add_library_metrics_never_touches_runs_or_artifacts(tmp_path):
+    db = tmp_path / "t.db"
+    scores_db.add_run("r1", db_path=db, surface="engine-duo", story_overall=4.5)
+    scores_db.add_artifact("a1", db_path=db, **{"class": "quest"}, overall=4.0)
+    scores_db.add_library_metrics(db_path=db, size_total=1)
+
+    assert len(scores_db.fetch_rows(db)) == 1
+    assert len(scores_db.fetch_artifacts(db)) == 1
+    assert len(scores_db.fetch_library_metrics(db)) == 1
+
+
+def test_each_call_appends_a_new_row_not_a_replace(tmp_path):
+    """Unlike add_run/add_artifact (INSERT OR REPLACE keyed on a caller id), library_metrics has
+    no natural key — every call is a fresh time-series point."""
+    db = tmp_path / "t.db"
+    scores_db.add_library_metrics(db_path=db, size_total=1)
+    scores_db.add_library_metrics(db_path=db, size_total=2)
+    scores_db.add_library_metrics(db_path=db, size_total=3)
+    rows = scores_db.fetch_library_metrics(db)
+    assert len(rows) == 3
+    assert sorted(r["size_total"] for r in rows) == [1, 2, 3]
+
+
+def test_fetch_library_metrics_newest_first(tmp_path):
+    db = tmp_path / "t.db"
+    scores_db.add_library_metrics(db_path=db, ts="2026-07-01T00:00:00+00:00", size_total=1)
+    scores_db.add_library_metrics(db_path=db, ts="2026-07-02T00:00:00+00:00", size_total=2)
+    rows = scores_db.fetch_library_metrics(db)
+    assert [r["size_total"] for r in rows] == [2, 1]
+
+
+def test_empty_table_fetch_is_empty_list(tmp_path):
+    db = tmp_path / "t.db"
+    scores_db.connect(db).close()  # ensure schema exists, zero rows
+    assert scores_db.fetch_library_metrics(db) == []
+
+
+def test_render_library_metrics_markdown_writes_file(tmp_path):
+    db = tmp_path / "t.db"
+    md = tmp_path / "out.md"
+    scores_db.add_library_metrics(db_path=db, size_total=2, promotion_pass_rate=0.5)
+    text = scores_db.render_library_metrics_markdown(db, md)
+    assert md.exists()
+    assert "Library Metrics Ledger" in text
+    assert "50%" in text  # promotion_pass_rate rendered as a percentage
+
+
+def test_render_library_metrics_markdown_empty_db(tmp_path):
+    db = tmp_path / "t.db"
+    md = tmp_path / "out.md"
+    scores_db.connect(db).close()
+    text = scores_db.render_library_metrics_markdown(db, md)
+    assert "Rows: **0**" in text
+
+
+# ---------------------------------------------------------------------------
+# library_metrics.py — scan_library (a fabricated library/ tree)
+# ---------------------------------------------------------------------------
+def _entry(tier="stable", reuse_count=0, **extra) -> dict:
+    e = {"artifact_id": "x", "class": "quest", "tier": tier, "reuse_count": reuse_count,
+        "provenance": {}, "scores": {"overall": 4.2, "dims": {"d": 4.2}}, "license": "proprietary",
+        "promoted_at": "2026-07-06T00:00:00+00:00"}
+    e.update(extra)
+    return e
+
+
+def _write_entry(library_dir: Path, subdir: str, filename: str, entry: dict) -> None:
+    d = library_dir / subdir
+    d.mkdir(parents=True, exist_ok=True)
+    (d / filename).write_text(json.dumps(entry), encoding="utf-8")
+
+
+def test_scan_empty_or_missing_library_is_all_zero(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    result = library_metrics.scan_library(missing)
+    assert result["size_total"] == 0
+    assert result["size_by_class"] == {}
+    assert result["size_by_tier"] == {"experimental": 0, "stable": 0, "canonical": 0}
+    assert result["reuse_count_sum"] == 0
+
+
+def test_scan_counts_size_by_class_and_tier(tmp_path):
+    lib = tmp_path / "library"
+    _write_entry(lib, "quests", "q1.json", _entry(tier="stable"))
+    _write_entry(lib, "quests", "q2.json", _entry(tier="experimental"))
+    _write_entry(lib, "npcs", "n1.json", _entry(tier="stable"))
+
+    result = library_metrics.scan_library(lib)
+
+    assert result["size_total"] == 3
+    assert result["size_by_class"] == {"quest": 2, "npc": 1}
+    assert result["size_by_tier"] == {"experimental": 1, "stable": 2, "canonical": 0}
+
+
+def test_scan_sums_reuse_count(tmp_path):
+    lib = tmp_path / "library"
+    _write_entry(lib, "quests", "q1.json", _entry(reuse_count=3))
+    _write_entry(lib, "quests", "q2.json", _entry(reuse_count=7))
+    _write_entry(lib, "npcs", "n1.json", _entry(reuse_count=0))
+
+    result = library_metrics.scan_library(lib)
+
+    assert result["reuse_count_sum"] == 10
+
+
+def test_scan_ignores_non_class_files(tmp_path):
+    lib = tmp_path / "library"
+    lib.mkdir(parents=True)
+    (lib / "pack.json").write_text("{}", encoding="utf-8")
+    (lib / ".promoted.jsonl").write_text("", encoding="utf-8")
+
+    result = library_metrics.scan_library(lib)
+
+    assert result["size_total"] == 0  # pack.json / .promoted.jsonl live at the root, not a class subdir
+
+
+def test_scan_malformed_entry_counted_in_size_but_not_reuse_or_tier(tmp_path):
+    lib = tmp_path / "library"
+    d = lib / "quests"
+    d.mkdir(parents=True)
+    (d / "broken.json").write_text("not valid json{{{", encoding="utf-8")
+
+    result = library_metrics.scan_library(lib)
+
+    assert result["size_total"] == 1  # occupies a library slot
+    assert result["reuse_count_sum"] == 0
+    assert result["size_by_tier"] == {"experimental": 0, "stable": 0, "canonical": 0}
+
+
+def test_scan_unrecognized_tier_not_counted_in_any_tier_bucket(tmp_path):
+    lib = tmp_path / "library"
+    _write_entry(lib, "quests", "q1.json", _entry(tier="bogus-tier"))
+    result = library_metrics.scan_library(lib)
+    assert result["size_total"] == 1
+    assert sum(result["size_by_tier"].values()) == 0
+
+
+# ---------------------------------------------------------------------------
+# library_metrics.py — scan_promotion_log
+# ---------------------------------------------------------------------------
+def _write_promoted_log(library_dir: Path, lines: list[dict]) -> None:
+    library_dir.mkdir(parents=True, exist_ok=True)
+    (library_dir / ".promoted.jsonl").write_text(
+        "\n".join(json.dumps(l) for l in lines) + ("\n" if lines else ""), encoding="utf-8"
+    )
+
+
+def test_promotion_log_missing_yields_none_pass_rate(tmp_path):
+    lib = tmp_path / "library"
+    result = library_metrics.scan_promotion_log(lib)
+    assert result == {"promoted_total": 0, "rejected_total": 0, "promotion_pass_rate": None}
+
+
+def test_promotion_log_empty_yields_none_pass_rate(tmp_path):
+    lib = tmp_path / "library"
+    _write_promoted_log(lib, [])
+    result = library_metrics.scan_promotion_log(lib)
+    assert result["promotion_pass_rate"] is None
+
+
+def test_promotion_log_pass_rate_computed(tmp_path):
+    lib = tmp_path / "library"
+    _write_promoted_log(lib, [
+        {"artifact_id": "a1", "verdict": "promoted", "tier": "stable"},
+        {"artifact_id": "a2", "verdict": "promoted", "tier": "stable"},
+        {"artifact_id": "a3", "verdict": "promoted", "tier": "stable"},
+        {"artifact_id": "a4", "verdict": "rejected", "tier": None},
+    ])
+    result = library_metrics.scan_promotion_log(lib)
+    assert result["promoted_total"] == 3
+    assert result["rejected_total"] == 1
+    assert result["promotion_pass_rate"] == pytest.approx(0.75)
+
+
+def test_promotion_log_skipped_unscored_not_counted_in_pass_rate_denominator(tmp_path):
+    lib = tmp_path / "library"
+    _write_promoted_log(lib, [
+        {"artifact_id": "a1", "verdict": "promoted", "tier": "stable"},
+        {"artifact_id": "a2", "verdict": "skipped-unscored", "tier": None},
+        {"artifact_id": "a3", "verdict": "score-failed", "tier": None},
+    ])
+    result = library_metrics.scan_promotion_log(lib)
+    # only the ONE gated (promoted) line counts; the two non-gated verdicts are excluded entirely
+    assert result["promoted_total"] == 1
+    assert result["rejected_total"] == 0
+    assert result["promotion_pass_rate"] == 1.0
+
+
+def test_promotion_log_malformed_line_skipped_not_fatal(tmp_path):
+    lib = tmp_path / "library"
+    lib.mkdir(parents=True)
+    (lib / ".promoted.jsonl").write_text(
+        "not json\n" + json.dumps({"artifact_id": "a1", "verdict": "promoted"}) + "\n",
+        encoding="utf-8",
+    )
+    result = library_metrics.scan_promotion_log(lib)
+    assert result["promoted_total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# library_metrics.py — snapshot_library (the writer, end to end over a fabricated library/)
+# ---------------------------------------------------------------------------
+def test_snapshot_library_writes_one_row_reflecting_known_state(tmp_path):
+    lib = tmp_path / "library"
+    db = tmp_path / "scores.db"
+    _write_entry(lib, "quests", "q1.json", _entry(tier="stable", reuse_count=5))
+    _write_entry(lib, "npcs", "n1.json", _entry(tier="stable", reuse_count=2))
+    _write_promoted_log(lib, [
+        {"artifact_id": "q1", "verdict": "promoted", "tier": "stable"},
+        {"artifact_id": "x2", "verdict": "rejected", "tier": None},
+    ])
+
+    payload = library_metrics.snapshot_library(library_dir=lib, db_path=db, library_sha="deadbeef")
+
+    assert payload["row_id"] is not None
+    rows = scores_db.fetch_library_metrics(db)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["library_sha"] == "deadbeef"
+    assert r["size_total"] == 2
+    assert json.loads(r["size_by_class_json"]) == {"quest": 1, "npc": 1}
+    assert json.loads(r["size_by_tier_json"]) == {"experimental": 0, "stable": 2, "canonical": 0}
+    assert r["reuse_count_sum"] == 7
+    assert r["promoted_total"] == 1
+    assert r["rejected_total"] == 1
+    assert r["promotion_pass_rate"] == pytest.approx(0.5)
+    assert r["source_path"] == str(lib)
+
+
+def test_snapshot_library_pct_library_sourced_defaults_to_none(tmp_path):
+    lib = tmp_path / "library"
+    db = tmp_path / "scores.db"
+    library_metrics.snapshot_library(library_dir=lib, db_path=db)
+    rows = scores_db.fetch_library_metrics(db)
+    assert rows[0]["pct_library_sourced"] is None
+
+
+def test_snapshot_library_pct_library_sourced_can_be_supplied(tmp_path):
+    lib = tmp_path / "library"
+    db = tmp_path / "scores.db"
+    library_metrics.snapshot_library(library_dir=lib, db_path=db, pct_library_sourced=0.35)
+    rows = scores_db.fetch_library_metrics(db)
+    assert rows[0]["pct_library_sourced"] == 0.35
+
+
+def test_snapshot_library_dry_run_writes_nothing(tmp_path):
+    lib = tmp_path / "library"
+    db = tmp_path / "scores.db"
+    _write_entry(lib, "quests", "q1.json", _entry())
+
+    payload = library_metrics.snapshot_library(library_dir=lib, db_path=db, dry_run=True)
+
+    assert "row_id" not in payload
+    assert payload["size_total"] == 1
+    assert not db.exists()  # dry-run never even opens/creates the db
+
+
+def test_snapshot_library_two_calls_append_two_rows_time_series(tmp_path):
+    lib = tmp_path / "library"
+    db = tmp_path / "scores.db"
+    _write_entry(lib, "quests", "q1.json", _entry())
+    library_metrics.snapshot_library(library_dir=lib, db_path=db)
+    _write_entry(lib, "quests", "q2.json", _entry())
+    library_metrics.snapshot_library(library_dir=lib, db_path=db)
+
+    rows = scores_db.fetch_library_metrics(db)
+    assert len(rows) == 2
+    sizes = sorted(json.loads(r["size_total"]) if isinstance(r["size_total"], str) else r["size_total"]
+                   for r in rows)
+    assert sizes == [1, 2]
+
+
+def test_snapshot_library_never_writes_into_library_dir(tmp_path):
+    """This module is a READER of library/ — it must never create/modify anything under it (that
+    stays promote.py's sole-writer job)."""
+    lib = tmp_path / "library"
+    db = tmp_path / "scores.db"
+    _write_entry(lib, "quests", "q1.json", _entry())
+    before = sorted(p.name for p in lib.rglob("*"))
+
+    library_metrics.snapshot_library(library_dir=lib, db_path=db)
+
+    after = sorted(p.name for p in lib.rglob("*"))
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def test_cli_dry_run_prints_payload_and_writes_nothing(tmp_path, capsys):
+    lib = tmp_path / "library"
+    db = tmp_path / "scores.db"
+    _write_entry(lib, "quests", "q1.json", _entry())
+
+    rc = library_metrics.main(["--library", str(lib), "--db", str(db), "--dry-run"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["size_total"] == 1
+    assert not db.exists()
+
+
+def test_cli_writes_and_renders(tmp_path, capsys, monkeypatch):
+    """--render must call scores_db.render_library_metrics_markdown after the snapshot. The real
+    render function's md_path default is bound (at import time) to the real repo path — like every
+    other --render* flag in this codebase (scores_db.py's own --render/--render-artifacts have no
+    output-path override either) — so this test verifies the CALL happens via a monkeypatched
+    render function, rather than trying to redirect the module-level path constant (which a bound
+    default argument would not observe)."""
+    lib = tmp_path / "library"
+    db = tmp_path / "scores.db"
+    _write_entry(lib, "quests", "q1.json", _entry())
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        scores_db, "render_library_metrics_markdown",
+        lambda db_path=None: calls.append(str(db_path)),
+    )
+
+    rc = library_metrics.main(["--library", str(lib), "--db", str(db), "--render"])
+
+    assert rc == 0
+    assert len(scores_db.fetch_library_metrics(db)) == 1
+    assert calls == [str(db)]  # rendered exactly once, against the snapshot's own db

--- a/qa/test_nightly_harvest.py
+++ b/qa/test_nightly_harvest.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""test_nightly_harvest.py — HV5 nightly batch artifact scorer (epic #1327, slice 2).
+
+Exercises the batch PATH fully OFFLINE: every test fabricates its own nominations.jsonl + a temp
+artifacts_out tree of loadable artifact JSONs + a temp scores.db, and monkeypatches
+``artifact_score.score_artifact_panel`` to a fabricated stub — mirrors
+qa/test_promote_pipeline.py's ``test_score_if_unscored_is_isolated_from_promotion_path`` discipline.
+NO test invokes score.sh / a live claude -p. Run:
+
+    uv run --directory servers/engine --group dev python -m pytest ../../qa/test_nightly_harvest.py -q -p no:xdist
+or:
+    python3 -m pytest qa/test_nightly_harvest.py -q -p no:xdist
+
+Invariant assertions live here:
+  * scores ONLY unscored nominations (an already-scored artifact_id is never re-scored/re-billed).
+  * idempotent: re-running after a full batch scores nothing new.
+  * resumable: --max-per-run caps one invocation; the remainder is picked up by the next call.
+  * bounded: --max-per-run never over-scores; a negative cap is rejected at the CLI.
+  * one artifact's load/score failure never aborts the rest of the batch (non-fatal isolation).
+  * dry-run writes nothing and calls the scorer zero times.
+  * writes ONLY new `artifacts` rows + its own log — never touches library/ (promotion stays separate).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+QA_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(QA_DIR))
+
+import scores_db  # noqa: E402
+import artifact_score  # noqa: E402
+import nightly_harvest  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# fabrication helpers
+# ---------------------------------------------------------------------------
+def _artifact_json(artifacts_dir: Path, artifact_id: str, cls: str = "quest", **payload_extra) -> Path:
+    """Write a loadable artifact JSON (satisfies artifact_score.load_artifact's canonical shape)."""
+    payload = {
+        "quest": {"id": artifact_id, "name": artifact_id, "objectives": ["o1"],
+                  "completed_objectives": ["o1"], "resolution_status": "completed",
+                  "evolves_to": None, "consequences": []},
+        "npc": {"id": artifact_id, "name": artifact_id, "voice_id": "v1", "personality": "p",
+                "attitude_arc": [], "final_status": "ally", "dialogue_snippets": ["a", "b", "c"]},
+    }[cls]
+    payload.update(payload_extra)
+    obj = {
+        "artifact_id": artifact_id, "class": cls, "world": "baldurs-gate",
+        "provenance": {"campaign_id": "bg", "run_id": "run-hi", "sha": "deadbeef"},
+        "payload": payload, "scores": None,
+    }
+    p = artifacts_dir / f"{artifact_id.replace(':', '_')}.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return p
+
+
+def _write_noms(path: Path, records: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n" if records else "",
+                    encoding="utf-8")
+
+
+def _nom(artifact_id: str, source_path) -> dict:
+    return {"artifact_id": artifact_id, "source_path": str(source_path) if source_path else None}
+
+
+@pytest.fixture
+def env(tmp_path):
+    return {
+        "db": tmp_path / "scores.db",
+        "artifacts_out": tmp_path / "artifacts_out",
+        "noms": tmp_path / "nominations.jsonl",
+        "log": tmp_path / "nightly_harvest_log.jsonl",
+    }
+
+
+@pytest.fixture
+def fake_panel(monkeypatch):
+    """A deterministic, offline stand-in for artifact_score.score_artifact_panel: no score.sh, no
+    subprocess, no network. Records a fixed overall + records the artifacts-table row exactly like
+    the real function does (via record_artifact_score), so downstream idempotency checks (reading
+    scores_db.fetch_artifacts) behave identically to a live run."""
+    calls: list[str] = []
+
+    def _fake(artifact, *, budget="1.50", panel_id=None, scorer_model="sonnet", is_control=False,
+              control_anchor=None, source_path=None, db_path=scores_db.DB_PATH):
+        calls.append(artifact["artifact_id"])
+        card = {"overall": 4.4, "scores": {"d1": 4.4, "d2": 4.4}}
+        artifact_score.record_artifact_score(
+            artifact, card, panel_id=panel_id, scorer_model=scorer_model, is_control=is_control,
+            control_anchor=control_anchor, source_path=source_path, db_path=db_path,
+        )
+        return card
+
+    monkeypatch.setattr(artifact_score, "score_artifact_panel", _fake)
+    return calls
+
+
+@pytest.fixture
+def failing_panel(monkeypatch):
+    """A scorer stub that always raises — for the non-fatal-isolation test."""
+    def _fake(*a, **k):
+        raise RuntimeError("score.sh sentinel: quota_exhausted")
+    monkeypatch.setattr(artifact_score, "score_artifact_panel", _fake)
+
+
+def _run(env, **kw):
+    return nightly_harvest.harvest_batch(
+        nominations_path=env["noms"], db_path=env["db"], log_path=env["log"], **kw
+    )
+
+
+# ---------------------------------------------------------------------------
+# scores only unscored nominations
+# ---------------------------------------------------------------------------
+def test_scores_unscored_nomination(env, fake_panel):
+    p = _artifact_json(env["artifacts_out"], "quest:bg:q1")
+    _write_noms(env["noms"], [_nom("quest:bg:q1", p)])
+
+    report = _run(env)
+
+    assert report["scored"] == 1
+    assert fake_panel == ["quest:bg:q1"]
+    rows = scores_db.fetch_artifacts(env["db"])
+    assert len(rows) == 1
+    assert rows[0]["artifact_id"] == "quest:bg:q1"
+    assert rows[0]["overall"] == 4.4
+
+
+def test_already_scored_artifact_is_not_rescored(env, fake_panel):
+    p = _artifact_json(env["artifacts_out"], "quest:bg:q1")
+    scores_db.add_artifact("quest:bg:q1", db_path=env["db"], **{"class": "quest"}, overall=4.7,
+                           dims_json={"d": 4.7})
+    _write_noms(env["noms"], [_nom("quest:bg:q1", p)])
+
+    report = _run(env)
+
+    assert report["scored"] == 0
+    assert report["already_scored"] == 1
+    assert fake_panel == []  # the scorer must NEVER be called for an already-scored artifact
+    rows = scores_db.fetch_artifacts(env["db"])
+    assert len(rows) == 1
+    assert rows[0]["overall"] == 4.7  # unchanged — not overwritten by a re-score
+
+
+def test_unscored_row_with_no_overall_is_still_rescored(env, fake_panel):
+    """A row present in `artifacts` but with overall=None (e.g. a prior failed/partial write) is
+    treated as UNSCORED — mirrors promote.py's own "row missing OR overall is None" definition."""
+    p = _artifact_json(env["artifacts_out"], "quest:bg:q1")
+    scores_db.add_artifact("quest:bg:q1", db_path=env["db"], **{"class": "quest"}, overall=None)
+    _write_noms(env["noms"], [_nom("quest:bg:q1", p)])
+
+    report = _run(env)
+
+    assert report["scored"] == 1
+    assert fake_panel == ["quest:bg:q1"]
+
+
+def test_empty_queue_is_additive_noop(env, fake_panel):
+    _write_noms(env["noms"], [])
+    report = _run(env)
+    assert report == {
+        "nominations_total": 0, "already_scored": 0, "candidates_unscored": 0, "scored": 0,
+        "load_failed": 0, "score_failed": 0, "remaining_for_next_run": 0, "dry_run": False,
+        "details": [],
+    }
+    assert fake_panel == []
+
+
+def test_missing_nominations_file_is_noop(env, fake_panel):
+    report = _run(env)  # env["noms"] was never written
+    assert report["nominations_total"] == 0
+    assert report["scored"] == 0
+    assert fake_panel == []
+
+
+# ---------------------------------------------------------------------------
+# idempotency + resumability + bounded batch size
+# ---------------------------------------------------------------------------
+def test_idempotent_second_run_scores_nothing_new(env, fake_panel):
+    p = _artifact_json(env["artifacts_out"], "quest:bg:q1")
+    _write_noms(env["noms"], [_nom("quest:bg:q1", p)])
+
+    first = _run(env)
+    second = _run(env)
+
+    assert first["scored"] == 1
+    assert second["scored"] == 0
+    assert second["already_scored"] == 1
+    assert fake_panel == ["quest:bg:q1"]  # scorer called exactly once across BOTH runs
+    assert len(scores_db.fetch_artifacts(env["db"])) == 1
+
+
+def test_duplicate_artifact_id_in_queue_scored_once(env, fake_panel):
+    """The same artifact_id nominated twice (two separate nominate.py runs appending to the same
+    queue) must be scored — and billed — at most once per batch."""
+    p = _artifact_json(env["artifacts_out"], "quest:bg:q1")
+    _write_noms(env["noms"], [_nom("quest:bg:q1", p), _nom("quest:bg:q1", p)])
+
+    report = _run(env)
+
+    assert report["scored"] == 1
+    assert fake_panel == ["quest:bg:q1"]
+
+
+def test_max_per_run_caps_the_batch_and_reports_remainder(env, fake_panel):
+    for i in range(5):
+        p = _artifact_json(env["artifacts_out"], f"quest:bg:q{i}")
+        with env["noms"].open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(_nom(f"quest:bg:q{i}", p)) + "\n")
+
+    report = _run(env, max_per_run=2)
+
+    assert report["scored"] == 2
+    assert report["candidates_unscored"] == 5
+    assert report["remaining_for_next_run"] == 3
+    assert len(fake_panel) == 2
+
+
+def test_resumable_across_two_capped_runs_drains_the_queue(env, fake_panel):
+    for i in range(3):
+        p = _artifact_json(env["artifacts_out"], f"quest:bg:q{i}")
+        with env["noms"].open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(_nom(f"quest:bg:q{i}", p)) + "\n")
+
+    first = _run(env, max_per_run=2)
+    second = _run(env, max_per_run=2)
+
+    assert first["scored"] == 2
+    assert second["scored"] == 1  # the leftover 1 from the first, capped run
+    assert second["remaining_for_next_run"] == 0
+    assert len(scores_db.fetch_artifacts(env["db"])) == 3
+    assert sorted(fake_panel) == ["quest:bg:q0", "quest:bg:q1", "quest:bg:q2"]
+
+
+def test_negative_max_per_run_rejected_at_cli(env, capsys):
+    with pytest.raises(SystemExit):
+        nightly_harvest.main(["--nominations", str(env["noms"]), "--db", str(env["db"]),
+                              "--max-per-run", "-1"])
+
+
+# ---------------------------------------------------------------------------
+# non-fatal isolation: one bad artifact never aborts the batch
+# ---------------------------------------------------------------------------
+def test_load_failed_artifact_does_not_abort_batch(env, fake_panel):
+    good = _artifact_json(env["artifacts_out"], "quest:bg:good")
+    _write_noms(env["noms"], [
+        _nom("quest:bg:missing-file", env["artifacts_out"] / "does_not_exist.json"),
+        _nom("quest:bg:good", good),
+    ])
+
+    report = _run(env)
+
+    assert report["load_failed"] == 1
+    assert report["scored"] == 1
+    assert fake_panel == ["quest:bg:good"]
+
+
+def test_nomination_with_no_source_path_is_load_failed(env, fake_panel):
+    _write_noms(env["noms"], [_nom("quest:bg:q1", None)])
+    report = _run(env)
+    assert report["load_failed"] == 1
+    assert report["scored"] == 0
+    assert fake_panel == []
+
+
+def test_mismatched_artifact_id_is_load_failed(env, fake_panel):
+    """source_path resolves to a DIFFERENT artifact_id than the nomination claims — refuse to score
+    the wrong artifact (mirrors promote.py's score_if_unscored guard)."""
+    p = _artifact_json(env["artifacts_out"], "quest:bg:actual")
+    _write_noms(env["noms"], [_nom("quest:bg:claimed", p)])
+
+    report = _run(env)
+
+    assert report["load_failed"] == 1
+    assert report["scored"] == 0
+    assert fake_panel == []
+
+
+def test_score_failed_artifact_does_not_abort_batch(env, failing_panel):
+    good = _artifact_json(env["artifacts_out"], "quest:bg:q1")
+    other = _artifact_json(env["artifacts_out"], "quest:bg:q2")
+    _write_noms(env["noms"], [_nom("quest:bg:q1", good), _nom("quest:bg:q2", other)])
+
+    report = _run(env)
+
+    assert report["score_failed"] == 2
+    assert report["scored"] == 0
+    assert len(scores_db.fetch_artifacts(env["db"])) == 0
+
+
+def test_score_failed_artifact_is_retried_next_run(env):
+    """A score-failed artifact must NOT be permanently skipped — it stays a candidate until scored."""
+    p = _artifact_json(env["artifacts_out"], "quest:bg:q1")
+    _write_noms(env["noms"], [_nom("quest:bg:q1", p)])
+
+    import artifact_score as _as
+    calls = {"n": 0}
+
+    def _flaky(artifact, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient failure")
+        card = {"overall": 4.2, "scores": {"d": 4.2}}
+        _as.record_artifact_score(artifact, card, db_path=kw.get("db_path", env["db"]))
+        return card
+
+    orig = _as.score_artifact_panel
+    _as.score_artifact_panel = _flaky
+    try:
+        first = _run(env)
+        second = _run(env)
+    finally:
+        _as.score_artifact_panel = orig
+
+    assert first["score_failed"] == 1
+    assert first["scored"] == 0
+    assert second["scored"] == 1
+    assert calls["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# dry-run: pure preview, zero scoring calls, zero writes
+# ---------------------------------------------------------------------------
+def test_dry_run_reports_would_score_and_writes_nothing(env, fake_panel):
+    p = _artifact_json(env["artifacts_out"], "quest:bg:q1")
+    _write_noms(env["noms"], [_nom("quest:bg:q1", p)])
+
+    report = _run(env, dry_run=True)
+
+    assert report["dry_run"] is True
+    assert report["would_score"] == ["quest:bg:q1"]
+    assert fake_panel == []  # the scorer is NEVER invoked under --dry-run
+    assert len(scores_db.fetch_artifacts(env["db"])) == 0
+    assert not env["log"].exists()
+
+
+def test_dry_run_respects_max_per_run_cap(env, fake_panel):
+    for i in range(3):
+        p = _artifact_json(env["artifacts_out"], f"quest:bg:q{i}")
+        with env["noms"].open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(_nom(f"quest:bg:q{i}", p)) + "\n")
+
+    report = _run(env, dry_run=True, max_per_run=1)
+
+    assert len(report["would_score"]) == 1
+    assert report["candidates_unscored"] == 3
+
+
+# ---------------------------------------------------------------------------
+# progress log (this module's OWN log — separate from library/.promoted.jsonl)
+# ---------------------------------------------------------------------------
+def test_log_appends_one_line_per_attempt(env, fake_panel):
+    p = _artifact_json(env["artifacts_out"], "quest:bg:q1")
+    _write_noms(env["noms"], [_nom("quest:bg:q1", p)])
+
+    _run(env)
+
+    lines = [json.loads(l) for l in env["log"].read_text().splitlines() if l.strip()]
+    assert len(lines) == 1
+    assert lines[0]["artifact_id"] == "quest:bg:q1"
+    assert lines[0]["verdict"] == "scored"
+    assert lines[0]["overall"] == 4.4
+
+
+def test_log_records_failures_too(env, failing_panel):
+    p = _artifact_json(env["artifacts_out"], "quest:bg:q1")
+    _write_noms(env["noms"], [_nom("quest:bg:q1", p)])
+
+    _run(env)
+
+    lines = [json.loads(l) for l in env["log"].read_text().splitlines() if l.strip()]
+    assert len(lines) == 1
+    assert lines[0]["verdict"] == "score-failed"
+    assert "error" in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# malformed queue lines are skipped, not fatal (tolerant reader — a nightly batch outlives typos)
+# ---------------------------------------------------------------------------
+def test_malformed_queue_line_is_skipped_not_fatal(env, fake_panel):
+    p = _artifact_json(env["artifacts_out"], "quest:bg:q1")
+    env["noms"].write_text(
+        "not json at all\n" + json.dumps(_nom("quest:bg:q1", p)) + "\n{}\n",
+        encoding="utf-8",
+    )
+
+    report = _run(env)
+
+    assert report["nominations_total"] == 1  # only the one well-formed, artifact_id-bearing line
+    assert report["scored"] == 1
+
+
+# ---------------------------------------------------------------------------
+# never touches library/ — a fresh assertion the harvest batch stays scoring-only
+# ---------------------------------------------------------------------------
+def test_never_writes_library_dir(env, fake_panel, tmp_path):
+    p = _artifact_json(env["artifacts_out"], "quest:bg:q1")
+    _write_noms(env["noms"], [_nom("quest:bg:q1", p)])
+    library_dir = tmp_path / "library"
+
+    _run(env)
+
+    assert not library_dir.exists()

--- a/qa/test_nightly_harvest.py
+++ b/qa/test_nightly_harvest.py
@@ -205,6 +205,7 @@ def test_duplicate_artifact_id_in_queue_scored_once(env, fake_panel):
     report = _run(env)
 
     assert report["scored"] == 1
+    assert report["already_scored"] == 0  # a de-duped nomination is NOT "already scored"
     assert fake_panel == ["quest:bg:q1"]
 
 
@@ -336,6 +337,10 @@ def test_dry_run_reports_would_score_and_writes_nothing(env, fake_panel):
     assert report["dry_run"] is True
     assert report["would_score"] == ["quest:bg:q1"]
     assert fake_panel == []  # the scorer is NEVER invoked under --dry-run
+    # Check db-file existence BEFORE the fetch_artifacts call below, which itself opens (and would
+    # schema-create) the db — this must observe harvest_batch's own side effects, not the test
+    # helper's.
+    assert not env["db"].exists()  # a fresh db_path stays untouched — no schema-init side effect
     assert len(scores_db.fetch_artifacts(env["db"])) == 0
     assert not env["log"].exists()
 


### PR DESCRIPTION
## What (HV5 epic #1327, slices 2+3 of the flywheel-ops sprint)

Builds on slice 1 (#1342, closeout auto-nomination → `qa/nominations.jsonl`, merged). This PR ships
the two remaining core slices; the weekly-curation stub (item 3 in the dispatch) was deprioritized
in favor of full test depth on 2+3 — flagged below, not silently dropped.

### Slice 2 — nightly batch scoring (`qa/nightly_harvest.py`)
Reads the accumulated `qa/nominations.jsonl`, finds nominations whose `artifact_id` has no scored
`artifacts` row yet (same "unscored" definition `promote.py` uses: row missing OR `overall is None`),
and scores each via HV1's plain callable entrypoint `qa/artifact_score.score_artifact_panel` — the
SAME seam `promote.py`'s `score_if_unscored` calls, so there is exactly one place a live LLM panel
call happens anywhere in the harvest loop.

- **Deferred from the duo hot path**, per the epic: nominate.py (slice 1) only nominates; this batch
  is the separate, off-line scoring step.
- **Bounded**: `--max-per-run` (default 20) caps one invocation; the remainder waits for the next
  nightly tick.
- **Resumable + idempotent**: the `artifacts` table itself is the "already scored" source of truth
  (mirrors `promote.py`); nothing is double-scored or double-billed across runs.
- **Non-fatal isolation**: one artifact's load failure (bad `source_path`, id mismatch) or scoring
  failure (score.sh sentinel/exception) is caught, logged to its own resumable progress log
  (`qa/nightly_harvest_log.jsonl`, separate from `library/.promoted.jsonl`), and retried next run —
  never aborts the batch.
- `--dry-run` previews the capped work list; scores nothing, writes nothing.

### Slice 3 — `library_metrics` table (the flywheel's own eval)
Additive `library_metrics` table in `qa/scores.db`, added via `qa/scores_db.py` (the sole schema/
writer surface — `add_library_metrics` / `fetch_library_metrics` / `render_library_metrics_markdown`,
mirroring the `artifacts` table's own pattern). One row per SNAPSHOT (time-series, not a replace-by-
key like `runs`/`artifacts`): `size_total`, `size_by_class_json`, `size_by_tier_json`,
`reuse_count_sum` (Σ reuse_count), `promotion_pass_rate` (+ `promoted_total`/`rejected_total`), and
`pct_library_sourced` (left `None` — HV4 wiring doesn't exist yet in this repo state; an honest
"not measured" rather than a guess).

`qa/library_metrics.py`'s `snapshot_library()` is the sole writer: a pure, read-only scan of
`library/**/*.json` + `library/.promoted.jsonl`, then one `add_library_metrics` call. Never a second
writer of `library/` — `promote.py` stays its sole writer; this only reads it.

### Deferred (flagged, not silently dropped)
Item 3 (weekly-curation stub listing stable-tier entries eligible for canonical review) was not
built in this PR — prioritized full offline test depth on slices 2+3 instead. Follow-up scoped
separately if wanted; canonical promotion stays human-only regardless.

## Offline-safety
Every test in `qa/test_nightly_harvest.py` monkeypatches `artifact_score.score_artifact_panel` to a
fabricated stub (mirrors `test_promote_pipeline.py`'s `test_score_if_unscored_is_isolated_from_promotion_path`
discipline) — no test invokes score.sh or a live `claude -p`. `qa/test_library_metrics.py` is pure
filesystem + sqlite over fabricated `tmp_path` trees. Nightly runs (a live LLM panel) are the
orchestrator's job, never CI/pytest.

## Invariants held
- **Additive**: `library_metrics` is a new, separate table — `runs` and `artifacts` schemas
  untouched (confirmed via `detect_changes`: only `scores_db.py`'s schema-ensure chain is touched,
  same blast radius HV1's `artifacts` table addition already established).
- **scores.db writes only through `qa/scores_db.py`**: `add_library_metrics` is the sole writer;
  `nightly_harvest.py` never hand-rolls SQL (it calls `artifact_score.record_artifact_score`
  internally via `score_artifact_panel`, the existing writer).
- **`promote.py` stays sole writer of `library/`**: both new modules are read-only over it.
- **Nightly scoring off the duo latency path**: confirmed by construction — `nightly_harvest.py` is
  never invoked from `run_duo.sh`/`nominate.py`'s hot-path hook.
- **No new `chk()`**: these are harvest-ops readers/writers, not behavioral-gate checks — nothing
  registered in `BEHAVIORAL_GATE_TAXONOMY.json` / `gate_corpus/manifest.json`.

## Tests
- `qa/test_nightly_harvest.py` — 21 offline tests: scores-only-unscored, idempotency, resumability
  across capped runs, bounded `--max-per-run` (incl. CLI rejection of a negative cap), non-fatal
  load/score-failure isolation + retry-next-run, dry-run (zero scorer calls), malformed-line
  tolerance, never touches `library/`.
- `qa/test_library_metrics.py` — 28 offline tests: `scores_db.py` schema/round-trip/render (incl.
  cross-table isolation from `runs`/`artifacts`), `scan_library` (size/tier/reuse counting, malformed-
  entry handling), `scan_promotion_log` (pass-rate math, gated-vs-non-gated verdicts), `snapshot_library`
  end-to-end against a known fabricated `library/` state, CLI dry-run/render.
- **70 new tests total** (single-process, `-p no:xdist`). Full regression: 212 passed, 1 pre-existing
  skip across `test_nominate.py` / `test_promote_pipeline.py` / `test_scores_db.py` /
  `test_artifact_evals.py` / `test_scores_db_comparability.py` / `test_closeout.py`.
- `qa/fast_gate.sh` green — 257 passed, $0 deterministic.
- `python3 tools/library/library_lint.py` — clean.

## Flags
- `pct_library_sourced` stays unset until HV4 (`questgen._derive_hooks` library candidate source)
  wires per-run attribution — today's expected state, not a bug (documented in the column comment
  and the rendered ledger's blockquote).
- `qa/library_metrics_ledger.md` is intentionally NOT committed here (mirrors `qa/nominations.jsonl`'s
  own precedent in slice 1 — a runtime-generated artifact, not founding-PR content); it materializes
  on the first real `snapshot_library()` run.
- Weekly-curation stub (dispatch item 3) deferred — see "Deferred" above.

Do NOT merge — orchestrator review.