### PR TITLE
[qa] run_duo resume-on-throttle — a killed/throttled ruler duo resumes instead of restarting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
             ../../qa/test_scores_db_comparability.py \
             ../../qa/test_scores_db.py \
             ../../qa/test_closeout.py \
+            ../../qa/test_duo_resume.py \
             ../../qa/test_release_gate_static.py \
             ../../qa/test_ui_playtest_score_image_outcomes.py \
             ../../qa/test_claude_auth_isolation.py \

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -31,6 +31,8 @@ BEATS="${4:-6}"
 ADVENTURE_ID="${WORLDOS_ADVENTURE_ID:-}"
 [ -n "$ADVENTURE_ID" ] && echo "[duo] AUTHORED-ADVENTURE mode: start_adventure(\"$ADVENTURE_ID\") at BEATS=$BEATS"
 BUDGET="${5:-0.80}"
+EX_TEMPFAIL=75
+CURRENT_SHA="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
 
 # ── Root + IS_SANDBOX preflight (the real beat-0 blocker, 2026-06-03) ─────────────────
 # claude refuses `--dangerously-skip-permissions` (which `--permission-mode bypassPermissions`
@@ -51,6 +53,7 @@ WORLDOS_DM_MODEL="$(worldos_env DM_MODEL opus)"
 # so behavior is unchanged) kept consistent with the party harness's WORLDOS_ACTOR_MODEL.
 WORLDOS_ACTOR_MODEL="$(worldos_env ACTOR_MODEL sonnet)"
 SCORE_SCRIPT="$(worldos_env SCORE_SCRIPT qa/score.sh)"
+ASSERT_BEHAVIORAL_SCRIPT="$(worldos_env ASSERT_BEHAVIORAL_SCRIPT qa/assert_behavioral.py)"
 # Opus's high-effort cold-open world-build costs ~$2.4 on its first turn (measured 2026-06-06); a low
 # caller per-turn budget (sweep $2.00, fast_probe $0.80) would trip error_max_budget_usd on the duo
 # cold-open the same way the .app backend did. Floor the per-turn cap for an Opus DM so the cold-open
@@ -86,7 +89,206 @@ worldos_apply_glm_profile
 WORLDOS_LEAN_BEATS="${WORLDOS_LEAN_BEATS:-1}"
 WORLDOS_LEAN_TAIL="${WORLDOS_LEAN_TAIL:-8}"
 T="qa/transcripts"; STATE_DIR="$ROOT/qa/state/$RUN"
