### PR TITLE
[fix] cross_door re-stages party in the linked room (#1378)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1371,6 +1371,15 @@ def cross_door(campaign_id: str, x: int, y: int) -> dict:
     if not conns:
         raise ValueError(f"{getattr(loc, 'name', '')!r} has no connected room to cross to")
     result = travel_to(campaign_id, conns[0])
+    # W4 follow-up (#1378): the party's stage_cell was just CLEARED by travel_to's _move_party_to
+    # (per-room scoping). If the destination room is ALSO painted, re-stage the party beside its
+    # entry door so the linked room's rest board renders them standing there — not the empty
+    # door-bar state (demo-reel frame 06). ADDITIVE: an un-painted destination gets no writes.
+    with campaign_lock(campaign_id):
+        c2 = _require(campaign_id)  # fresh state — travel_to persisted its own copy above
+        dest = c2.locations.get(c2.current_location_id) if c2.current_location_id else None
+        if dest is not None and _seed_stage_cells_on_arrival(c2, dest):
+            save_campaign(c2)
     result["crossed_door"] = [int(x), int(y)]
     result["multi_connection"] = len(conns) > 1
     return result
@@ -4673,6 +4682,56 @@ def rest_blocked_cells(
         for x, y in scene_grid_mod.impassable_cells(grid, width, height, occupied=occupied)
     }
     return width, height, impassable | occupied
+
+
+def _seed_stage_cells_on_arrival(c: "Campaign", dest: "Location") -> list[str]:
+    """W4 follow-up (#1378): on a ``cross_door`` arrival, seed each traveling party member's
+    ``Character.stage_cell`` to a walkable cell beside the destination room's entry door, so the
+    linked room's rest board renders the party re-staged — not the empty door-bar state left when
+    ``_move_party_to`` clears every member's stage_cell on travel.
+
+    Mirrors ``_seed_combat_cells_from_stage``'s discipline: a deterministic member order, cells
+    ranked nearest-the-door first, each member claiming the NEXT free cell so two tokens never
+    stack (contention spreads to the next-nearest walkable). ADDITIVE / default-safe — a
+    destination with NO ``scene_grid`` or NO ``door_cells`` gets zero writes (returns ``[]``):
+    a room that behaved as today (no re-stage, no error) still does. Engine is the SOLE writer;
+    the caller holds the campaign lock and persists.
+
+    Returns the ids actually re-staged (for surfacing/tests)."""
+    grid = getattr(dest, "scene_grid", None)
+    if grid is None:
+        return []
+    door_cells = sorted({(int(a), int(b)) for (a, b) in (getattr(grid, "door_cells", None) or [])})
+    if not door_cells:
+        return []
+    width, height, blocked = rest_blocked_cells(c, dest)
+    if width <= 0 or height <= 0:
+        return []
+    # Best-effort ARRIVAL door: the lowest-sorted door of the destination. There is no authored
+    # door->origin map yet (the same limitation cross_door surfaces via `multi_connection`), so a
+    # deterministic first pick stands in. The party stands BESIDE it, never on the threshold.
+    door = door_cells[0]
+    # Candidate rest cells: every FREE cell reachable from the door (routes around walls/props so
+    # nobody lands in a walled-off pocket), ranked nearest-first with a stable (y, x) tiebreak.
+    reach = combat_grid.reachable(door, width + height, set(), width, height, impassable=blocked)
+    candidates = iter(
+        sorted(reach, key=lambda cell: (combat_grid.chebyshev_cells(cell, door), cell[1], cell[0]))
+    )
+    # Traveling party = the members _move_party_to just co-located here (PC(s) + companions), in
+    # c.characters insertion order for a deterministic seat assignment. Cells are unique + consumed
+    # sequentially, so each member lands on a distinct cell (no stacking).
+    party_ids = set(c.party)
+    seeded: list[str] = []
+    for cid, member in c.characters.items():
+        travels = cid in party_ids or member.kind in ("player", "companion")
+        if not travels or member.location_id != dest.id:
+            continue
+        cell = next(candidates, None)
+        if cell is None:
+            break  # the room ran out of free cells near the door — leave the rest unplaced
+        member.stage_cell = cell
+        seeded.append(cid)
+    return seeded
 
 
 def _coerce_cell_pairs(raw, label: str) -> list[list[int]]:

--- a/servers/engine/tests/test_cross_door.py
+++ b/servers/engine/tests/test_cross_door.py
@@ -5,6 +5,7 @@ room-unit (Location.connections), delegating the party move to travel_to. Additi
 """
 import pytest
 
+import combat_grid
 import server  # noqa: PLC0415  (conftest puts servers/engine on the path; import-first per the
 from scene_grid import SceneGrid, SceneGridSpec, SceneCellDefault  # models<->scene_grid circular note)
 
@@ -37,6 +38,53 @@ def test_cross_door_travels_to_the_connected_room(two_room):
     assert server._require(cid).current_location_id == b  # crossed into the linked unit
     assert res["crossed_door"] == [6, 0]
     assert res["multi_connection"] is False
+
+
+def test_cross_door_restages_party_near_the_destination_door(two_room):
+    # #1378: when the linked room is ALSO painted, the party must arrive re-staged onto walkable
+    # cells beside that room's door — not the empty door-bar board (their stage_cell is cleared on
+    # every travel by _move_party_to). Give room B its own grid + entry door and cross into it.
+    cid, a, b = two_room
+    _author_grid(cid, b, [[3, 0]])
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=30)["id"]
+    ally = server.create_character(cid, "Ally", kind="companion", max_hp=20)["id"]
+    c = server._require(cid)
+    for pid, cell in ((hero, (5, 5)), (ally, (6, 5))):  # standing at rest in room A
+        c.characters[pid].location_id = a
+        c.characters[pid].stage_cell = cell
+    server.save_campaign(c)
+
+    server.cross_door(cid, 6, 0)  # walk through A's door → arrive in room B
+
+    c = server._require(cid)
+    assert c.current_location_id == b
+    hero_cell = c.characters[hero].stage_cell
+    ally_cell = c.characters[ally].stage_cell
+    assert hero_cell is not None and ally_cell is not None  # re-staged (was None: the bug)
+    assert hero_cell != ally_cell  # no stacking — deterministic spread
+    door = (3, 0)
+    for pid, cell in ((hero, hero_cell), (ally, ally_cell)):
+        w, h, blocked = server.rest_blocked_cells(c, c.locations[b], exclude_id=pid)
+        assert 0 <= cell[0] < w and 0 <= cell[1] < h  # on the destination grid
+        assert cell not in blocked  # walkable, not a wall/prop and not on a party-mate
+        assert combat_grid.chebyshev_cells(cell, door) <= 2  # beside the arrival door
+
+
+def test_cross_door_into_ungridded_room_writes_no_stage_cells(two_room):
+    # ADDITIVE guard: the destination (room B) has NO scene_grid → seeding is a no-op, exactly as
+    # before #1378 (stage_cell stays None after the travel clear). Byte-identical legacy behavior.
+    cid, a, b = two_room
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=30)["id"]
+    c = server._require(cid)
+    c.characters[hero].location_id = a
+    c.characters[hero].stage_cell = (5, 5)
+    server.save_campaign(c)
+
+    server.cross_door(cid, 6, 0)
+
+    c = server._require(cid)
+    assert c.current_location_id == b
+    assert c.characters[hero].stage_cell is None
 
 
 def test_cross_door_rejects_a_non_doorway_cell(two_room):


### PR DESCRIPTION
Fixes #1378 — after a door-cell click walks the party through `cross_door` into the linked room, the destination room's rest board rendered WITHOUT the party re-staged (empty door-bar state). `_move_party_to` clears every member's `stage_cell` on travel (per-room scoping, W2 #1319), and nothing re-seeded arrival cells in the new room.

## Root cause
`servers/engine/server.py::cross_door` delegates to `travel_to`, whose `_move_party_to` sets `member.stage_cell = None`. No arrival seeding existed → party unplaced on the destination rest board.

## Fix (additive, engine-side)
- New `_seed_stage_cells_on_arrival(c, dest)` (sibling of W4's `_seed_combat_cells_from_stage`): on `cross_door` success, seeds each traveling party member's `stage_cell` to a walkable cell beside the destination room's entry door.
- **Seeding rule:** best-effort arrival door = the destination's lowest-sorted `door_cell` (no authored door→origin map yet — same limit `multi_connection` surfaces). Candidate cells = every FREE cell **reachable** from the door (`combat_grid.reachable`, routes around walls/props via the shared `rest_blocked_cells` blocked-set), ranked nearest-first `(chebyshev-to-door, y, x)`. Party members (PC + companions, `c.characters` insertion order) each claim the NEXT free cell → deterministic spread, **no stacking**. Party stands beside the threshold, never on it.
- Wired into `cross_door` after `travel_to` returns, under a fresh `campaign_lock` (flock is non-reentrant) on freshly-`_require`'d state; saves only when something was seeded. Engine stays sole writer.

## Invariants
- **Additive / default-safe:** destination with no `scene_grid` or no `door_cells` → zero writes, `stage_cell` stays `None` (byte-identical to today). Covered by `test_cross_door_into_ungridded_room_writes_no_stage_cells`.
- Gates read only engine-mutated values; old snapshots round-trip (no schema change).

## Tests (red-first, single-process)
- `test_cross_door_restages_party_near_the_destination_door` — party arrives re-staged on distinct walkable cells within chebyshev≤2 of B's door. **Red** before the fix (`stage_cell is None`), green after.
- `test_cross_door_into_ungridded_room_writes_no_stage_cells` — additive guard.
- `uv run --directory servers/engine python -m pytest tests/test_cross_door.py tests/test_living_stage.py tests/test_walk_to.py -q -p no:xdist` → **34 passed**.
- `qa/fast_gate.sh` → **257 passed** ✅.

## Follow-up (not built here, QA-econ v2)
A cheap deterministic "party has stage_cells after cross_door" check fits `qa/mechanism_probe.sh`'s fixture pattern — noting as a follow-up, not building now.

## Merge
Per `docs/OPERATIONS.md`, repo-wide GitHub auto-merge hangs (#1389) — **admin-merge is the procedure**: `gh pr merge <n> --admin --squash` once green. `--auto` armed as a courtesy; do not rely on it alone.