### PR TITLE
docs: close the 3 cold-agent bootstrap gaps (test-driven)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -60,3 +60,6 @@ List the checks you ran.
 ## Notes For Next Agent
 
 - Exact next action:
+
+---
+_Merging note: required checks stuck at "expected/pending" with mergeState BLOCKED is the known repo-wide auto-merge hang (#1389), NOT a CI failure. Procedure: real checks green + threads resolved → `gh pr merge <n> --admin --squash` (docs/OPERATIONS.md "Merging")._

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 
 ## WorldOS Takeover Truth
 
-- Read `WorldOS-OPERATING-GOAL.md` first, then `WorldOS-GUI-RUNBOOK.md`, `WorldOS-RUNBOOK.md`, and `qa/SCORECARD.md`.
+- Read `docs/OPERATIONS.md` FIRST (the bootstrap), then `docs/roadmap/NOW.md` → `docs/ACTIVE-GOAL.md` → `docs/roadmap/PRODUCT-ROADMAP.md` → the `active-sprint`-labeled charter issue. Runbooks (`WorldOS-RUNBOOK.md`, `WorldOS-GUI-RUNBOOK.md`) are reference, not the entry point.
 - The product is the launchable, playable `dist/WorldOS.app`. Wrapper/config/test-only progress does not count as product progress unless it directly unlocks built-app gameplay evidence.
 - Engine remains sole writer of campaign state. GUI/native app remains a thin reader plus `/move` intent submitter.
 - Built-app proof must include visible narration, private art, an active player, enabled actions, accepted `/move`, and `/session-surface` showing the live campaign as actionable.

--- a/docs/ACTIVE-GOAL.md
+++ b/docs/ACTIVE-GOAL.md
@@ -22,7 +22,7 @@ unexecuted, citing a "box blocker" that was never verified (the box was up the w
 
 ## THE QUEUE
 
-The work queue is the open **`sprint-charter`-labeled issues, in sprint order** (S2, S3, … per
+The work queue is the open **`sprint-charter`-labeled issues, in sprint order** — the current head carries the **`active-sprint`** label (exactly one issue; move it at every transition) — (S2, S3, … per
 PRODUCT-ROADMAP.md §Act I; interleaved Act II/box charters ride the same label).
 
 - Closing charter N (with evidence on the issue) **pulls charter N+1**.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -12,7 +12,7 @@
 2. **Read `docs/roadmap/PRODUCT-ROADMAP.md`** — the three Acts, every sprint (S/W/HV series) with
    its binding gate, the version map, the Owner Gate Register (human-gated items — never block on
    these silently; park `blocked/needs-human` and take other work).
-3. **Find the active work**: `gh issue list --label sprint-charter --state open` — charters are
+3. **Find the active work**: `gh issue list --label active-sprint --state open` — exactly ONE issue carries `active-sprint` (the queue head; move the label at every charter transition). `gh issue list --label sprint-charter --state open` lists ALL charters — charters are
    the live sprints. Each charter lists ORDERED issues with `lane:*` labels, the runnable gate,
    and the invariant checklist. Claim an unclaimed issue in your lane (comment on it) — **`[EPIC]`
    issues named in the ACTIVE charter's ordered list ARE claimable directly** (the live lane must


### PR DESCRIPTION
A fresh-Opus one-word-"continue" bootstrap test navigated the trail correctly and reported 4 gaps; #1393 already fixes the NOW.md one, this closes the other three: stale AGENTS.md entry-point line → live docs/ trail; `active-sprint` label (created + on #1386) so the queue head is machine-readable (OPERATIONS + ACTIVE-GOAL updated); PR-template note that expected/pending-BLOCKED = the #1389 hang, not CI failure. Docs-only.