-mkdir -p "$T" "$STATE_DIR"; rm -rf "$STATE_DIR/campaigns" 2>/dev/null
+CHECKPOINT="$STATE_DIR/.duo_checkpoint.json"
+CHECKPOINT_MANIFEST="$STATE_DIR/.duo_checkpoint_offsets.json"
+CHECKPOINT_SLOT="duo_checkpoint"
+mkdir -p "$T" "$STATE_DIR"
+
+RESUME_MODE=0
+LAST_COMPLETED_BEAT=-1
+START_BEAT=1
+DSID=""
+PSID=""
+CAMPAIGN_ID=""
+
+duo_quota_seen() {
+  grep -qiE 'api_error_status"[[:space:]]*:[[:space:]]*429|session limit|HTTP 429|hit your (session|usage) limit|rate[_ -]?limit|too many requests' "$@" 2>/dev/null
+}
+
+duo_engine_slot() {
+  local action="$1" campaign_id="$2"
+  [ -n "$campaign_id" ] || return 1
+  WORLDOS_STATE_DIR="$STATE_DIR" uv run --directory "$ROOT/servers/engine" python - "$action" "$campaign_id" "$CHECKPOINT_SLOT" <<'PY' >/dev/null
+import sys
+import server
+
+action, campaign_id, slot = sys.argv[1], sys.argv[2], sys.argv[3]
+if action == "save":
+    server.save_slot(campaign_id, slot)
+elif action == "load":
+    server.load_slot(campaign_id, slot)
+else:
+    raise SystemExit(f"unknown checkpoint slot action: {action}")
+PY
+}
+
+duo_write_manifest() {
+  python3 - "$CHECKPOINT_MANIFEST" "$ROOT" "$COMBINED" "$CHAT" "$MOVES" "$TOOLTIMING_PATH" "$T/$RUN.dm.err" "$T/$RUN.player.err" "$T" "$RUN" "$1" <<'PY'
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+manifest, root, *rest = sys.argv[1:]
+combined, chat, moves, tooltiming, dm_err, player_err, tdir, run, beat = rest
+root_path = Path(root)
+
+def rel(p: str) -> str:
+    try:
+        return str(Path(p).resolve().relative_to(root_path.resolve()))
+    except ValueError:
+        return str(Path(p))
+
+files = {}
+for raw in [combined, chat, moves, tooltiming, dm_err, player_err]:
+    p = Path(raw)
+    files[rel(raw)] = p.stat().st_size if p.exists() else 0
+
+dm_files = []
+for raw in sorted(glob.glob(str(Path(tdir) / f"{run}.dm.*.jsonl"))):
+    dm_files.append(rel(raw))
+
+payload = {
+    "last_completed_beat": int(beat),
+    "files": files,
+    "dm_files": dm_files,
+}
+path = Path(manifest)
+tmp = path.with_suffix(path.suffix + ".tmp")
+tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+os.replace(tmp, path)
+PY
+}
+
+duo_restore_manifest() {
+  [ -s "$CHECKPOINT_MANIFEST" ] || return 0
+  python3 - "$CHECKPOINT_MANIFEST" "$ROOT" "$T" "$RUN" <<'PY'
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+manifest, root, tdir, run = sys.argv[1:]
+root_path = Path(root)
+data = json.loads(Path(manifest).read_text(encoding="utf-8"))
+files = data.get("files") or {}
+for rel, size in files.items():
+    path = root_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    keep = int(size)
+    if not path.exists():
+        if keep == 0:
+            path.write_bytes(b"")
+        continue
+    with path.open("r+b") as handle:
+        handle.truncate(keep)
+
+kept = {str((root_path / rel).resolve()) for rel in (data.get("dm_files") or [])}
+for raw in glob.glob(str(Path(tdir) / f"{run}.dm.*.jsonl")):
+    if str(Path(raw).resolve()) not in kept:
+        try:
+            os.remove(raw)
+        except FileNotFoundError:
+            pass
+PY
+}
+
+duo_write_checkpoint() {
+  local beat="$1"
+  [ -n "$CAMPAIGN_ID" ] || return 0
+  if ! duo_engine_slot save "$CAMPAIGN_ID"; then
+    echo "[duo] checkpoint write failed: could not save checkpoint slot for campaign $CAMPAIGN_ID" >&2
+    exit 2
+  fi
+  if ! duo_write_manifest "$beat"; then
+    echo "[duo] checkpoint write failed: could not write checkpoint manifest for beat $beat" >&2
+    exit 2
+  fi
+  if ! python3 - "$CHECKPOINT" "$beat" "$PSID" "$DSID" "$CAMPAIGN_ID" "$WORLD" "$PLAYER_PROMPT_FILE" "$BEATS" "$BUDGET" "$CURRENT_SHA" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+path, beat, player_sid, dm_sid, campaign_id, world, persona, total_beats, budget, sha = sys.argv[1:]
+payload = {
+    "last_completed_beat": int(beat),
+    "player_session_id": player_sid,
+    "dm_session_id": dm_sid,
+    "campaign_id": campaign_id,
+    "world": world,
+    "persona": persona,
+    "total_beats": int(total_beats),
+    "budget": budget,
+    "sha": sha,
+}
+p = Path(path)
+tmp = p.with_suffix(p.suffix + ".tmp")
+tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+os.replace(tmp, p)
+PY
+  then
+    echo "[duo] checkpoint write failed: could not write $CHECKPOINT" >&2
+    exit 2
+  fi
+  LAST_COMPLETED_BEAT="$beat"
+  START_BEAT=$((LAST_COMPLETED_BEAT + 1))
+}
+
+duo_delete_checkpoint() {
+  rm -f "$CHECKPOINT" "$CHECKPOINT.tmp" "$CHECKPOINT_MANIFEST" "$CHECKPOINT_MANIFEST.tmp" 2>/dev/null || true
+}
+
+duo_last_dm_chat() {
+  python3 - "$CHAT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+last = ""
+if path.exists():
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if row.get("role") == "dm" and row.get("text") and not row.get("beat_failed"):
+            last = row.get("text") or ""
+print(last)
+PY
+}
+
+if [ -s "$CHECKPOINT" ]; then
+  if ! jq -e . "$CHECKPOINT" >/dev/null 2>&1; then
+    echo "[duo] checkpoint at $CHECKPOINT is invalid JSON; delete the checkpoint to restart" >&2
+    exit 2
+  fi
+  ck_sha="$(jq -r '.sha // ""' "$CHECKPOINT")"
+  if [ "$ck_sha" != "$CURRENT_SHA" ]; then
+    echo "[duo] checkpoint sha $ck_sha != current $CURRENT_SHA — a resume across code changes is invalid; delete the checkpoint to restart" >&2
+    exit 2
+  fi
+  ck_world="$(jq -r '.world // ""' "$CHECKPOINT")"
+  ck_persona="$(jq -r '.persona // ""' "$CHECKPOINT")"
+  ck_beats="$(jq -r '.total_beats // ""' "$CHECKPOINT")"
+  if [ "$ck_world" != "$WORLD" ] || [ "$ck_persona" != "$PLAYER_PROMPT_FILE" ] || [ "$ck_beats" != "$BEATS" ]; then
+    echo "[duo] checkpoint invocation mismatch (checkpoint world=$ck_world persona=$ck_persona total_beats=$ck_beats; current world=$WORLD persona=$PLAYER_PROMPT_FILE total_beats=$BEATS); delete the checkpoint to restart" >&2
+    exit 2
+  fi
+  RESUME_MODE=1
+  LAST_COMPLETED_BEAT="$(jq -r '.last_completed_beat' "$CHECKPOINT")"
+  PSID="$(jq -r '.player_session_id' "$CHECKPOINT")"
+  DSID="$(jq -r '.dm_session_id' "$CHECKPOINT")"
+  CAMPAIGN_ID="$(jq -r '.campaign_id' "$CHECKPOINT")"
+  START_BEAT=$((LAST_COMPLETED_BEAT + 1))
+fi
+
+if [ "$RESUME_MODE" != "1" ]; then
+  rm -rf "$STATE_DIR/campaigns" 2>/dev/null
+fi
 # #892 follow-up: keep the cold-open `claude -p` (the DM) off the macOS keychain + off any /Volumes
 # TCC prompt so the duo QA harness runs headless. GATED no-op without an env/file credential (so the
 # Terminal/keychain path is byte-unchanged). Called ONCE here, after STATE_DIR, before the first DM
@@ -95,13 +297,15 @@ worldos_isolate_claude_auth
 
 # DM gets the engine (state dir patched in); the player gets an EMPTY strict config.
 DM_CFG="$STATE_DIR/dm.mcp.json"; PLAYER_CFG="$STATE_DIR/player.mcp.json"
-MOVES="$STATE_DIR/player_moves.jsonl"; : > "$MOVES"  # the player's structured moves (It.1)
+MOVES="$STATE_DIR/player_moves.jsonl"
+[ "$RESUME_MODE" = "1" ] || : > "$MOVES"  # the player's structured moves (It.1)
 # Wave-1 per-tool timing sidecar (Round-2 wiring): the engine appends one {ts,tool,wall_ms,ok,
 # campaign_id} line per tool call to this ABSOLUTE path — but only because we set
 # WORLDOS_TOOLTIMING_PATH in the engine MCP env below (it is a no-op when that var is unset, so
 # production play pays nothing). latency_rollup.py reads it via --tooltiming to split tool-exec vs
 # generation. Truncate at run start so a re-run never appends to a stale sidecar.
