### PR TITLE
docs: box bridge re-arm recovery + NOW.md truing

### DIFF
--- a/docs/roadmap/NOW.md
+++ b/docs/roadmap/NOW.md
@@ -4,7 +4,7 @@
 > a bootstrapping agent reads after OPERATIONS.md. Keep it under a screen. History belongs in
 > git, not here.
 
-_Last updated: 2026-07-08 (UTC) — driver installation session._
+_Last updated: 2026-07-08 (UTC) — driver live; charter #1386 active; bridge recovered._
 
 ## Active sprint
 
@@ -13,13 +13,11 @@ _Last updated: 2026-07-08 (UTC) — driver installation session._
   engine-release bar). S3 charter = #1310. S4-S10: charters not yet written (writing the next
   one from PRODUCT-ROADMAP.md is queue work, not a stop).
 - **Act II:** W1-W4 + HV1-HV5 merged; W5 (Unity player tier, #1322) remains — box lane.
-  The Act II successor charter (live box lane: #1284 → rendered-rest-demo → W5a) is being filed
-  as part of the 2026-07-08 gap-fix batch.
+  ACTIVE charter: **#1386** (Rendered Felt: #1284 → rendered-rest-demo → W5a → HV follow-ups).
 
 ## Live lanes
 
-- **#1284 actor grounding v2** — fix committed on `fix/actor-grounding-v2` (377f5caf); box
-  validation (MenuItem wrapper → capture → visual_pregate floor-contact) in flight → PR.
+- **#1284 actor grounding v2** — PR #1392 open; deterministic floor-contact PASS (−55px → 0px); live-frame acceptance capture in flight (bridge re-armed per BOX.md recovery).
 - **Next box lanes (in order):** rendered rest-scene demo (the real visual bar) → W5a player
   build (packet on #1322).
 - **Flywheel:** nightly harvest accumulates; extractor quality pass 2 targets the 3.9→4.0 quest

--- a/extensions/renderers/unity/BOX.md
+++ b/extensions/renderers/unity/BOX.md
@@ -43,3 +43,14 @@
 For the full drive loop (bring-up, liveness preflight, the unity-mcp raw drive loop, full-res
 capture, non-black gate), use the `gex44-unity-host` skill. This file is the durable
 connection/claim/facts reference the skill and any cold agent should read first.
+
+## Bridge re-arm (session dropped) — PROVEN recovery, no VNC
+Symptom: MCP calls return `no_unity_session` while the editor process is alive and
+`curl 127.0.0.1:8080/mcp` returns 406 (server healthy). The editor↔server SESSION dropped.
+Fix (headless, over SSH as the `unity` user on DISPLAY=:0):
+1. `scrot -o /tmp/s.png` → scp back → locate the "MCP For Unity" window (red "No Session" + Connect).
+2. `xdotool mousemove <titlebar-x> <titlebar-y> click 1` — focus the window first (openbox needs it).
+3. `xdotool mousemove <connect-x> <connect-y> click 1`, sleep ~5.
+4. Verify: panel shows green "Session Active (worldos-unity)"; a `read_console` probe returns entries.
+Do NOT restart the editor or the :8080 server for this symptom, and do not wait for a human VNC
+connect — ssh+xdotool is the proven agent-control path on this box.


### PR DESCRIPTION
Encodes the PROVEN no_unity_session recovery (ssh+xdotool focus+Connect click — refutes the 'needs VNC' assumption that stalled the #1284 acceptance) into BOX.md, and trues NOW.md to charter #1386 / PR #1392 state. Docs-only.