### PR TITLE
[qa] deterministic visual pre-gate — floor-contact/frame-lit/scale/occupancy (the floating-actor tripwire)

### DIFF
--- a/docs/qa/FAST_GATE.md
+++ b/docs/qa/FAST_GATE.md
@@ -48,6 +48,7 @@ the bug classes that have actually shipped.
 | Tier | What | Cost | Owns |
 |---|---|---|---|
 | **0 — Deterministic (CI/pytest, $0, ~60s)** | seat-path skill correctness · rest-restores · travel-moves · combat-through-engine · model normalizers | **~60s, $0** | the structural + **seat-path** + engine-transition classes — *including the skill-case crit* |
+| **0.5 — Visual pre-gate (`qa/visual_pregate.py`, $0, under 1s when frames exist)** | rendered frame PNG + manifest `{actors, grid, floor_y_px}`; actor bboxes from manifest or `--baseline` empty-plate diff; checks **frame-lit · floor-contact · screen-scale · occupancy** | **under 1s, $0** | deterministic visual tripwires before any visual-critic/LLM pass: black/blown/solid frames, floating actors, giant/tiny imports, and missing expected actors. Not CI-wired until the capture harness produces frames/manifests. |
 | **1.5 — Mechanism probe (`qa/mechanism_probe.sh`, ~$1, ~10 min)** | a **seeded trigger state** (`qa/probe_fixtures/<fixture>.py`, deterministic, engine=sole-writer) + **2–3 REAL DM beats**, then a **deterministic** verdict (no LLM lens): *did the DM ACT on obligation cue X (engine state moved), only narrate it (**IGNORED**), or did the cue never hold steady at the start (**CUE_ABSENT** — an inconclusive setup, not a DM verdict)?* | **~10 min** | the **cue-mechanism** iteration question that used to cost a 24-beat Opus duo (~$5–8) to reach the trigger state naturally |
 | **1 — Fast LLM loop (~13 min, ~$2.5)** | **rotated** persona `[iter % 5]` from a **short cold-open** (catches seating + free-play reachability + variance over 5 loops) · **≥6-beat** duo (floors stay armed) · a "free-play *reached* combat" check distinct from the sprint | **~13 min** | the satisfaction/quality *iteration* signal (honestly, not a verdict) |
 | **2 — Milestone sweep (unchanged)** | full 5-persona `.app` + RRI + native part-A, **+ correlation tracking** | ~90 min | the release verdict |