-TOOLTIMING_PATH="$ROOT/$T/$RUN.tooltiming.jsonl"; : > "$TOOLTIMING_PATH"
+TOOLTIMING_PATH="$ROOT/$T/$RUN.tooltiming.jsonl"
+[ "$RESUME_MODE" = "1" ] || : > "$TOOLTIMING_PATH"
 python3 - "$ROOT/qa/qa.mcp.example.json" "$STATE_DIR" "$DM_CFG" "$ROOT" "$TOOLTIMING_PATH" <<'PY'
 import json, sys, os
 cfg_path, state, out, root, tooltiming = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
@@ -148,24 +352,39 @@ json.dump({"mcpServers": {"worldos-player": {"command": "uv",
   "env": {"WORLDOS_STATE_DIR": state, "WORLDOS_PLAYER_MOVES": moves}}}}, open(out, "w"))
 PY
 
-DSID="$(python3 -c 'import uuid;print(uuid.uuid4())')"
-PSID="$(python3 -c 'import uuid;print(uuid.uuid4())')"
+if [ "$RESUME_MODE" = "1" ]; then
+  if ! duo_engine_slot load "$CAMPAIGN_ID"; then
+    echo "[duo] checkpoint could not restore campaign $CAMPAIGN_ID from slot $CHECKPOINT_SLOT; delete the checkpoint to restart" >&2
+    exit 2
+  fi
+  if ! duo_restore_manifest; then
+    echo "[duo] checkpoint could not restore transcript offsets from $CHECKPOINT_MANIFEST; delete the checkpoint to restart" >&2
+    exit 2
+  fi
+else
+  DSID="$(python3 -c 'import uuid;print(uuid.uuid4())')"
+  PSID="$(python3 -c 'import uuid;print(uuid.uuid4())')"
+fi
 # The DM's campaign id (for the lean re-ground). Resolved AFTER the cold-open D1 mints the
 # world (start_world writes $STATE_DIR/campaigns/<id>/). Declared here (empty) so the DM
 # turn()'s lean branch can reference it safely under `set -u` even during the cold open —
 # when it's empty, worldos_dm_lean_args no-ops and the normal --resume path is used.
-CAMPAIGN_ID=""
+[ "$RESUME_MODE" = "1" ] || CAMPAIGN_ID=""
 DM_BRIEF="$(cat qa/play_dm_duo.txt)"; PLAYER_BRIEF="$(cat "$PLAYER_PROMPT_FILE")"
-COMBINED="$T/$RUN.jsonl"; : > "$COMBINED"
+COMBINED="$T/$RUN.jsonl"; [ "$RESUME_MODE" = "1" ] || : > "$COMBINED"
 # A clean two-sided conversation log (the player agent's turns AND the DM's), so the
 # dashboard can show the PROTAGONIST acting — not just the DM narrating. The DM's own
 # stream (COMBINED) doesn't echo the player's turns, so we capture both sides here.
-CHAT="$T/$RUN.chat.jsonl"; : > "$CHAT"
+CHAT="$T/$RUN.chat.jsonl"; [ "$RESUME_MODE" = "1" ] || : > "$CHAT"
 # chatlog is the SHARED lib implementation (qa/lib_beat_driver.sh, reads ambient $CHAT at call
 # time). SYN-01/F12-7: a local 2-arg override here used to shadow it AFTER sourcing the lib,
 # silently discarding worldos_chatlog_dm's {"fallback_recovered":true} honesty stamp — never
 # re-define chatlog in a runner.
