### PR TITLE
[qa] demo_reel — the standing walkable-loop pixel artifact (#1346 R2)

### DIFF
--- a/qa/demo_reel.py
+++ b/qa/demo_reel.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""demo_reel.py — the STANDING walkable-loop pixel artifact (#1346 R2).
+
+The owner's #1 visibility deliverable, made rerunnable: boot the REAL viewer on a seeded
+2-room rest campaign and capture the full walkable loop as browser-level PNG frames of the
+actual /openworlds/ UI — the rest scene, click-to-walk, approach-a-present-NPC, the parley
+opening AT the actor, a door-cell cross, and arrival in the linked room.
+
+ASSEMBLY (reuse, don't regress):
+  - STATE + DRIVING is qa/walk_click_replay.py: its seed() (a 2-room rest campaign with a
+    party PC + a present NPC + a shared doorway), its viewer boot with boot-log CAPTURE +
+    one fresh-port retry, and its readiness probe are imported and reused verbatim. The
+    engine is the SOLE WRITER — this script only SEEDS then drives the booted viewer.
+  - PIXELS are captured at the BROWSER level by qa/demo_reel_capture.js (system Chrome via
+    the existing qa/playwright install — NO new deps). It drives the loop through REAL DOM
+    clicks on the rest board (the same onClick → POST /move the player fires), so the frames
+    are the honest UI, not a synthetic render.
+
+NO DM / NO LLM: walk_to_cell + parley_approach (generate_parley_options approach=True) are
+engine-only; the viewer is a pure consumer.
+
+Run:  uv run --directory servers/engine python "$PWD/qa/demo_reel.py" [--out DIR]
+Exit 0 = every frame captured + verified non-black; non-zero (with a readable error) = the
+first step that failed. This is a CI-adjacent artifact — it must fail loud.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import zlib
+from pathlib import Path
+
+# Reuse walk_click_replay's seed + boot + readiness (STATE/DRIVING) without regressing it.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import walk_click_replay as wcr  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+CAPTURE_JS = ROOT / "qa" / "demo_reel_capture.js"
+DEFAULT_OUT = Path.home() / "worldos-session-notes" / "felt-frames" / "demo-reel-2026-07-08"
+
+# The loop targets on the seeded 8x6 grid (hero starts at (1,4), NPC sits at (6,1)):
+WALK_CELL = (6, 4)      # click-to-walk: a clear cell across the room
+APPROACH_CELL = (6, 2)  # approach walk: a walkable cell adjacent (Chebyshev-1) to the NPC at (6,1)
+
+CAPTIONS = {
+    "01-rest-scene": "Rest scene: the party (Aldric) and a present NPC (Innkeeper Bram) stand on the walkable plate.",
+    "02-walk-arrived": "Click-to-walk: the selected token glided along an engine-routed path to the clicked cell (6,4).",
+    "03-approach-walk": "Approach: a second click walks Aldric up beside Bram, ready to talk.",
+    "04-parley-open": "Clicking the NPC opens the parley AT the actor — the Dialogue screen, staged at Bram's cell.",
+    "05-door-cell": "Back on the board: the northern doorway cell, selected for a cross into the linked room.",
+    "06-arrived-linked-room": "After the door click: walked to the doorway and crossed into the linked Inner Hall — the return doorway back to the Antechamber is now offered.",
+}
+EXPECTED_FRAMES = list(CAPTIONS.keys())
+
+
+def _die(msg: str, code: int = 1) -> "NoReturn":  # type: ignore[valid-type]
+    print(f"\nDEMO-REEL FAILED: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _png_size(p: Path) -> tuple[int, int]:
+    """(w, h) from a PNG IHDR — no image deps."""
+    with open(p, "rb") as f:
+        head = f.read(24)
+    if head[:8] != b"\x89PNG\r\n\x1a\n":
+        _die(f"{p.name} is not a PNG")
+    w, h = struct.unpack(">II", head[16:24])
+    return w, h
+
+
+def _mean_luma_sample(p: Path) -> float:
+    """Cheap non-black check: decode the PNG (stdlib zlib) and average a stride sample of
+    luma. A black/blank frame scores ~0; a rendered painterly board scores well above the
+    threshold. Kept dependency-free (no PIL) so the reel runs anywhere the engine runs."""
+    raw = p.read_bytes()
+    # Concatenate all IDAT chunks, inflate, and un-filter enough rows to sample.
+    pos = 8
+    idat = bytearray()
+    width = height = 0
+    color_type = 0
+    while pos + 8 <= len(raw):
+        (length,) = struct.unpack(">I", raw[pos:pos + 4])
+        ctype = raw[pos + 4:pos + 8]
+        data = raw[pos + 8:pos + 8 + length]
+        if ctype == b"IHDR":
+            width, height, _bd, color_type = struct.unpack(">IIBB", data[:10])
+        elif ctype == b"IDAT":
+            idat += data
+        elif ctype == b"IEND":
+            break
+        pos += 12 + length
+    if not idat or not width or not height:
+        _die(f"{p.name}: could not read pixel data for the non-black check")
+    channels = {0: 1, 2: 3, 3: 1, 4: 2, 6: 4}.get(color_type, 4)
+    stride = width * channels
+    buf = zlib.decompress(bytes(idat))
+    prev = bytearray(stride)
+    total = 0.0
+    count = 0
+    for y in range(height):
+        base = y * (stride + 1)
+        if base + 1 + stride > len(buf):
+            break
+        ft = buf[base]
+        row = bytearray(buf[base + 1: base + 1 + stride])
+        # Un-filter (PNG filter types 0-4) so sampled bytes are true pixel values.
+        for i in range(stride):
+            a = row[i - channels] if i >= channels else 0
+            b = prev[i]
+            c = prev[i - channels] if i >= channels else 0
+            x = row[i]
+            if ft == 1:
+                row[i] = (x + a) & 0xFF
+            elif ft == 2:
+                row[i] = (x + b) & 0xFF
+            elif ft == 3:
+                row[i] = (x + ((a + b) >> 1)) & 0xFF
+            elif ft == 4:
+                pa, pb, pc = abs(b - c), abs(a - c), abs(a + b - 2 * c)
+                pr = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
+                row[i] = (x + pr) & 0xFF
+        # Sample every ~37th pixel's first channel (luma proxy) to keep this cheap.
+        for px in range(0, width, 37):
+            total += row[px * channels]
+            count += 1
+        prev = row
+    return (total / count) if count else 0.0
+
+
+def _maybe_gif(out_dir: Path, frame_paths: list[Path]) -> bool:
+    """Assemble a demo.gif if ffmpeg or ImageMagick is present; skip gracefully otherwise."""
+    gif = out_dir / "demo.gif"
+    if shutil.which("ffmpeg"):
+        # Build a concat list so each frame holds ~1.6s.
+        listing = out_dir / "_gif_frames.txt"
+        listing.write_text("".join(f"file '{p.name}'\nduration 1.6\n" for p in frame_paths)
+                           + f"file '{frame_paths[-1].name}'\n")
+        r = subprocess.run(
+            ["ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(listing),
+             "-vf", "scale=1000:-1:flags=lanczos", str(gif)],
+            cwd=out_dir, capture_output=True, text=True,
+        )
+        listing.unlink(missing_ok=True)
+        if r.returncode == 0 and gif.exists():
+            return True
+        print(f"  (ffmpeg gif assembly failed, skipping: {r.stderr.strip()[-200:]})", file=sys.stderr)
+        return False
+    magick = shutil.which("magick") or shutil.which("convert")
+    if magick:
+        cmd = [magick] + (["convert"] if magick.endswith("convert") is False and Path(magick).name == "magick" else [])
+        r = subprocess.run(
+            [magick, "-delay", "160", "-loop", "0", "-resize", "1000x"]
+            + [str(p) for p in frame_paths] + [str(gif)],
+            capture_output=True, text=True,
+        )
+        if r.returncode == 0 and gif.exists():
+            return True
+        print(f"  (ImageMagick gif assembly failed, skipping: {r.stderr.strip()[-200:]})", file=sys.stderr)
+        return False
+    print("  (no ffmpeg/ImageMagick — skipping demo.gif)")
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Capture the WorldOS walkable-loop demo reel.")
+    ap.add_argument("--out", default=str(DEFAULT_OUT), help="output dir for frames + captions")
+    ap.add_argument("--keep-viewer-log", action="store_true", help="print the viewer boot log on success too")
+    args = ap.parse_args()
+
+    if not shutil.which("node"):
+        _die("node is not on PATH — the browser capture half needs it")
+    # Resolve the Playwright install: the repo-local qa/playwright/node_modules is the default, but a
+    # git worktree won't have that untracked dir — WORLDOS_PLAYWRIGHT_NM (a node_modules dir) overrides
+    # it so the reel runs from a worktree against a canonical checkout's install (no new deps either way).
+    pw_override = os.environ.get("WORLDOS_PLAYWRIGHT_NM")
+    pw_nm = Path(pw_override) if pw_override else (ROOT / "qa" / "playwright" / "node_modules")
+    pw = pw_nm / "playwright"
+    if not pw.exists():
+        _die(f"the qa/playwright install is missing ({pw}); run its npm install once "
+             f"(or set WORLDOS_PLAYWRIGHT_NM to a node_modules dir that has it) — no new deps added here")
+
+    out_dir = Path(args.out).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="demo-reel-") as td:
+        state_dir = str(Path(td) / "state")
+        Path(state_dir).mkdir(parents=True, exist_ok=True)
+        ids = wcr.seed(state_dir)
+
+        env = dict(os.environ)
+        env["WORLDOS_STATE_DIR"] = state_dir
+        env["WORLDOS_PLAYER_MOVES"] = str(Path(td) / "moves.ndjson")  # enables the /move write path
+
+        # Boot the viewer with output CAPTURED + one fresh-port retry (reused verbatim from
+        # walk_click_replay.main so a silent import/bind failure surfaces, not a generic timeout).
+        boot_log = Path(td) / "viewer-boot.log"
+        proc = None
+        base = ""
+        for attempt in (1, 2):
+            port = wcr._free_port()
+            base = f"http://127.0.0.1:{port}"
+            with open(boot_log, "wb") as lf:
+                proc = subprocess.Popen(
+                    [sys.executable, str(wcr.VIEWER), wcr.CID, str(port)],
+                    env=env, stdout=lf, stderr=subprocess.STDOUT,
+                )
+            try:
+                wcr._wait_ready(base)
+                break
+            except RuntimeError:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                tail = boot_log.read_bytes()[-2000:].decode(errors="replace")
+                if attempt == 2:
+                    _die(f"viewer never came up; boot log tail:\n{tail}")
+                print(f"boot attempt {attempt} failed (bind race or slow boot) — retrying on a "
+                      f"fresh port; log tail:\n{tail}", file=sys.stderr)
+
+        try:
+            print(f"viewer up on {base} (campaign {wcr.CID}) — driving the loop through the real UI")
+            cap_env = dict(os.environ)
+            cap_env["WORLDOS_PW_MODULE"] = str(pw)
+            cap = subprocess.run(
+                ["node", str(CAPTURE_JS), base, "Aldric", "Innkeeper Bram",
+                 str(WALK_CELL[0]), str(WALK_CELL[1]), str(APPROACH_CELL[0]), str(APPROACH_CELL[1]),
+                 str(out_dir)],
+                capture_output=True, text=True, timeout=180, env=cap_env,
+            )
+            if cap.returncode != 0:
+                _die(f"browser capture failed (exit {cap.returncode}):\n{cap.stdout}\n{cap.stderr}")
+            try:
+                manifest = json.loads(cap.stdout.strip().splitlines()[-1])
+            except (ValueError, IndexError):
+                _die(f"could not parse the capture manifest:\n{cap.stdout}\n{cap.stderr}")
+            if manifest.get("pageErrors"):
+                print(f"  note: page errors during capture: {manifest['pageErrors']}", file=sys.stderr)
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            if args.keep_viewer_log:
+                print(f"--- viewer boot log ---\n{boot_log.read_text(errors='replace')}")
+
+    # ── verify every expected frame is on disk, a real PNG, non-trivial, and non-black ──────────
+    frame_paths: list[Path] = []
+    for name in EXPECTED_FRAMES:
+        p = out_dir / f"{name}.png"
+        if not p.exists():
+            _die(f"expected frame {p.name} was never written")
+        size = p.stat().st_size
+        if size < 20_000:
+            _die(f"{p.name} is only {size} bytes — trivially small (likely blank)")
+        w, h = _png_size(p)
+        if w < 400 or h < 300:
+            _die(f"{p.name} is {w}x{h} — too small to be the real UI")
+        luma = _mean_luma_sample(p)
+        if luma < 8.0:
+            _die(f"{p.name} mean luma {luma:.1f} — frame is black/blank")
+        print(f"  OK  {p.name}  ({w}x{h}, {size // 1024} KiB, luma {luma:.0f})")
+        frame_paths.append(p)
+
+    # captions.txt — one line per frame.
+    captions = out_dir / "captions.txt"
+    captions.write_text("".join(f"{name}.png  —  {CAPTIONS[name]}\n" for name in EXPECTED_FRAMES))
+    print(f"  captions -> {captions}")
+
+    gif_made = _maybe_gif(out_dir, frame_paths)
+    print(f"\ndemo_reel: {len(frame_paths)} frames verified + captions written to {out_dir}"
+          f"{' (+ demo.gif)' if gif_made else ''} ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/demo_reel.py
+++ b/qa/demo_reel.py
@@ -19,6 +19,20 @@ ASSEMBLY (reuse, don't regress):
 NO DM / NO LLM: walk_to_cell + parley_approach (generate_parley_options approach=True) are
 engine-only; the viewer is a pure consumer.
 
+PLATE RESOLUTION — the load-bearing gotcha (record for the next agent): the rest board paints
+the location's scene plate from scope `location:<loc_id>` (build_combat_surface), which the
+viewer's `_safe_scope` bridge (viewer/server.py:_scope_key) resolves by NAME-KEY: it drops the
+kind prefix and matches the ingested art keyed `scene:<slug>`. So a plate renders ONLY when the
+location id is a readable SLUG (e.g. canon `loc-lower-city` -> "lower-city" -> matches
+`scene:lower-city`). This synthetic reel's seed (walk_click_replay) uses HASH ids
+(`loc_<hex>`) which normalize to the bare hex and match NOTHING — so it renders a walkable
+grid with NO plate, BY DESIGN. To capture a plate UNDER the loop, drive an ART-BACKED campaign
+whose current location has a slug id + ingested plate: seed via qa/seed_canon_fixture.py
+(baldurs-gate; current loc `loc-lower-city` has a servable plate + a 19x14 scene_grid), add a
+present NPC on a walkable cell, and run demo_reel_capture.js directly against that booted
+viewer (from the canonical checkout, where the gitignored _private art lives). The door steps
+in demo_reel_capture.js are OPTIONAL — they skip cleanly when the location has no linked room.
+
 Run:  uv run --directory servers/engine python "$PWD/qa/demo_reel.py" [--out DIR]
 Exit 0 = every frame captured + verified non-black; non-zero (with a readable error) = the
 first step that failed. This is a CI-adjacent artifact — it must fail loud.

--- a/qa/demo_reel.py
+++ b/qa/demo_reel.py
@@ -139,7 +139,11 @@ def _mean_luma_sample(p: Path) -> float:
                 pa, pb, pc = abs(b - c), abs(a - c), abs(a + b - 2 * c)
                 pr = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
                 row[i] = (x + pr) & 0xFF
-        # Sample every ~37th pixel's first channel (luma proxy) to keep this cheap.
+        # Sample every ~37th pixel's first channel (luma proxy) to keep this cheap. NOTE: this is
+        # red-biased (true luma weights G ~0.59 >> R ~0.30), so a near-monochrome dark-green/blue
+        # frame could read lower than its real luminance — acceptable for a coarse non-black gate
+        # (threshold 8.0 is well below any rendered board's red channel), but not a general luma
+        # meter. Widen to all channels if a real capture ever needs a tighter threshold here.
         for px in range(0, width, 37):
             total += row[px * channels]
             count += 1
@@ -167,9 +171,11 @@ def _maybe_gif(out_dir: Path, frame_paths: list[Path]) -> bool:
         return False
     magick = shutil.which("magick") or shutil.which("convert")
     if magick:
-        cmd = [magick] + (["convert"] if magick.endswith("convert") is False and Path(magick).name == "magick" else [])
+        # IM7's `magick` binary needs an explicit `convert` subcommand; IM6's `convert` binary
+        # (or a `magick` symlinked straight to it) does not.
+        cmd = [magick] + (["convert"] if Path(magick).name == "magick" and not magick.endswith("convert") else [])
         r = subprocess.run(
-            [magick, "-delay", "160", "-loop", "0", "-resize", "1000x"]
+            cmd + ["-delay", "160", "-loop", "0", "-resize", "1000x"]
             + [str(p) for p in frame_paths] + [str(gif)],
             capture_output=True, text=True,
         )
@@ -205,7 +211,7 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="demo-reel-") as td:
         state_dir = str(Path(td) / "state")
         Path(state_dir).mkdir(parents=True, exist_ok=True)
-        ids = wcr.seed(state_dir)
+        wcr.seed(state_dir)
 
         env = dict(os.environ)
         env["WORLDOS_STATE_DIR"] = state_dir

--- a/qa/demo_reel_capture.js
+++ b/qa/demo_reel_capture.js
@@ -113,10 +113,17 @@ async function main() {
     await shot("04-parley-open");
 
     // ── 05 back to the board: select the hero, capture the door cell about to be crossed ──────
+    // The door steps are OPTIONAL: a location with no linked room has no door cell on its board
+    // (an art-backed single-room location is the common case). Capture the walk + approach-talk
+    // loop only and finish clean — a shorter reel, not a failure. Skip 05/06 when no door exists.
     await openBoard();
     await selectHero();
-    await page.waitForSelector(`${board} [data-worldos-door="1"]`, { timeout: 12000 })
-      .catch(() => fail("the door cell never rendered on the board"));
+    const doorCell = await page.$(`${board} [data-worldos-door="1"]`);
+    if (!doorCell) {
+      console.log(JSON.stringify({ ok: true, frames, doorSteps: false, pageErrors: pageErrors.slice(0, 8) }));
+      await browser.close();
+      return;
+    }
     await shot("05-door-cell");
 
     // ── 06 door click → walk-then-cross → arrived in the LINKED room ──────────────────────────
@@ -132,7 +139,7 @@ async function main() {
     await page.waitForTimeout(SETTLE_MS);
     await shot("06-arrived-linked-room");
 
-    console.log(JSON.stringify({ ok: true, frames, pageErrors: pageErrors.slice(0, 8) }));
+    console.log(JSON.stringify({ ok: true, frames, doorSteps: true, pageErrors: pageErrors.slice(0, 8) }));
   } finally {
     await browser.close();
   }

--- a/qa/demo_reel_capture.js
+++ b/qa/demo_reel_capture.js
@@ -1,0 +1,141 @@
+/*
+ * demo_reel_capture.js — the BROWSER half of qa/demo_reel.py (#1346 R2).
+ *
+ * Drives the REAL /openworlds/ UI (system Chrome via Playwright's `channel:"chrome"`,
+ * reusing the qa/playwright install — NO new deps, NO bundled-chromium download) around
+ * the full W2/W3 walkable loop against a viewer that qa/demo_reel.py has already booted on
+ * a seeded 2-room rest campaign, and saves one PNG per beat. Every walk / approach / door
+ * step is a REAL DOM click on the rest board (the same onClick → POST /move the player
+ * fires); the engine (in-process in the viewer) is the sole writer + router.
+ *
+ * Frames captured (into --out):
+ *   01-rest-scene            the painterly rest board: party + a present NPC on the plate
+ *   02-walk-arrived          click-to-walk — the selected token glided to the clicked cell
+ *   03-approach-walk         a walk toward the NPC (the approach step)
+ *   04-parley-open           clicking the NPC opens the parley AT the actor (Dialogue screen)
+ *   05-door-cell             back on the board, the door cell selected for a cross
+ *   06-arrived-linked-room   after the door click: arrived in the LINKED room
+ *
+ * Args (all required, positional):
+ *   base heroName npcName walkX walkY approachX approachY outDir
+ *
+ * Exits 0 on a full clean loop; non-zero with a readable error if any step fails
+ * (a selector never appears, a click never lands) — this is a CI-adjacent artifact.
+ */
+"use strict";
+
+const path = require("path");
+// Reuse the established qa/playwright install (system Chrome via channel) — never npm-install here.
+// WORLDOS_PW_MODULE lets demo_reel.py point at a canonical checkout's install when this file runs
+// from a git worktree (which git does not populate with the untracked node_modules).
+const PW_MODULE = process.env.WORLDOS_PW_MODULE || path.join(__dirname, "playwright", "node_modules", "playwright");
+const { chromium } = require(PW_MODULE);
+
+const [, , BASE, HERO_NAME, NPC_NAME, WALK_X, WALK_Y, APP_X, APP_Y, OUT_DIR] = process.argv;
+if (!BASE || !OUT_DIR) {
+  console.error("usage: node demo_reel_capture.js <base> <heroName> <npcName> <walkX> <walkY> <approachX> <approachY> <outDir>");
+  process.exit(2);
+}
+const CID_URL = `${BASE}/openworlds/#/combat`; // campaign is pinned by the booted viewer; #/combat lands on the scene screen
+const SETTLE_MS = 900; // let the glide CSS-transition + surface reload land before a capture
+const frames = [];
+
+function fail(msg) {
+  console.error(`DEMO-REEL-CAPTURE FAIL: ${msg}`);
+  process.exit(1);
+}
+
+async function main() {
+  const browser = await chromium.launch({ channel: "chrome", headless: true });
+  const pageErrors = [];
+  try {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 800 }, deviceScaleFactor: 2 });
+    page.on("pageerror", (e) => pageErrors.push(String((e && e.message) || e)));
+
+    const shot = async (name) => {
+      const p = path.join(OUT_DIR, `${name}.png`);
+      await page.screenshot({ path: p });
+      frames.push(name);
+    };
+    const board = '[data-worldos-testid="rest-board"]';
+    // Click a rest-board cell by its exact aria-label (the real player click at the cell's screen box).
+    const clickLabel = async (label, what) => {
+      const sel = `${board} [aria-label="${label}"]`;
+      const el = await page.waitForSelector(sel, { timeout: 12000 }).catch(() => null);
+      if (!el) fail(`could not find board cell «${label}» (${what})`);
+      await el.click();
+    };
+    const clickPrefix = async (prefix, what) => {
+      const sel = `${board} [aria-label^="${prefix}"]`;
+      const el = await page.waitForSelector(sel, { timeout: 12000 }).catch(() => null);
+      if (!el) fail(`could not find board cell starting «${prefix}» (${what})`);
+      await el.click();
+    };
+    const selectHero = () => clickPrefix(HERO_NAME, "select the hero token");
+
+    const openBoard = async () => {
+      await page.goto(CID_URL, { waitUntil: "networkidle", timeout: 30000 });
+      await page.waitForSelector(board, { timeout: 15000 }).catch(() => fail("rest board never rendered"));
+      await page.waitForTimeout(SETTLE_MS);
+    };
+
+    // ── 01 the rest scene: party + NPC on the plate ──────────────────────────────────────────
+    await openBoard();
+    await shot("01-rest-scene");
+
+    // ── 02 click-to-walk: select the hero, click a walkable cell, glide to it ─────────────────
+    await selectHero();
+    const walkLabel = `walk → (${WALK_X}, ${WALK_Y})`;
+    await clickLabel(walkLabel, "click-to-walk target");
+    // deterministic arrival: the walkable-cell label is replaced by the token once it lands there.
+    await page.waitForSelector(`${board} [aria-label="${walkLabel}"]`, { state: "detached", timeout: 12000 })
+      .catch(() => fail("the click-to-walk token never arrived at the clicked cell"));
+    await page.waitForTimeout(SETTLE_MS);
+    await shot("02-walk-arrived");
+
+    // ── 03 approach walk: walk the hero toward the NPC (the step before the parley) ───────────
+    await selectHero();
+    const appLabel = `walk → (${APP_X}, ${APP_Y})`;
+    await clickLabel(appLabel, "approach-walk target (adjacent to the NPC)");
+    await page.waitForSelector(`${board} [aria-label="${appLabel}"]`, { state: "detached", timeout: 12000 })
+      .catch(() => fail("the approach-walk token never arrived"));
+    await page.waitForTimeout(SETTLE_MS);
+    await shot("03-approach-walk");
+
+    // ── 04 click the NPC → approach + parley opens AT the actor (Dialogue screen) ─────────────
+    await clickPrefix(`Talk to ${NPC_NAME}`, "click the NPC to talk");
+    // the approach navigates to the Dialogue screen (onNavigate('dialogue')) and fetches /parley-surface.
+    await page.waitForFunction(() => /parley|dialogue/.test((window.location.hash || "").toLowerCase()), { timeout: 12000 })
+      .catch(() => fail("clicking the NPC never opened the Dialogue screen"));
+    await page.waitForFunction(() => /Speaking with/i.test(document.body.innerText || ""), { timeout: 12000 })
+      .catch(() => fail("the parley header (Speaking with …) never rendered"));
+    await page.waitForTimeout(SETTLE_MS);
+    await shot("04-parley-open");
+
+    // ── 05 back to the board: select the hero, capture the door cell about to be crossed ──────
+    await openBoard();
+    await selectHero();
+    await page.waitForSelector(`${board} [data-worldos-door="1"]`, { timeout: 12000 })
+      .catch(() => fail("the door cell never rendered on the board"));
+    await shot("05-door-cell");
+
+    // ── 06 door click → walk-then-cross → arrived in the LINKED room ──────────────────────────
+    // onRestDoorWalk walks the selected hero to the doorway, then crosses into the linked room.
+    // The linked room (Inner Hall) has an authored grid but no re-staged party token yet, so it
+    // renders the door-bar empty state (not a rest board) — its "Cross to Antechamber →" return
+    // door (present ONLY in the linked room, never on room A's board) is the honest arrival signal.
+    const doorEl = await page.$(`${board} [data-worldos-door="1"]`);
+    if (!doorEl) fail("door cell disappeared before the click");
+    await doorEl.click();
+    await page.waitForFunction(() => /Cross to Antechamber/i.test(document.body.innerText || ""), { timeout: 15000 })
+      .catch(() => fail("never arrived in the linked room after the door click"));
+    await page.waitForTimeout(SETTLE_MS);
+    await shot("06-arrived-linked-room");
+
+    console.log(JSON.stringify({ ok: true, frames, pageErrors: pageErrors.slice(0, 8) }));
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((e) => fail((e && e.message) || String(e)));

--- a/qa/test_demo_reel.py
+++ b/qa/test_demo_reel.py
@@ -37,6 +37,25 @@ def _write_png(path: Path, width: int, height: int, rgb: tuple[int, int, int]) -
     assert len(raw) == (stride + 1) * height  # sanity on the scanline layout
 
 
+def _write_png_rgba(path: Path, width: int, height: int, rgba: tuple[int, int, int, int]) -> None:
+    """Minimal filter-0 RGBA (color_type 6) PNG encoder — the format Playwright's page.screenshot
+    actually produces, so the luma gate must be pinned against this path too, not just RGB."""
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (struct.pack(">I", len(data)) + tag + data
+                + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF))
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)
+    stride = width * 4
+    raw = bytearray()
+    for _ in range(height):
+        raw.append(0)  # filter type 0 (none)
+        raw.extend(bytes(rgba) * width)
+    idat = zlib.compress(bytes(raw), 9)
+    path.write_bytes(b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr)
+                     + chunk(b"IDAT", idat) + chunk(b"IEND", b""))
+    assert len(raw) == (stride + 1) * height  # sanity on the scanline layout
+
+
 def test_png_size_reads_dimensions(tmp_path: Path) -> None:
     p = tmp_path / "dims.png"
     _write_png(p, 640, 400, (200, 180, 120))
@@ -54,6 +73,20 @@ def test_mean_luma_passes_rendered_frame(tmp_path: Path) -> None:
     bright = tmp_path / "bright.png"
     _write_png(bright, 200, 120, (180, 150, 90))  # a painterly-plate-ish mid tone
     # A real (non-blank) frame must score WELL above the threshold so it is ACCEPTED.
+    assert demo_reel._mean_luma_sample(bright) > 50.0
+
+
+def test_mean_luma_rgba_flags_black_frame(tmp_path: Path) -> None:
+    # Playwright screenshots are color_type 6 (RGBA) — pin the gate against that exact path, not
+    # just the RGB fixture above, so an un-filter/stride regression on this format can't slip by.
+    black = tmp_path / "black_rgba.png"
+    _write_png_rgba(black, 200, 120, (0, 0, 0, 255))
+    assert demo_reel._mean_luma_sample(black) < 8.0
+
+
+def test_mean_luma_rgba_passes_rendered_frame(tmp_path: Path) -> None:
+    bright = tmp_path / "bright_rgba.png"
+    _write_png_rgba(bright, 200, 120, (180, 150, 90, 255))
     assert demo_reel._mean_luma_sample(bright) > 50.0
 
 

--- a/qa/test_demo_reel.py
+++ b/qa/test_demo_reel.py
@@ -1,0 +1,64 @@
+"""test_demo_reel.py — unit cover for demo_reel.py's load-bearing frame-verification helpers.
+
+The demo reel is a CI-adjacent artifact whose whole value is "the frames are real, not blank".
+That guarantee lives in two dependency-free PNG helpers (_png_size + _mean_luma_sample); this
+pins them so a regression there can't silently pass a black frame. Single-process, no engine,
+no network, no browser — builds tiny in-memory PNGs and asserts the gate discriminates.
+
+  uv run --directory servers/engine python -m pytest qa/test_demo_reel.py
+  (or plain: python3 -m pytest qa/test_demo_reel.py — no engine deps are imported)
+"""
+from __future__ import annotations
+
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import demo_reel  # noqa: E402  (pure stdlib import; seed()/server are lazy, not touched here)
+
+
+def _write_png(path: Path, width: int, height: int, rgb: tuple[int, int, int]) -> None:
+    """Minimal filter-0 truecolor (color_type 2) PNG encoder — no image deps."""
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (struct.pack(">I", len(data)) + tag + data
+                + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF))
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    stride = width * 3
+    raw = bytearray()
+    for _ in range(height):
+        raw.append(0)  # filter type 0 (none)
+        raw.extend(bytes(rgb) * width)
+    idat = zlib.compress(bytes(raw), 9)
+    path.write_bytes(b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr)
+                     + chunk(b"IDAT", idat) + chunk(b"IEND", b""))
+    assert len(raw) == (stride + 1) * height  # sanity on the scanline layout
+
+
+def test_png_size_reads_dimensions(tmp_path: Path) -> None:
+    p = tmp_path / "dims.png"
+    _write_png(p, 640, 400, (200, 180, 120))
+    assert demo_reel._png_size(p) == (640, 400)
+
+
+def test_mean_luma_flags_black_frame(tmp_path: Path) -> None:
+    black = tmp_path / "black.png"
+    _write_png(black, 200, 120, (0, 0, 0))
+    # A fully black frame must score under the gate threshold (8.0) so it is REJECTED.
+    assert demo_reel._mean_luma_sample(black) < 8.0
+
+
+def test_mean_luma_passes_rendered_frame(tmp_path: Path) -> None:
+    bright = tmp_path / "bright.png"
+    _write_png(bright, 200, 120, (180, 150, 90))  # a painterly-plate-ish mid tone
+    # A real (non-blank) frame must score WELL above the threshold so it is ACCEPTED.
+    assert demo_reel._mean_luma_sample(bright) > 50.0
+
+
+def test_captions_cover_every_expected_frame() -> None:
+    # captions.txt is generated from CAPTIONS keyed by EXPECTED_FRAMES — every frame must caption.
+    assert set(demo_reel.EXPECTED_FRAMES) == set(demo_reel.CAPTIONS)
+    assert len(demo_reel.EXPECTED_FRAMES) == 6
+    assert all(demo_reel.CAPTIONS[name].strip() for name in demo_reel.EXPECTED_FRAMES)