@@ -74,6 +75,13 @@ test (`test_canon_wizard_seat_yields_proficient_skill_bonus` in `tests/test_cano
 Covers: G1 combat (`test_combat`), G1 rest (`test_rests`), G1 travel (`test_travel`), G2 seat-path
 data (`test_canon_abilities` + `test_character_skill_normalization`). `$0`, ~60s, no LLM, no cold-open.
 Run it on every change before deciding whether a heavier probe is even warranted.
+
+### Tier 0.5 — visual pre-gate (built now, frame-dependent)
+`qa/visual_pregate.py <frame.png> <manifest.json> [--baseline empty.png] [--json-out report.json]`
+is the deterministic visual tripwire for renderer lanes once a capture harness has produced a frame
+and manifest. It fails fast on frame-lit, floor-contact, screen-scale, and occupancy defects, using
+manifest-provided bboxes when available or diff-vs-empty-plate clusters with `--baseline`. This is
+not wired into CI in this PR because CI does not yet produce renderer frames.
 
 ### Tier 1 — the fast LLM loop (next, with the critique's mitigations baked in)
 Not yet built — it needs a small harness change (skip the cold-open splice when handed a seeded

--- a/qa/test_visual_pregate.py
+++ b/qa/test_visual_pregate.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Offline synthetic tests for qa/visual_pregate.py's spec-facing CLI.
+
+Run single-process from the repo root:
+    uv run --directory servers/engine python -m pytest ../../qa/test_visual_pregate.py -q -p no:xdist
+
+The fixtures are tiny stdlib-generated PNGs: no Unity, no private art, no LLM, no game state.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+QA_DIR = Path(__file__).resolve().parent
+if str(QA_DIR) not in sys.path:
+    sys.path.insert(0, str(QA_DIR))
+
+import visual_pregate as vp  # noqa: E402
+
+
+FRAME_SIZE = (100, 100)
+FLOOR_Y = 80
+NORMAL_BBOX = [40, 50, 55, FLOOR_Y]
+
+
+def _chunk(tag: bytes, data: bytes) -> bytes:
+    return (struct.pack(">I", len(data)) + tag + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF))
+
+
+def _write_rgb_png(path: Path, pixels: list[list[tuple[int, int, int]]]) -> Path:
+    height = len(pixels)
+    width = len(pixels[0])
+    rows = bytearray()
+    for row in pixels:
+        rows.append(0)
+        for r, g, b in row:
+            rows += bytes([r, g, b])
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + _chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+        + _chunk(b"IDAT", zlib.compress(bytes(rows), 9))
+        + _chunk(b"IEND", b"")
+    )
+    return path
+
+
+def _base_pixels() -> list[list[tuple[int, int, int]]]:
+    width, height = FRAME_SIZE
+    pixels: list[list[tuple[int, int, int]]] = []
+    for y in range(height):
+        row = []
+        for x in range(width):
+            shade = 84 if ((x // 5) + (y // 5)) % 2 == 0 else 132
+            row.append((shade, shade, shade))
+        pixels.append(row)
+    return pixels
+
+
+def _write_frame(path: Path, *, bbox: list[int] | None = NORMAL_BBOX, black: bool = False) -> Path:
+    width, height = FRAME_SIZE
+    pixels = [[(0, 0, 0) for _ in range(width)] for _ in range(height)] if black else _base_pixels()
+    if bbox is not None:
+        x0, y0, x1, y1 = bbox
+        for y in range(max(0, y0), min(height, y1)):
+            for x in range(max(0, x0), min(width, x1)):
+                pixels[y][x] = (40, 220, 80)
+    return _write_rgb_png(path, pixels)
+
+
+def _manifest(path: Path, *, bbox: list[int] | None = NORMAL_BBOX) -> Path:
+    actor: dict = {"name": "Hero", "expected_cell": [1, 1]}
+    if bbox is not None:
+        actor["screen_bbox"] = bbox
+    path.write_text(json.dumps({
+        "actors": [actor],
+        "grid": {"origin": [0, 0], "cell_px": [50, 50], "rows": 2, "cols": 2},
+        "floor_y_px": FLOOR_Y,
+        "checks": {
+            "frame_lit": {
+                "min_mean_luma": 0.08,
+                "max_mean_luma": 0.95,
+                "max_single_color_frac": 0.90,
+            },
+            "floor_contact": {"tolerance_px": 4},
+            "screen_scale": {"min_height_frac": 0.04, "max_height_frac": 0.40},
+            "diff": {"threshold": 20, "min_area_px": 8},
+        },
+    }))
+    return path
+
+
+def _run_cli(tmp_path: Path, frame: Path, manifest: Path, *extra: str) -> tuple[int, dict]:
+    report = tmp_path / f"report-{len(list(tmp_path.glob('report-*.json')))}.json"
+    rc = vp.main([str(frame), str(manifest), "--json-out", str(report), *extra])
+    assert report.exists(), "spec CLI should always write --json-out"
+    return rc, json.loads(report.read_text())
+
+
+def _check(report: dict, name: str) -> dict:
+    matches = [c for c in report["checks"] if c["check"] == name]
+    assert matches, f"missing check {name}: {report}"
+    return matches[0]
+
+
+def test_manifest_bbox_grounded_actor_passes(tmp_path):
+    frame = _write_frame(tmp_path / "grounded.png", bbox=NORMAL_BBOX)
+    manifest = _manifest(tmp_path / "manifest.json", bbox=NORMAL_BBOX)
+
+    rc, report = _run_cli(tmp_path, frame, manifest)
+
+    assert rc == 0
+    assert report["verdict"] == "PASS"
+    assert _check(report, "floor-contact")["status"] == "PASS"
+    assert _check(report, "screen-scale")["status"] == "PASS"
+    assert _check(report, "occupancy")["status"] == "PASS"
+    assert report["bbox_source"] == "manifest"
+
+
+def test_manifest_bbox_floating_actor_fails_floor_contact(tmp_path):
+    floating = [40, 35, 55, 65]
+    frame = _write_frame(tmp_path / "floating.png", bbox=floating)
+    manifest = _manifest(tmp_path / "manifest.json", bbox=floating)
+
+    rc, report = _run_cli(tmp_path, frame, manifest)
+
+    assert rc != 0
+    assert report["verdict"] == "FAIL"
+    floor = _check(report, "floor-contact")
+    assert floor["status"] == "FAIL"
+    assert "floating" in floor["detail"].lower()
+
+
+def test_black_frame_fails_frame_lit(tmp_path):
+    frame = _write_frame(tmp_path / "black.png", bbox=None, black=True)
+    manifest = _manifest(tmp_path / "manifest.json", bbox=NORMAL_BBOX)
+
+    rc, report = _run_cli(tmp_path, frame, manifest)
+
+    assert rc != 0
+    lit = _check(report, "frame-lit")
+    assert lit["status"] == "FAIL"
+    assert "luma" in lit["detail"].lower()
+
+
+def test_giant_actor_fails_screen_scale(tmp_path):
+    giant = [20, 10, 80, 80]
+    frame = _write_frame(tmp_path / "giant.png", bbox=giant)
+    manifest = _manifest(tmp_path / "manifest.json", bbox=giant)
+
+    rc, report = _run_cli(tmp_path, frame, manifest)
+
+    assert rc != 0
+    scale = _check(report, "screen-scale")
+    assert scale["status"] == "FAIL"
+    assert "height" in scale["detail"].lower()
+
+
+def test_missing_manifest_bbox_fails_occupancy(tmp_path):
+    frame = _write_frame(tmp_path / "missing.png", bbox=None)
+    manifest = _manifest(tmp_path / "manifest.json", bbox=None)
+
+    rc, report = _run_cli(tmp_path, frame, manifest)
+
+    assert rc != 0
+    occupancy = _check(report, "occupancy")
+    assert occupancy["status"] == "FAIL"
+    assert occupancy["value"]["found"] == 0
+    assert occupancy["value"]["expected"] == 1
+
+
+def test_diff_vs_baseline_detects_grounded_actor_bbox(tmp_path):
+    baseline = _write_frame(tmp_path / "baseline.png", bbox=None)
+    frame = _write_frame(tmp_path / "with_actor.png", bbox=NORMAL_BBOX)
+    manifest = _manifest(tmp_path / "manifest.json", bbox=None)
+
+    rc, report = _run_cli(tmp_path, frame, manifest, "--baseline", str(baseline))
+
+    assert rc == 0
+    assert report["verdict"] == "PASS"
+    assert report["bbox_source"] == "baseline-diff"
+    assert len(report["bboxes"]) == 1
+    assert _check(report, "occupancy")["status"] == "PASS"
+    assert _check(report, "floor-contact")["status"] == "PASS"
+
+
+def test_diff_vs_baseline_missing_actor_fails_occupancy(tmp_path):
+    baseline = _write_frame(tmp_path / "baseline.png", bbox=None)
+    frame = _write_frame(tmp_path / "same.png", bbox=None)
+    manifest = _manifest(tmp_path / "manifest.json", bbox=None)
+
+    rc, report = _run_cli(tmp_path, frame, manifest, "--baseline", str(baseline))
+
+    assert rc != 0
+    assert report["bbox_source"] == "baseline-diff"
+    assert _check(report, "occupancy")["status"] == "FAIL"

--- a/qa/visual_pregate.py
+++ b/qa/visual_pregate.py
@@ -63,11 +63,16 @@ USAGE
     print(result["verdict"])                # PASS | FLAG (any CRITICAL/HIGH) | SKIPPED
     # result["gates"] -> list of {gate, severity, metric, value, threshold, detail}
 
-    # CLI:
+    # Spec-facing CLI (future capture harness):
+    python qa/visual_pregate.py /tmp/frame.png /tmp/manifest.json \
+        --baseline /tmp/empty-plate.png --json-out /tmp/report.json
+
+    # Legacy visual-critic CLI:
     python qa/visual_pregate.py --render /tmp/frame.png --scenegrid fixtures/tavern.scenegrid.json \
         --actors @/tmp/actors.json --json
 
-Exit codes: 0 = PASS / SKIPPED, 2 = FLAG (a CRITICAL or HIGH pre-gate fired) — so the loop / CI can gate.
+Exit codes: spec CLI 0 = PASS, 2 = FAIL; legacy CLI 0 = PASS / SKIPPED, 2 = FLAG
+(a CRITICAL or HIGH pre-gate fired) — so the loop / CI can gate.
 """
 
 from __future__ import annotations
@@ -924,6 +929,349 @@ def _summary(verdict: str, gates: list[dict]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Spec-facing manifest runner
+# ---------------------------------------------------------------------------
+def _manifest_check(manifest: dict, name: str) -> dict:
+    checks = manifest.get("checks", {})
+    cfg = checks.get(name, {}) if isinstance(checks, dict) else {}
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def _rgb_tuple(pixels: bytearray, base: int, channels: int) -> tuple[int, int, int]:
+    if channels == 1:
+        v = int(pixels[base])
+        return v, v, v
+    return int(pixels[base]), int(pixels[base + 1]), int(pixels[base + 2])
+
+
+def _bbox_from_actor(actor: dict) -> Optional[list[int]]:
+    raw = actor.get("screen_bbox", actor.get("bbox", actor.get("box")))
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        if all(k in raw for k in ("x", "y", "w", "h")):
+            vals = [raw["x"], raw["y"], raw["x"] + raw["w"], raw["y"] + raw["h"]]
+        elif all(k in raw for k in ("left", "top", "right", "bottom")):
+            vals = [raw["left"], raw["top"], raw["right"], raw["bottom"]]
+        else:
+            return None
+    elif isinstance(raw, (list, tuple)) and len(raw) == 4:
+        vals = list(raw)
+    else:
+        return None
+    try:
+        x0, y0, x1, y1 = [int(round(float(v))) for v in vals]
+    except (TypeError, ValueError):
+        return None
+    if x1 < x0:
+        x0, x1 = x1, x0
+    if y1 < y0:
+        y0, y1 = y1, y0
+    if x1 == x0 or y1 == y0:
+        return None
+    return [x0, y0, x1, y1]
+
+
+def _frame_lit_manifest_check(frame_png: str | Path, manifest: dict) -> tuple[dict, tuple[int, int] | None]:
+    cfg = _manifest_check(manifest, "frame_lit")
+    min_mean = float(cfg.get("min_mean_luma", cfg.get("min", MEAN_LUM_DARK)))
+    max_mean = float(cfg.get("max_mean_luma", cfg.get("max", MEAN_LUM_BLOWN)))
+    max_single = float(cfg.get("max_single_color_frac", cfg.get("max_single_color", 0.90)))
+    try:
+        pixels, width, height, channels = _decode_png_pixels(Path(frame_png))
+    except Exception as exc:
+        return ({
+            "check": "frame-lit", "status": "FAIL", "metric": "decode",
+            "value": None, "threshold": None,
+            "detail": f"could not decode frame PNG: {exc}",
+        }, None)
+
+    stride = width * channels
+    total = width * height
+    step = max(1, total // 65536)
+    luma_sum = 0.0
+    colors: dict[tuple[int, int, int], int] = {}
+    samples = 0
+    for i in range(0, total, step):
+        base = (i // width) * stride + (i % width) * channels
+        color = _rgb_tuple(pixels, base, channels)
+        colors[color] = colors.get(color, 0) + 1
+        luma_sum += (0.2126 * color[0] + 0.7152 * color[1] + 0.0722 * color[2]) / 255.0
+        samples += 1
+    mean = luma_sum / (samples or 1)
+    single_frac = max(colors.values(), default=0) / (samples or 1)
+    failures = []
+    if mean < min_mean:
+        failures.append(f"mean luma {mean:.3f} < {min_mean:.3f}")
+    if mean > max_mean:
+        failures.append(f"mean luma {mean:.3f} > {max_mean:.3f}")
+    if single_frac > max_single:
+        failures.append(f"dominant color {single_frac:.1%} > {max_single:.0%}")
+    status = "FAIL" if failures else "PASS"
+    return ({
+        "check": "frame-lit", "status": status, "metric": "mean_luma",
+        "value": {"mean_luma": round(mean, 4), "single_color_frac": round(single_frac, 4)},
+        "threshold": {
+            "min_mean_luma": min_mean,
+            "max_mean_luma": max_mean,
+            "max_single_color_frac": max_single,
+        },
+        "detail": "; ".join(failures) if failures else
+                  f"frame lit: mean luma {mean:.3f}, dominant color {single_frac:.1%}",
+    }, (width, height))
+
+
+def _diff_bboxes(frame_png: str | Path, baseline_png: str | Path, manifest: dict) -> list[list[int]]:
+    cfg = _manifest_check(manifest, "diff")
+    threshold = float(cfg.get("threshold", 20))
+    min_area = int(cfg.get("min_area_px", cfg.get("min_area", 16)))
+    fp, fw, fh, fc = _decode_png_pixels(Path(frame_png))
+    bp, bw, bh, bc = _decode_png_pixels(Path(baseline_png))
+    if (fw, fh) != (bw, bh):
+        raise ValueError(f"baseline dimensions {bw}x{bh} do not match frame {fw}x{fh}")
+    fstride = fw * fc
+    bstride = bw * bc
+    total = fw * fh
+    mask = bytearray(total)
+    for i in range(total):
+        fx, fy = i % fw, i // fw
+        fr, fg, fb = _rgb_tuple(fp, fy * fstride + fx * fc, fc)
+        br, bg, bb = _rgb_tuple(bp, fy * bstride + fx * bc, bc)
+        if max(abs(fr - br), abs(fg - bg), abs(fb - bb)) > threshold:
+            mask[i] = 1
+
+    seen = bytearray(total)
+    bboxes: list[list[int]] = []
+    for start, changed in enumerate(mask):
+        if not changed or seen[start]:
+            continue
+        stack = [start]
+        seen[start] = 1
+        min_x = max_x = start % fw
+        min_y = max_y = start // fw
+        area = 0
+        while stack:
+            idx = stack.pop()
+            area += 1
+            x, y = idx % fw, idx // fw
+            min_x, max_x = min(min_x, x), max(max_x, x)
+            min_y, max_y = min(min_y, y), max(max_y, y)
+            if x > 0:
+                ni = idx - 1
+                if mask[ni] and not seen[ni]:
+                    seen[ni] = 1
+                    stack.append(ni)
+            if x + 1 < fw:
+                ni = idx + 1
+                if mask[ni] and not seen[ni]:
+                    seen[ni] = 1
+                    stack.append(ni)
+            if y > 0:
+                ni = idx - fw
+                if mask[ni] and not seen[ni]:
+                    seen[ni] = 1
+                    stack.append(ni)
+            if y + 1 < fh:
+                ni = idx + fw
+                if mask[ni] and not seen[ni]:
+                    seen[ni] = 1
+                    stack.append(ni)
+        if area >= min_area:
+            bboxes.append([min_x, min_y, max_x + 1, max_y + 1])
+    return sorted(bboxes, key=lambda b: (b[0], b[1], -(b[2] - b[0]) * (b[3] - b[1])))
+
+
+def _grid_expected_floor_y(actor: dict, manifest: dict) -> Optional[float]:
+    if "floor_y_px" in actor:
+        return float(actor["floor_y_px"])
+    if "floor_y_px" in manifest:
+        return float(manifest["floor_y_px"])
+    grid = manifest.get("grid")
+    cell = actor.get("expected_cell", actor.get("cell"))
+    if not isinstance(grid, dict) or not (isinstance(cell, (list, tuple)) and len(cell) == 2):
+        return None
+    origin = grid.get("origin", [0, 0])
+    cell_px = grid.get("cell_px", 1)
+    if not (isinstance(origin, (list, tuple)) and len(origin) >= 2):
+        return None
+    if isinstance(cell_px, (int, float)):
+        cell_h = float(cell_px)
+    elif isinstance(cell_px, (list, tuple)) and len(cell_px) >= 2:
+        cell_h = float(cell_px[1])
+    else:
+        return None
+    try:
+        row = int(cell[1])
+        origin_y = float(origin[1])
+    except (TypeError, ValueError):
+        return None
+    return origin_y + (row + 1) * cell_h
+
+
+def _occupancy_manifest_check(expected_count: int, bboxes: list[list[int]]) -> dict:
+    found = len(bboxes)
+    status = "PASS" if found >= expected_count else "FAIL"
+    return {
+        "check": "occupancy", "status": status, "metric": "actor_bbox_count",
+        "value": {"expected": expected_count, "found": found},
+        "threshold": expected_count,
+        "detail": f"found {found}/{expected_count} expected actor bbox(es)",
+    }
+
+
+def _floor_contact_manifest_check(actors: list[dict], actor_bboxes: list[tuple[dict, list[int]]],
+                                  manifest: dict) -> dict:
+    cfg = _manifest_check(manifest, "floor_contact")
+    tolerance = float(cfg.get("tolerance_px", cfg.get("tolerance", 6)))
+    entries = []
+    failures = []
+    for actor, bbox in actor_bboxes:
+        name = str(actor.get("name") or actor.get("id") or "?")
+        floor_y = _grid_expected_floor_y(actor, manifest)
+        if floor_y is None:
+            entries.append({"actor": name, "status": "SKIP", "detail": "no floor_y_px or grid projection"})
+            continue
+        bottom_y = float(bbox[3])
+        delta = bottom_y - floor_y
+        if abs(delta) <= tolerance:
+            status = "PASS"
+            detail = f"{name} grounded: bbox bottom {bottom_y:.1f}px within {tolerance:.1f}px of floor {floor_y:.1f}px"
+        else:
+            status = "FAIL"
+            mode = "floating above" if delta < 0 else "clipping below"
+            detail = f"{name} {mode}: bbox bottom {bottom_y:.1f}px vs floor {floor_y:.1f}px ({delta:+.1f}px)"
+            failures.append(detail)
+        entries.append({"actor": name, "status": status, "delta_px": round(delta, 2), "detail": detail})
+    if not actor_bboxes and actors:
+        return {
+            "check": "floor-contact", "status": "SKIP", "metric": "feet_vs_floor_px",
+            "value": [], "threshold": tolerance,
+            "detail": "no actor bbox available; occupancy check owns the missing-actor failure",
+        }
+    status = "FAIL" if failures else "PASS"
+    return {
+        "check": "floor-contact", "status": status, "metric": "feet_vs_floor_px",
+        "value": entries, "threshold": tolerance,
+        "detail": "; ".join(failures) if failures else f"{len(entries)} actor bbox(es) grounded",
+    }
+
+
+def _screen_scale_manifest_check(actor_bboxes: list[tuple[dict, list[int]]], manifest: dict,
+                                 frame_size: tuple[int, int] | None) -> dict:
+    cfg = _manifest_check(manifest, "screen_scale")
+    min_frac = float(cfg.get("min_height_frac", cfg.get("min", 0.04)))
+    max_frac = float(cfg.get("max_height_frac", cfg.get("max", 0.40)))
+    if frame_size is None:
+        return {
+            "check": "screen-scale", "status": "SKIP", "metric": "bbox_height_frac",
+            "value": [], "threshold": {"min": min_frac, "max": max_frac},
+            "detail": "frame dimensions unavailable; screen-scale skipped",
+        }
+    _, frame_h = frame_size
+    entries = []
+    failures = []
+    for actor, bbox in actor_bboxes:
+        name = str(actor.get("name") or actor.get("id") or "?")
+        height = max(0, bbox[3] - bbox[1])
+        frac = height / (frame_h or 1)
+        if min_frac <= frac <= max_frac:
+            status = "PASS"
+            detail = f"{name} height {height}px ({frac:.1%}) within {min_frac:.0%}-{max_frac:.0%}"
+        else:
+            status = "FAIL"
+            detail = f"{name} height {height}px ({frac:.1%}) outside {min_frac:.0%}-{max_frac:.0%}"
+            failures.append(detail)
+        entries.append({"actor": name, "status": status, "height_px": height,
+                        "height_frac": round(frac, 4), "detail": detail})
+    if not actor_bboxes:
+        return {
+            "check": "screen-scale", "status": "SKIP", "metric": "bbox_height_frac",
+            "value": [], "threshold": {"min": min_frac, "max": max_frac},
+            "detail": "no actor bbox available; occupancy check owns the missing-actor failure",
+        }
+    status = "FAIL" if failures else "PASS"
+    return {
+        "check": "screen-scale", "status": status, "metric": "bbox_height_frac",
+        "value": entries, "threshold": {"min": min_frac, "max": max_frac},
+        "detail": "; ".join(failures) if failures else f"{len(entries)} actor bbox(es) within scale band",
+    }
+
+
+def run_manifest_pregate(frame_png: str | Path, manifest_json: str | Path,
+                         baseline_png: str | Path | None = None) -> dict:
+    """Run the spec-facing deterministic visual pre-gate.
+
+    Manifest shape:
+        {
+          "actors": [{"name": "Hero", "expected_cell": [c, r], "screen_bbox": [x0,y0,x1,y1]}],
+          "grid": {"origin": [x,y], "cell_px": [w,h], "rows": N, "cols": M},
+          "floor_y_px": 80,
+          "checks": {"floor_contact": {"tolerance_px": 6}, ...}
+        }
+
+    Bboxes come either from actor.screen_bbox (preferred capture-harness path) or from
+    ``baseline_png`` diff clusters when the manifest omits bboxes.
+    """
+    manifest = json.loads(Path(manifest_json).read_text())
+    actors = manifest.get("actors", [])
+    if not isinstance(actors, list):
+        actors = []
+
+    checks: list[dict] = []
+    frame_check, frame_size = _frame_lit_manifest_check(frame_png, manifest)
+    checks.append(frame_check)
+
+    manifest_actor_bboxes = []
+    for actor in actors:
+        bbox = _bbox_from_actor(actor)
+        if bbox is not None:
+            manifest_actor_bboxes.append((actor, bbox))
+    manifest_bboxes = [bbox for _, bbox in manifest_actor_bboxes]
+    bbox_source = "manifest"
+    if baseline_png is not None:
+        try:
+            bboxes = _diff_bboxes(frame_png, baseline_png, manifest)
+        except Exception as exc:
+            bboxes = []
+            checks.append({
+                "check": "bbox-detection", "status": "FAIL", "metric": "baseline_diff",
+                "value": None, "threshold": None,
+                "detail": f"could not compute diff-vs-baseline actor bboxes: {exc}",
+            })
+        bbox_source = "baseline-diff"
+        actor_bboxes = list(zip(actors, bboxes))
+    else:
+        bboxes = manifest_bboxes
+        actor_bboxes = manifest_actor_bboxes
+
+    checks.append(_occupancy_manifest_check(len(actors), bboxes))
+    checks.append(_floor_contact_manifest_check(actors, actor_bboxes, manifest))
+    checks.append(_screen_scale_manifest_check(actor_bboxes, manifest, frame_size))
+
+    failed = [c for c in checks if c["status"] == "FAIL"]
+    verdict = "FAIL" if failed else "PASS"
+    return {
+        "schema": "worldos.visual_pregate.v1",
+        "verdict": verdict,
+        "bbox_source": bbox_source,
+        "frame": str(frame_png),
+        "manifest": str(manifest_json),
+        "baseline": str(baseline_png) if baseline_png else None,
+        "bboxes": [{"bbox": b, "source": bbox_source} for b in bboxes],
+        "checks": checks,
+        "failures": failed,
+        "summary": _manifest_summary(verdict, checks),
+    }
+
+
+def _manifest_summary(verdict: str, checks: list[dict]) -> str:
+    lines = [f"VISUAL PRE-GATE {verdict}"]
+    for c in checks:
+        lines.append(f"  [{c['status']:4s}] {c['check']:14s} {c.get('metric','')}={c.get('value')} :: {c['detail']}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 def _load_actors(arg: Optional[str]) -> list[dict]:
@@ -948,15 +1296,33 @@ def _load_reel(arg: Optional[str]) -> Optional[list[dict]]:
 
 def main(argv: Optional[list[str]] = None) -> int:
     ap = argparse.ArgumentParser(description="Deterministic visual pre-gates for the visual-critic loop")
-    ap.add_argument("--render", required=True, help="path to the rendered PNG")
+    ap.add_argument("positional", nargs="*", metavar="ARG",
+                    help="spec CLI: <frame.png> <manifest.json>; legacy mode uses --render")
+    ap.add_argument("--render", help="legacy: path to the rendered PNG")
     ap.add_argument("--scenegrid", help="path to the *.scenegrid.json (enables G2/G3/G4)")
     ap.add_argument("--actors", help="measured actor boxes JSON or @file.json")
     ap.add_argument("--occupancy", help="rendered occupancy tint JSON or @file.json")
+    ap.add_argument("--baseline", help="spec CLI: empty-plate PNG for diff-vs-baseline actor bbox mode")
+    ap.add_argument("--json-out", help="write machine-readable JSON report to this path")
     ap.add_argument("--reel", help="motion-reel frames JSON or @file.json (enables G5); accepts a "
                                    "bare list of frame dicts OR a qa/motion_reel.py sidecar object "
                                    "with a top-level 'frames' key")
     ap.add_argument("--json", action="store_true", help="emit JSON")
     args = ap.parse_args(argv)
+
+    if args.positional:
+        if len(args.positional) != 2:
+            ap.error("spec CLI expects exactly: <frame.png> <manifest.json>")
+        frame_png, manifest_json = args.positional
+        res = run_manifest_pregate(frame_png, manifest_json, baseline_png=args.baseline)
+        if args.json_out:
+            Path(args.json_out).write_text(json.dumps(res, indent=2) + "\n")
+        if args.json or not args.json_out:
+            print(json.dumps(res, indent=2) if args.json else res["summary"])
+        return 2 if res["verdict"] == "FAIL" else 0
+
+    if not args.render:
+        ap.error("--render is required in legacy option mode")
 
     sg = load_scenegrid(args.scenegrid) if args.scenegrid else None
     actors = _load_actors(args.actors)
@@ -967,9 +1333,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         occ = None
     reel = _load_reel(args.reel) if args.reel else None
     res = run_pregates(args.render, scenegrid=sg, actors=actors, occupancy_tint=occ, reel=reel)
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(res, indent=2) + "\n")
     if args.json:
         print(json.dumps(res, indent=2))
-    else:
+    elif not args.json_out:
         print(res["summary"])
     return 2 if res["verdict"] == "FLAG" else 0
 


### PR DESCRIPTION
Closes #1381

## Summary
- Add the spec-facing visual pre-gate CLI: `qa/visual_pregate.py <frame.png> <manifest.json> [--baseline empty.png] [--json-out report.json]`.
- Score deterministic `frame-lit`, `floor-contact`, `screen-scale`, and `occupancy` checks from manifest bboxes or diff-vs-empty-plate clusters.
- Add offline synthetic fixtures for grounded/floating/black/giant/missing actor cases and both bbox modes.
- Document Tier 0.5 in `docs/qa/FAST_GATE.md` without wiring it into CI yet.

## Validation
- `uv run --directory servers/engine python -m pytest ../../qa/test_visual_pregate.py -q -p no:xdist`
- `qa/fast_gate.sh`
- `uv run --directory servers/engine python -m pytest ../../qa/test_visual_critic.py ../../qa/test_motion_reel.py -q -p no:xdist`