-echo "[duo] run=$RUN world=$WORLD beats=$BEATS dm=$DSID player=$PSID"
+if [ "$RESUME_MODE" = "1" ]; then
+  echo "[duo] resume checkpoint: run=$RUN last_completed=$LAST_COMPLETED_BEAT next_beat=$START_BEAT campaign=$CAMPAIGN_ID dm=$DSID player=$PSID"
+else
+  echo "[duo] run=$RUN world=$WORLD beats=$BEATS dm=$DSID player=$PSID"
+fi
 
 # $1=role(player|dm) $2=session-id $3=first?(1/0) $4=message ; echoes the agent's reply text
 turn() {
@@ -307,7 +526,13 @@ turn_retry() {
 # subshell), so a `MCURSOR=…` assignment is LOST on return — the cursor would stay 0 and
 # every beat would re-relay the ENTIRE move history to the DM (stale, ballooning input).
 # A file persists across the subshell, so each beat relays only the NEW moves.
-MCURSOR_FILE="$STATE_DIR/.mcursor"; echo 0 > "$MCURSOR_FILE"
+MCURSOR_FILE="$STATE_DIR/.mcursor"
+if [ "$RESUME_MODE" = "1" ]; then
+  _move_count="$(wc -l < "$MOVES" 2>/dev/null | tr -d ' ')"; _move_count="${_move_count:-0}"
+  echo "$_move_count" > "$MCURSOR_FILE"
+else
+  echo 0 > "$MCURSOR_FILE"
+fi
 # A player turn via the constrained facade: the player acts ONLY through tools, which
 # append structured moves to $MOVES. Relay ONLY the structured moves it made THIS turn —
 # NEVER its raw reply text (relaying free-text would re-open the over-writing hole the
@@ -347,6 +572,7 @@ player_move() {
 # move through player_move (NOT raw prose) so the behavioral gate
 # `player_turns_structured` still sees a structured first turn (a raw-text intro caps
 # all G5 lenses ≤2.5 — see the say()-vs-prose note below).
+if [ "$RESUME_MODE" != "1" ]; then
 PLAYER_INTRO_PROMPT="$PLAYER_BRIEF
 
 This is the very start — the world isn't built and the scene isn't set yet. Introduce your character with a SINGLE say(\"…\"): who they are and what they want. Do NOT do()/attack/cast yet — wait for the DM to open the scene. One say(), nothing else."
@@ -386,10 +612,11 @@ echo "[duo] DM opened: ${DMSG:0:120}…"
 # "session limit" / "HTTP 429" marker. An empty/recovered reply on top of a 429 is NOT a product
 # failure — it is an INFRA abort. Detect it BEFORE scoring so we never burn the 3-lens scorer on a
 # quota corpse (or, worse, cap-RED a quota'd run as a 2.5 product score). Log a marker the VM sweep
-# greps for and exit rc=2 (distinct from the rc=1 genuine-no-opening abort below).
-if grep -qiE "session limit|HTTP 429|hit your (session|usage) limit" "$COMBINED" "$T/$RUN.dm.err" 2>/dev/null; then
+# greps for and exit rc=75 / EX_TEMPFAIL (distinct from the rc=1 genuine-no-opening abort below).
+if duo_quota_seen "$COMBINED" "$T/$RUN.dm.err"; then
   echo "[duo] QUOTA ABORT — DM cold-open hit the account session limit (HTTP 429). Skipping scoring; this is an INFRA abort, NOT a product measurement." >&2
-  exit 2
+  echo "[duo] throttled at beat 0 — re-invoke the same command in a fresh window to resume" >&2
+  exit "$EX_TEMPFAIL"
 fi
 # SYN-01: an empty resolved reply is a FAILED beat (error-class result, recycled-only prose, or
 # nothing recovered). Record the wrapper-authored VISIBLE failure row — never the error text,
@@ -428,13 +655,23 @@ if [ "$WORLDOS_LEAN_BEATS" = "1" ]; then
     echo "[duo] lean-beats ON but campaign id not found under $STATE_DIR/campaigns — beats use the normal resume path" >&2
   fi
 fi
+duo_write_checkpoint 0
+else
+  DMSG="$(duo_last_dm_chat)"
+  if [ -z "$DMSG" ]; then
+    echo "[duo] checkpoint has no prior DM chat row to continue from; delete the checkpoint to restart" >&2
+    exit 2
+  fi
+  echo "[duo] resumed after beat $LAST_COMPLETED_BEAT; continuing with prior DM context: ${DMSG:0:100}…"
+fi
 
 # Alternate player <-> DM for BEATS rounds. Each beat is now BEAT-AWARE (decision §A):
 # read the clock + location at the START of the beat, pick the ONE moment-specific runbook
 # for this beat (scene-intro / reversal / climax / travel-peopling / rising-action) instead
 # of the old constant "keep the world moving" paragraph, then after the DM beat run the soft
 # clock-tick backstop (decision §C) so a frozen clock advances ONE phase via the engine.
-for b in $(seq 1 "$BEATS"); do
+if [ "$START_BEAT" -le "$BEATS" ]; then
+for b in $(seq "$START_BEAT" "$BEATS"); do
   # Progression snapshot at the START of this beat (drives both the runbook + the tick).
   PROG_PRE="$(worldos_read_progress "$STATE_DIR")"
   PREV_DAY="$(printf '%s' "$PROG_PRE" | cut -f1)"; PREV_DAY="${PREV_DAY:-1}"
@@ -482,6 +719,11 @@ $EVENT_ADV")"
   # by assert_behavioral's dm_beat_honesty) instead of masking with error text/recycled prose.
   if [ -z "$DMSG" ]; then
     worldos_chatlog_dm_failed
+    if duo_quota_seen "$STATE_DIR/.dm_last_result" "$COMBINED" "$T/$RUN.dm.err"; then
+      echo "[duo] QUOTA ABORT — DM beat $b hit the account session limit / rate limit. Skipping scoring; this is an INFRA abort, NOT a product measurement." >&2
+      echo "[duo] throttled at beat $b — re-invoke the same command in a fresh window to resume" >&2
+      exit "$EX_TEMPFAIL"
+    fi
     # #1285: worldos_chatlog_dm_failed stamps $STATE_DIR/.run_infra_invalid.json once the
     # CONSECUTIVE failure streak crosses WORLDOS_INFRA_INVALID_STREAK — a quota window / host
     # death mid-run (rri-a1-duo/duo2), not a product defect. Abort NOW (same rc=2 INFRA ABORT
@@ -501,7 +743,9 @@ $EVENT_ADV")"
   # C — soft clock-tick backstop: if the DM didn't move the clock this beat, advance one
   # phase via the engine (sole writer). Defers to the DM when it advanced time in-fiction.
   worldos_soft_tick "$ROOT" "$STATE_DIR" "$PREV_DAY" "$PREV_TOD"
+  duo_write_checkpoint "$b"
 done
+fi
 
 # #1285 defense-in-depth: if the streak was stamped but a caller path didn't already exit 2 above
 # (e.g. the threshold was crossed on the LAST beat and the loop simply ended rather than hitting
@@ -512,6 +756,11 @@ done
 
 # Wrap + score the DM transcript (it carries the narration + all tool calls).
 turn dm "$DSID" 0 "We are out of time. Bring this beat to a clean stopping point and call end_session with a one-line summary." >/dev/null
+if duo_quota_seen "$STATE_DIR/.dm_last_result" "$COMBINED" "$T/$RUN.dm.err"; then
+  echo "[duo] QUOTA ABORT — throttled after beat $LAST_COMPLETED_BEAT during session wrap-up. Skipping scoring; this is an INFRA abort, NOT a product measurement." >&2
+  echo "[duo] throttled at beat $LAST_COMPLETED_BEAT — re-invoke the same command in a fresh window to resume" >&2
+  exit "$EX_TEMPFAIL"
+fi
 echo "[duo] distilling + scoring…"
 python3 qa/distill.py "$COMBINED" 2>/dev/null
 # The PLAYED exchange (both sides) for the STORY scorer: scene_craft/playability must be
@@ -544,11 +793,12 @@ wait
 # sentinel into its OUT and exiting rc=2 — so the scorer can quota-trip even when the DM cold-open
 # itself didn't (e.g. the account hits the limit AFTER the play, during scoring). Any lens carrying
 # that sentinel is NOT a valid scorecard — short-circuit to the same QUOTA ABORT path Fix E uses
-# (log the marker the VM sweep greps + exit rc=2) instead of scoring/gating on a quota corpse.
+# (log the marker the VM sweep greps + exit rc=75 / EX_TEMPFAIL) instead of scoring/gating on a quota corpse.
 for _scf in "$T/$RUN.tolkien.json" "$T/$RUN.score.json" "$T/$RUN.angrydm.json"; do
   if [ -f "$_scf" ] && jq -e '.quota_exhausted == true' "$_scf" >/dev/null 2>&1; then
     echo "[duo] QUOTA ABORT — the scorer hit the account session limit (HTTP 429) on $(basename "$_scf"). Skipping the gate + scorecards; INFRA abort, NOT a product measurement." >&2
-    exit 2
+    echo "[duo] throttled at beat $LAST_COMPLETED_BEAT — re-invoke the same command in a fresh window to resume" >&2
+    exit "$EX_TEMPFAIL"
   fi
 done
 # SCORER-INTEGRITY (WS0a) — a scorer FAILURE must NOT read as GREEN/passing or as a blank no-score.
@@ -575,7 +825,7 @@ if [ "$UNSCORABLE" = "1" ]; then
   echo "[duo] RUN STATUS: unscorable — one or more lenses failed to score (${UNSCORABLE_DETAIL}). A blank/sentinel lens value is a scorer FAILURE, not a passing or no-score run." >&2
 fi
 # Behavioral gate — flip RED on a structurally broken run (treat it like software).
-python3 qa/assert_behavioral.py "$COMBINED" "$T/$RUN.state.json" "$T/$RUN.chat.jsonl" "$MOVES" | tee "$T/$RUN.gate.txt"; GATE=${PIPESTATUS[0]}
+python3 "$ASSERT_BEHAVIORAL_SCRIPT" "$COMBINED" "$T/$RUN.state.json" "$T/$RUN.chat.jsonl" "$MOVES" | tee "$T/$RUN.gate.txt"; GATE=${PIPESTATUS[0]}
 # Honest scoring: a gate-RED (non-progressing/structurally broken) run must NOT display as 4.1.
 # CAP both recorded scorecards to ≤2.5 / INVALID and annotate WHY (the failed checks), so a dead
 # scene can't masquerade as prestige play. Engine/scoring untouched on a GREEN run.
@@ -603,4 +853,5 @@ fi
 # card, else FAILED:<status> (missing|invalid|sentinel|nonnumeric). When ANY lens failed, the line
 # carries an explicit status=unscorable so a downstream reader / a human can never mistake it for GREEN.
 echo "[duo] done. story-craft=$(worldos_lens_display "$T/$RUN.tolkien.json") mechanical=$(worldos_lens_display "$T/$RUN.score.json") angry-dm=$(worldos_lens_display "$T/$RUN.angrydm.json") behavioral=$([ "$GATE" = 0 ] && echo GREEN || echo RED)$([ "$UNSCORABLE" = 1 ] && echo ' status=unscorable') ${LAT_SUMMARY:-}"
+duo_delete_checkpoint
 exit $GATE

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -92,6 +92,7 @@ T="qa/transcripts"; STATE_DIR="$ROOT/qa/state/$RUN"
 CHECKPOINT="$STATE_DIR/.duo_checkpoint.json"
 CHECKPOINT_MANIFEST="$STATE_DIR/.duo_checkpoint_offsets.json"
 CHECKPOINT_SLOT="duo_checkpoint"
+LOCKDIR="$STATE_DIR/.duo_run.lock"
 mkdir -p "$T" "$STATE_DIR"
 
 RESUME_MODE=0
@@ -101,8 +102,38 @@ DSID=""
 PSID=""
 CAMPAIGN_ID=""
 
-duo_quota_seen() {
+duo_quota_protocol_seen() {
+  grep -qiE 'api_error_status"[[:space:]]*:[[:space:]]*429|session limit|HTTP 429|hit your (session|usage) limit' "$@" 2>/dev/null
+}
+
+duo_quota_error_seen() {
   grep -qiE 'api_error_status"[[:space:]]*:[[:space:]]*429|session limit|HTTP 429|hit your (session|usage) limit|rate[_ -]?limit|too many requests' "$@" 2>/dev/null
+}
+
+duo_release_lock() {
+  rm -rf "$LOCKDIR" 2>/dev/null || true
+}
+
+duo_acquire_lock() {
+  if mkdir "$LOCKDIR" 2>/dev/null; then
+    printf '%s\n' "$$" > "$LOCKDIR/pid"
+    trap duo_release_lock EXIT
+    return 0
+  fi
+  local oldpid=""
+  oldpid="$(cat "$LOCKDIR/pid" 2>/dev/null || true)"
+  if [ -n "$oldpid" ] && kill -0 "$oldpid" 2>/dev/null; then
+    echo "[duo] another qa/run_duo.sh process is already using $STATE_DIR (pid $oldpid); use a different run id or wait for it to finish" >&2
+    exit 2
+  fi
+  echo "[duo] removing stale run lock at $LOCKDIR" >&2
+  rm -rf "$LOCKDIR" 2>/dev/null || true
+  if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "[duo] could not acquire run lock at $LOCKDIR" >&2
+    exit 2
+  fi
+  printf '%s\n' "$$" > "$LOCKDIR/pid"
+  trap duo_release_lock EXIT
 }
 
 duo_engine_slot() {
@@ -260,6 +291,8 @@ if path.exists():
 print(last)
 PY
 }
+
+duo_acquire_lock
 
 if [ -s "$CHECKPOINT" ]; then
   if ! jq -e . "$CHECKPOINT" >/dev/null 2>&1; then
@@ -613,7 +646,7 @@ echo "[duo] DM opened: ${DMSG:0:120}…"
 # failure — it is an INFRA abort. Detect it BEFORE scoring so we never burn the 3-lens scorer on a
 # quota corpse (or, worse, cap-RED a quota'd run as a 2.5 product score). Log a marker the VM sweep
 # greps for and exit rc=75 / EX_TEMPFAIL (distinct from the rc=1 genuine-no-opening abort below).
-if duo_quota_seen "$COMBINED" "$T/$RUN.dm.err"; then
+if duo_quota_protocol_seen "$COMBINED" "$T/$RUN.dm.err" || duo_quota_error_seen "$T/$RUN.dm.err" "$STATE_DIR/.dm_last_result"; then
   echo "[duo] QUOTA ABORT — DM cold-open hit the account session limit (HTTP 429). Skipping scoring; this is an INFRA abort, NOT a product measurement." >&2
   echo "[duo] throttled at beat 0 — re-invoke the same command in a fresh window to resume" >&2
   exit "$EX_TEMPFAIL"
@@ -719,7 +752,7 @@ $EVENT_ADV")"
   # by assert_behavioral's dm_beat_honesty) instead of masking with error text/recycled prose.
   if [ -z "$DMSG" ]; then
     worldos_chatlog_dm_failed
-    if duo_quota_seen "$STATE_DIR/.dm_last_result" "$COMBINED" "$T/$RUN.dm.err"; then
+    if duo_quota_protocol_seen "$STATE_DIR/.dm_last_result" "$COMBINED" "$T/$RUN.dm.err" || duo_quota_error_seen "$STATE_DIR/.dm_last_result" "$T/$RUN.dm.err"; then
       echo "[duo] QUOTA ABORT — DM beat $b hit the account session limit / rate limit. Skipping scoring; this is an INFRA abort, NOT a product measurement." >&2
       echo "[duo] throttled at beat $b — re-invoke the same command in a fresh window to resume" >&2
       exit "$EX_TEMPFAIL"
@@ -756,7 +789,7 @@ fi
 
 # Wrap + score the DM transcript (it carries the narration + all tool calls).
 turn dm "$DSID" 0 "We are out of time. Bring this beat to a clean stopping point and call end_session with a one-line summary." >/dev/null
-if duo_quota_seen "$STATE_DIR/.dm_last_result" "$COMBINED" "$T/$RUN.dm.err"; then
+if duo_quota_protocol_seen "$STATE_DIR/.dm_last_result" "$COMBINED" "$T/$RUN.dm.err" || duo_quota_error_seen "$STATE_DIR/.dm_last_result" "$T/$RUN.dm.err"; then
   echo "[duo] QUOTA ABORT — throttled after beat $LAST_COMPLETED_BEAT during session wrap-up. Skipping scoring; this is an INFRA abort, NOT a product measurement." >&2
   echo "[duo] throttled at beat $LAST_COMPLETED_BEAT — re-invoke the same command in a fresh window to resume" >&2
   exit "$EX_TEMPFAIL"

--- a/qa/test_duo_resume.py
+++ b/qa/test_duo_resume.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""No-LLM resume tests for qa/run_duo.sh.
+
+The test stubs claude/uv and the scorer, then drives the real bash runner so the
+checkpoint, resume, throttle, and artifact-pruning paths are exercised without a
+live model or real engine process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+import uuid
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class DuoResumeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self.tmp.name)
+        self.bin_dir = self.tmp_path / "bin"
+        self.bin_dir.mkdir()
+        self.log_path = self.tmp_path / "stub-calls.jsonl"
+        self.score_script = self.tmp_path / "score_stub.sh"
+        self.assert_script = self.tmp_path / "assert_green.py"
+        self._write_stubs()
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _run_id(self) -> str:
+        return f"duo-resume-test-{uuid.uuid4().hex[:10]}"
+
+    def _cleanup_run(self, run_id: str) -> None:
+        shutil.rmtree(ROOT / "qa" / "state" / run_id, ignore_errors=True)
+        transcript_dir = ROOT / "qa" / "transcripts"
+        for path in transcript_dir.glob(f"{run_id}*"):
+            if path.is_file() or path.is_symlink():
+                path.unlink(missing_ok=True)
+            elif path.is_dir():
+                shutil.rmtree(path, ignore_errors=True)
+
+    def _write_stubs(self) -> None:
+        claude = self.bin_dir / "claude"
+        claude.write_text(
+            textwrap.dedent(
+                r"""
+                #!/usr/bin/env python3
+                import json
+                import os
+                import sys
+                from pathlib import Path
+
+                argv = sys.argv[1:]
+
+                def arg_after(flag, default=""):
+                    try:
+                        return argv[argv.index(flag) + 1]
+                    except (ValueError, IndexError):
+                        return default
+
+                cfg_path = arg_after("--mcp-config")
+                cfg = json.loads(Path(cfg_path).read_text()) if cfg_path else {}
+                log = Path(os.environ["WORLDOS_DUO_STUB_LOG"])
+
+                if arg_after("--output-format") == "json":
+                    moves = Path(cfg["mcpServers"]["worldos-player"]["env"]["WORLDOS_PLAYER_MOVES"])
+                    moves.parent.mkdir(parents=True, exist_ok=True)
+                    count = 1
+                    if moves.exists() and moves.read_text().strip():
+                        count = len(moves.read_text().splitlines()) + 1
+                    text = f"player move {count}"
+                    with moves.open("a", encoding="utf-8") as handle:
+                        handle.write(json.dumps({"kind": "say", "text": text}) + "\n")
+                    with log.open("a", encoding="utf-8") as handle:
+                        handle.write(json.dumps({"role": "player", "text": text}) + "\n")
+                    print(json.dumps({"result": text}))
+                    sys.exit(0)
+
+                engine = cfg["mcpServers"]["worldos-engine"]
+                state = Path(engine["env"]["WORLDOS_STATE_DIR"])
+                state.mkdir(parents=True, exist_ok=True)
+                campaigns = state / "campaigns"
+                camp = campaigns / "camp_stub"
+                camp.mkdir(parents=True, exist_ok=True)
+                snap = camp / "snapshot.json"
+                if not snap.exists():
+                    snap.write_text(json.dumps({
+                        "id": "camp_stub",
+                        "title": "Stub Campaign",
+                        "world_id": "baldurs-gate",
+                        "day": 1,
+                        "time_of_day": "morning",
+                        "locations": {"loc_stub": {"id": "loc_stub", "name": "Stub Room", "visited": True}},
+                        "current_location_id": "loc_stub",
+                        "characters": {},
+                        "party": [],
+                        "combat": {"active": False}
+                    }) + "\n", encoding="utf-8")
+
+                prompt = arg_after("-p")
+                phase = "dm"
+                if "Begin the session" in prompt:
+                    phase = "cold_open"
+                elif "We are out of time" in prompt:
+                    phase = "wrap"
+                elif "The player does:" in prompt:
+                    phase = "beat"
+
+                beat = 0
+                if phase == "beat":
+                    import re
+                    match = re.search(r"beat (\d+)", prompt)
+                    if match:
+                        beat = int(match.group(1))
+                    else:
+                        beat_file = state / ".stub_beat_count"
+                        beat = int(beat_file.read_text()) + 1 if beat_file.exists() else 1
+                        beat_file.write_text(str(beat), encoding="utf-8")
+
+                throttle = int(os.environ.get("WORLDOS_DUO_STUB_THROTTLE_BEAT", "0") or "0")
+                with log.open("a", encoding="utf-8") as handle:
+                    handle.write(json.dumps({"role": "dm", "phase": phase, "beat": beat}) + "\n")
+                if phase == "beat" and beat == throttle:
+                    print(json.dumps({
+                        "type": "result",
+                        "is_error": True,
+                        "api_error_status": 429,
+                        "result": "HTTP 429 hit your session limit"
+                    }))
+                    sys.exit(0)
+
+                if phase == "beat":
+                    data = json.loads(snap.read_text())
+                    data["day"] = int(data.get("day") or 1) + 1
+                    snap.write_text(json.dumps(data) + "\n", encoding="utf-8")
+
+                if phase == "cold_open":
+                    result = "DM opened the stub scene."
+                elif phase == "wrap":
+                    result = "DM wrapped the stub session."
+                elif phase == "beat":
+                    result = f"DM beat {beat} resolved."
+                else:
+                    result = "DM response."
+                print(json.dumps({"type": "result", "subtype": "success", "is_error": False, "result": result}))
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        claude.chmod(0o755)
+
+        uv = self.bin_dir / "uv"
+        uv.write_text(
+            textwrap.dedent(
+                r"""
+                #!/usr/bin/env python3
+                import os
+                import shutil
+                import sys
+                from pathlib import Path
+
+                sys.stdin.read()
+                state = Path(os.environ.get("WORLDOS_STATE_DIR", ""))
+                args = sys.argv[1:]
+                tail = args[args.index("-") + 1:] if "-" in args else []
+                if tail and tail[0] in {"save", "load"}:
+                    action, campaign_id, slot = tail[:3]
+                    camp = state / "campaigns" / campaign_id
+                    snap = camp / "snapshot.json"
+                    slot_path = camp / "slots" / f"{slot}.json"
+                    slot_path.parent.mkdir(parents=True, exist_ok=True)
+                    if action == "save":
+                        shutil.copyfile(snap, slot_path)
+                    else:
+                        shutil.copyfile(slot_path, snap)
+                    sys.exit(0)
+                if len(tail) == 1:
+                    snap = state / "campaigns" / "camp_stub" / "snapshot.json"
+                    if snap.exists():
+                        print("camp_stub")
+                    sys.exit(0)
+                sys.exit(0)
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        uv.chmod(0o755)
+
+        self.score_script.write_text(
+            "#!/usr/bin/env bash\nprintf '{\"overall\":4.0,\"scores\":{}}\\n' > \"$5\"\n",
+            encoding="utf-8",
+        )
+        self.score_script.chmod(0o755)
+
+        self.assert_script.write_text(
+            "#!/usr/bin/env python3\nprint('[PASS] stub behavioral gate')\n",
+            encoding="utf-8",
+        )
+        self.assert_script.chmod(0o755)
+
+    def _env(self, **overrides: str) -> dict[str, str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.bin_dir}:{env.get('PATH', '')}",
+                "WORLDOS_DM_MODEL": "sonnet",
+                "WORLDOS_ACTOR_MODEL": "sonnet",
+                "WORLDOS_SCORE_SCRIPT": str(self.score_script),
+                "WORLDOS_ASSERT_BEHAVIORAL_SCRIPT": str(self.assert_script),
+                "WORLDOS_DUO_STUB_LOG": str(self.log_path),
+                "WORLDOS_DM_MAX_ATTEMPTS": "1",
+                "WORLDOS_LEAN_BEATS": "0",
+                "WORLDOS_COLDOPEN_TIMEOUT": "5",
+                "WORLDOS_BEAT_TIMEOUT": "5",
+                "WORLDOS_SCORE_TIMEOUT": "5",
+            }
+        )
+        env.update(overrides)
+        return env
+
+    def _run_duo(self, run_id: str, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", "qa/run_duo.sh", run_id, "baldurs-gate", "qa/play_player_duo.txt", "3", "0.80"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            env=self._env(**env_overrides),
+            timeout=30,
+        )
+
+    def _checkpoint(self, run_id: str) -> Path:
+        return ROOT / "qa" / "state" / run_id / ".duo_checkpoint.json"
+
+    def _chat_rows(self, run_id: str) -> list[dict]:
+        path = ROOT / "qa" / "transcripts" / f"{run_id}.chat.jsonl"
+        return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+    def test_one_window_run_removes_checkpoint_and_records_three_beats(self) -> None:
+        run_id = self._run_id()
+        self.addCleanup(self._cleanup_run, run_id)
+
+        proc = self._run_duo(run_id)
+
+        self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+        self.assertFalse(self._checkpoint(run_id).exists())
+        dm_beat_rows = [r for r in self._chat_rows(run_id) if r["role"] == "dm" and r["text"].startswith("DM beat ")]
+        self.assertEqual([r["text"] for r in dm_beat_rows], [
+            "DM beat 1 resolved.",
+            "DM beat 2 resolved.",
+            "DM beat 3 resolved.",
+        ])
+
+    def test_throttled_run_resumes_from_last_completed_beat_without_double_logging(self) -> None:
+        run_id = self._run_id()
+        self.addCleanup(self._cleanup_run, run_id)
+
+        first = self._run_duo(run_id, WORLDOS_DUO_STUB_THROTTLE_BEAT="3")
+        self.assertEqual(first.returncode, 75, first.stderr + first.stdout)
+        self.assertIn("throttled at beat 3", first.stderr + first.stdout)
+        checkpoint = json.loads(self._checkpoint(run_id).read_text())
+        self.assertEqual(checkpoint["last_completed_beat"], 2)
+
+        second = self._run_duo(run_id)
+        self.assertEqual(second.returncode, 0, second.stderr + second.stdout)
+        self.assertFalse(self._checkpoint(run_id).exists())
+        rows = self._chat_rows(run_id)
+        dm_beat_rows = [r for r in rows if r["role"] == "dm" and r["text"].startswith("DM beat ")]
+        player_rows = [r for r in rows if r["role"] == "player"]
+        self.assertEqual([r["text"] for r in dm_beat_rows], [
+            "DM beat 1 resolved.",
+            "DM beat 2 resolved.",
+            "DM beat 3 resolved.",
+        ])
+        self.assertEqual(len(player_rows), 4)  # intro + exactly three beat moves
+
+    def test_sha_mismatch_refuses_resume_without_silent_restart(self) -> None:
+        run_id = self._run_id()
+        self.addCleanup(self._cleanup_run, run_id)
+        state = ROOT / "qa" / "state" / run_id
+        state.mkdir(parents=True, exist_ok=True)
+        self._checkpoint(run_id).write_text(
+            json.dumps(
+                {
+                    "last_completed_beat": 1,
+                    "player_session_id": "player-old",
+                    "dm_session_id": "dm-old",
+                    "campaign_id": "camp_stub",
+                    "world": "baldurs-gate",
+                    "persona": "qa/play_player_duo.txt",
+                    "total_beats": 3,
+                    "budget": "0.80",
+                    "sha": "oldsha",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        proc = self._run_duo(run_id)
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("checkpoint sha oldsha != current", proc.stderr + proc.stdout)
+        self.assertFalse((ROOT / "qa" / "transcripts" / f"{run_id}.chat.jsonl").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qa/test_duo_resume.py
+++ b/qa/test_duo_resume.py
@@ -12,7 +12,6 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
 import textwrap
 import unittest

--- a/qa/test_release_gate_static.py
+++ b/qa/test_release_gate_static.py
@@ -276,12 +276,13 @@ class QuotaCircuitBreakerStaticContractTests(unittest.TestCase):
 
     def test_run_duo_checks_for_quota_abort_before_scoring(self):
         # Fix E + Fix F (caller half): run_duo.sh must (1) detect a DM cold-open 429 and emit the
-        # "[duo] QUOTA ABORT" marker + exit rc=2 BEFORE the empty-reply abort, and (2) treat the
+        # "[duo] QUOTA ABORT" marker + exit EX_TEMPFAIL BEFORE the empty-reply abort, and (2) treat the
         # score.sh quota sentinel as a quota abort (not a valid scorecard) before the behavioral gate.
         source = (ROOT / "qa" / "run_duo.sh").read_text(encoding="utf-8")
         self.assertIn("[duo] QUOTA ABORT", source)
         self.assertIn("session limit|HTTP 429|hit your (session|usage) limit", source)
         self.assertIn(".quota_exhausted == true", source)
+        self.assertIn('ASSERT_BEHAVIORAL_SCRIPT="$(worldos_env ASSERT_BEHAVIORAL_SCRIPT qa/assert_behavioral.py)"', source)
         # the cold-open quota check must precede the empty-reply abort (DM produced no opening).
         self.assertLess(
             source.index("[duo] QUOTA ABORT"),
@@ -290,7 +291,7 @@ class QuotaCircuitBreakerStaticContractTests(unittest.TestCase):
         # the scorer-sentinel quota check must precede the behavioral gate (no gating a quota corpse).
         self.assertLess(
             source.index(".quota_exhausted == true"),
-            source.index("python3 qa/assert_behavioral.py"),
+            source.index('python3 "$ASSERT_BEHAVIORAL_SCRIPT"'),
         )
 
 


### PR DESCRIPTION
Closes #1373.

## Summary
- Add per-beat qa/state/<run>/.duo_checkpoint.json with last completed beat, session ids, campaign id, invocation identity, budget, and git SHA.
- Resume matching invocations from last_completed_beat + 1, restore the checkpointed engine snapshot through the existing engine save/load slot, and prune partial next-beat transcript artifacts before replay.
- Return EX_TEMPFAIL/75 for detected quota/rate-limit aborts with a resume instruction, preserving checkpoints; delete checkpoints only after clean completion.
- Add no-LLM subprocess coverage for one-window completion, throttle resume, SHA-mismatch refusal, and no double-logged beats.

## Verification
- bash -n qa/run_duo.sh
- uv run --directory servers/engine python -m pytest ../../qa/test_duo_resume.py ../../qa/test_release_gate_static.py -q -p no:xdist
- bash qa/test_run_duo_retry_robustness.sh
- bash qa/test_run_duo_dm_timeout.sh
- bash qa/fast_gate.sh