### PR DESCRIPTION
## What

`qa/demo_reel.py` — the owner's #1 visibility deliverable made rerunnable: boot the REAL viewer on a seeded 2-room rest campaign and capture the full W2/W3 walkable loop as **browser-level PNG frames of the actual `/openworlds/` UI**.

Tonight's frames are on disk at `~/worldos-session-notes/felt-frames/demo-reel-2026-07-08/` (6 PNGs + `captions.txt` + `demo.gif`).

## The loop (6 frames, every step a REAL DOM click on the rest board → the same `onClick → POST /move` the player fires)

1. `01-rest-scene` — party (Aldric) + a present NPC (Innkeeper Bram) on the walkable plate
2. `02-walk-arrived` — click-to-walk: the selected token glided along an engine-routed path to the clicked cell (6,4)
3. `03-approach-walk` — a second click walks Aldric up beside Bram
4. `04-parley-open` — clicking the NPC opens the parley AT the actor (Dialogue screen, "ON STAGE (6, 1)", sheet-correct skill slots)
5. `05-door-cell` — back on the board, the doorway cell selected for a cross
6. `06-arrived-linked-room` — walked to the doorway and crossed into the linked Inner Hall (return door offered)

## Assembly (reuse, don't regress)

- **STATE + DRIVING**: imports `qa/walk_click_replay.py`'s `seed()` + viewer boot (boot-log capture + one fresh-port retry) + readiness probe, verbatim. Engine is the **sole writer**.
- **PIXELS**: `qa/demo_reel_capture.js` drives the real UI via Playwright's system-Chrome channel (`channel:"chrome"`), reusing the existing `qa/playwright` install — **no new deps, no bundled-chromium download**.
- **NO DM / NO LLM**: `walk_to_cell` + `parley_approach` (`generate_parley_options(approach=True)`) are engine-only; the viewer is a pure consumer.

## Guarantees

- Verifies every frame is a real, non-trivial, **non-black** PNG (dependency-free luma sampler) and **exits non-zero with a readable error** on any missing/blank frame or failed step — it is a CI-adjacent artifact and fails loud.
- Assembles `demo.gif` when ffmpeg/ImageMagick is present; skips gracefully otherwise.
- `qa/test_demo_reel.py`: single-process unit cover for the non-black gate helpers (4 tests, green).
- `fast_gate.sh`: green (257 passed) — the change is purely additive (three new `qa/` files, zero engine changes).

## Run

```
uv run --directory servers/engine python "\$PWD/qa/demo_reel.py" [--out DIR]
```

Do NOT merge — for orchestrator review.

---

## Update — art-backed money-shot frames (#1346 R2 follow-up)

The synthetic seed renders a walkable grid with **no painterly plate** — that is BY DESIGN, and it is a real gotcha worth recording:

**PLATE-RESOLUTION FINDING (name-key vs hash-id).** The rest board paints the location's scene plate from scope `location:<loc_id>` (`build_combat_surface`), which the viewer's `_safe_scope` bridge (`viewer/server.py:_scope_key`) resolves by **NAME-KEY** — it drops the kind prefix and matches ingested art keyed `scene:<slug>`. So a plate renders only when the location id is a readable **SLUG** (canon `loc-lower-city` → `"lower-city"` → matches `scene:lower-city`). The synthetic seed (`walk_click_replay`) uses **hash ids** (`loc_<hex>`) that normalize to bare hex and match nothing → bare grid. (Documented in `demo_reel.py`'s module docstring.)

**Art-backed frames captured** at `~/worldos-session-notes/felt-frames/demo-reel-2026-07-08/art/` (4 frames, plate visible under the tokens in each; luma 138–140, ~3.5 MB):
- `01-rest-scene` — Baldur's Gate Lower City plate under the walkable grid, party (Aubree, Arthus) + a present NPC (Dockhand Mory) on the board
- `02-walk-arrived` — click-to-walk over the plate (Battle Log: "Aubree walks to (6, 9)" · `lane: /move`)
- `03-approach-walk` — walk up beside the NPC
- `04-parley-open` — parley AT the actor ("Speaking with Dockhand Mory", ON STAGE (12, 9), Aubree's canon portrait + ranger skill slots), plate behind the header

Campaign: `qa/seed_canon_fixture.py` (baldurs-gate) `camp_637cc4322ef2`, current loc `loc-lower-city` (servable plate + 19×14 `scene_grid`); one present NPC added on a walkable cell. **No linked room** → walk + approach-talk only (no door-cross), which is why the **door steps are now conditional** in `demo_reel_capture.js`.
