### PR TITLE
qa/score.sh: proactive scorer auth-expiry circuit-breaker + 401 fast-fail

### DIFF
--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -1479,7 +1479,7 @@ except Exception:
 if not isinstance(d, dict):
     print("invalid"); sys.exit(0)
 # A failure sentinel (scorer exhausted retries, or a 429 quota trip) is NOT a score.
-if d.get("error") == "scorer_failed" or d.get("quota_exhausted") is True:
+if d.get("error") in ("scorer_failed", "scorer_auth_expired") or d.get("quota_exhausted") is True:
     print("sentinel"); sys.exit(0)
 ov = d.get("overall")
 # bool is a subclass of int — exclude it; a scorecard overall is a real number.

--- a/qa/score.sh
+++ b/qa/score.sh
@@ -151,14 +151,57 @@ while [ "$attempt" -lt 3 ]; do
   # skipped derivation, the key was stripped anyway, and the child got NO auth at all — the
   # exact "Not logged in" failure this fix exists to solve. Derivation must only be gated on
   # whether we already HAVE a token (first clause), not on an env var the child never sees.
+  # #1404: capture the token's expiresAt (epoch ms) and its source ALONGSIDE the accessToken, so
+  # we can PROACTIVELY detect an expired credential and fail fast with an actionable diagnostic
+  # (gate (d) below) instead of 401ing three times into a generic scorer_failed corpse that reads
+  # like a transient blip. A caller-provided CLAUDE_CODE_OAUTH_TOKEN still wins and is used as-is —
+  # we can't introspect its expiry, so the pre-check simply doesn't fire for that path (unchanged).
   _scorer_tok="${CLAUDE_CODE_OAUTH_TOKEN:-}"
-  if [ -z "$_scorer_tok" ] && [ "$(uname)" = "Darwin" ]; then
-    _scorer_tok="$(security find-generic-password -s 'Claude Code-credentials' -a "$USER" -w 2>/dev/null \
-      | python3 -c 'import json,sys;print(json.load(sys.stdin).get("claudeAiOauth",{}).get("accessToken",""))' 2>/dev/null || true)"
-  elif [ -z "$_scorer_tok" ] && [ "$(uname)" != "Darwin" ]; then
-    _scorer_creds_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json"
-    if [ -s "$_scorer_creds_file" ]; then
-      _scorer_tok="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("claudeAiOauth",{}).get("accessToken",""))' "$_scorer_creds_file" 2>/dev/null || true)"
+  _scorer_tok_exp=""           # expiresAt (epoch ms) of a DERIVED token; empty when caller-provided/unknown
+  _cred_src=""                 # human-readable source of the derived credential (for the diagnostic)
+  if [ -z "$_scorer_tok" ]; then
+    _cred_blob=""
+    if [ "$(uname)" = "Darwin" ]; then
+      _cred_src="macOS Keychain item 'Claude Code-credentials'"
+      _cred_blob="$(security find-generic-password -s 'Claude Code-credentials' -a "$USER" -w 2>/dev/null || true)"
+    else
+      _scorer_creds_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json"
+      _cred_src="$_scorer_creds_file"
+      [ -s "$_scorer_creds_file" ] && _cred_blob="$(cat "$_scorer_creds_file" 2>/dev/null || true)"
+    fi
+    if [ -n "$_cred_blob" ]; then
+      # Emit "<accessToken>\t<expiresAt-or-empty>" from the shared {claudeAiOauth:{…}} shape
+      # (identical extraction to before, now also carrying expiresAt for the expiry gate).
+      _cred_line="$(printf '%s' "$_cred_blob" | python3 -c 'import json,sys
+try:
+    d = json.load(sys.stdin).get("claudeAiOauth", {})
+except Exception:
+    d = {}
+exp = d.get("expiresAt")
+sys.stdout.write("%s\t%s" % (d.get("accessToken") or "", exp if isinstance(exp, int) else ""))' 2>/dev/null || true)"
+      _scorer_tok="${_cred_line%%$'\t'*}"
+      _scorer_tok_exp="${_cred_line#*$'\t'}"
+    fi
+  fi
+
+  # --- (d) PROACTIVE auth-expiry circuit-breaker (#1404) -------------------------------------
+  # A DERIVED token whose expiresAt is already past (or lapses within a 60s skew) will 401 on
+  # EVERY attempt. Fail fast with a DISTINCT, actionable sentinel — mirroring the 429 quota
+  # breaker below — rather than burning the 3 retries + ~15s of sleeps only to land on a generic
+  # scorer_failed. No-op when the expiry is unknown/absent (caller-token path, or an old keychain
+  # blob without expiresAt), so that behavior is byte-identical to today. This does NOT mint a new
+  # token: refreshing OAuth is the CLI's job — `claude login` (or the CLI's own background refresh)
+  # rewrites the keychain; re-implementing rotation here would race the CLI under the parallel swarm.
+  if [ -n "$_scorer_tok" ] && [[ "$_scorer_tok_exp" =~ ^[0-9]+$ ]]; then
+    _now_ms="$(python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/null || echo 0)"
+    if [ "$_now_ms" != 0 ] && [ "$_scorer_tok_exp" -le "$(( _now_ms + 60000 ))" ]; then
+      _ago_s=$(( (_now_ms - _scorer_tok_exp) / 1000 ))
+      echo "[score] AUTH EXPIRED for $(basename "$OUT"): scorer OAuth access token (from ${_cred_src}) expired ~${_ago_s}s ago (expiresAt=${_scorer_tok_exp}ms, now=${_now_ms}ms)." >&2
+      echo "[score]   Every scoring call 401s until the credential is refreshed. Run \`claude login\` on this host (or let the Claude CLI refresh the keychain), then re-run scoring." >&2
+      echo "[score]   Failing fast (no retries); writing an auth sentinel + exiting rc=2." >&2
+      printf '{"error":"scorer_auth_expired","expired_at_ms":%s,"expired_ago_seconds":%s}\n' "$_scorer_tok_exp" "$_ago_s" > "$OUT"
+      rm -f "$RAW" 2>/dev/null || true
+      exit 2
     fi
   fi
   printf '%s' "$INPUT" | env -u ANTHROPIC_BASE_URL -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN \
@@ -195,6 +238,18 @@ while [ "$attempt" -lt 3 ]; do
   if [ "$api_err" = "429" ] || jq -e 'select(.is_error == true) | (.result // "") | test("session limit|HTTP 429|hit your (session|usage) limit"; "i")' "$RAW" >/dev/null 2>&1; then
     echo "[score] QUOTA EXHAUSTED (HTTP 429 account session limit) for $(basename "$OUT") — failing fast (no retries). Writing a quota sentinel + exiting rc=2." >&2
     printf '{"quota_exhausted":true,"api_error_status":429}\n' > "$OUT"
+    rm -f "$RAW"
+    exit 2
+  fi
+  # #1404 (auth breaker, live-call half): a 401 (expired/invalid credential) will NOT heal across a
+  # 5s sleep — retrying just burns the window and ends in a generic scorer_failed that hides the real
+  # cause. Fail fast with the SAME actionable auth sentinel as the proactive pre-check. Covers what
+  # the pre-check can't: a token that lapses mid-run, or a caller-provided CLAUDE_CODE_OAUTH_TOKEN we
+  # couldn't introspect for expiry.
+  if [ "$api_err" = "401" ] || jq -e 'select(.is_error == true) | (.result // "") | test("HTTP 401|invalid.*(auth|credential|token)|authentication_error|OAuth token (has )?expired|Invalid authentication credentials"; "i")' "$RAW" >/dev/null 2>&1; then
+    echo "[score] AUTH FAILURE (HTTP 401 / invalid credential) for $(basename "$OUT") — failing fast (no retries)." >&2
+    echo "[score]   The scorer credential is expired or invalid. Run \`claude login\` on this host to refresh it, then re-run scoring. Detail: $(jq -r '.result // "<no message>"' "$RAW" 2>/dev/null | head -1)" >&2
+    printf '{"error":"scorer_auth_expired","api_error_status":401}\n' > "$OUT"
     rm -f "$RAW"
     exit 2
   fi

--- a/qa/test_release_gate_static.py
+++ b/qa/test_release_gate_static.py
@@ -274,6 +274,24 @@ class QuotaCircuitBreakerStaticContractTests(unittest.TestCase):
         # so a 429 short-circuits instead of burning the 3 attempts.
         self.assertLess(source.index('[ "$api_err" = "429" ]'), source.index('if [ ! -s "$RAW" ]; then'))
 
+    def test_score_sh_has_auth_expiry_fast_fail_arm(self):
+        # #1404: score.sh must (1) PROACTIVELY detect an expired DERIVED credential (compare the
+        # keychain/creds-file expiresAt to now) and fail fast with a distinct {error:scorer_auth_expired}
+        # sentinel + exit rc=2, and (2) fail fast on a live 401 instead of burning the 3 retries.
+        source = (ROOT / "qa" / "score.sh").read_text(encoding="utf-8")
+        # proactive pre-check arm
+        self.assertIn('"$_scorer_tok_exp" =~ ^[0-9]+$', source)
+        self.assertIn('"error":"scorer_auth_expired"', source)
+        # live-call 401 arm
+        self.assertIn('[ "$api_err" = "401" ]', source)
+        # both auth arms must sit BEFORE the generic retry-loop tail so an auth failure short-circuits.
+        self.assertLess(source.index('[ "$api_err" = "401" ]'), source.index('if [ ! -s "$RAW" ]; then'))
+        # the proactive pre-check must run BEFORE the live claude call (it gates on the derived token).
+        self.assertLess(source.index('"error":"scorer_auth_expired"'), source.index("timeout \"${WORLDOS_SCORE_TIMEOUT:-600}\" claude -p"))
+        # the lens validator must recognize the new sentinel as a sentinel (not a numeric score).
+        lib = (ROOT / "qa" / "lib_beat_driver.sh").read_text(encoding="utf-8")
+        self.assertIn('"scorer_failed", "scorer_auth_expired"', lib)
+
     def test_run_duo_checks_for_quota_abort_before_scoring(self):
         # Fix E + Fix F (caller half): run_duo.sh must (1) detect a DM cold-open 429 and emit the
         # "[duo] QUOTA ABORT" marker + exit EX_TEMPFAIL BEFORE the empty-reply abort, and (2) treat the


### PR DESCRIPTION
## Problem (surfaced during PR #1404, extractor-quality-pass2)

`qa/score.sh` derives an `accessToken` from the macOS Keychain (`Claude Code-credentials`) / Linux `.credentials.json` and hands it to an **isolated `CLAUDE_CONFIG_DIR`** child as a fixed `CLAUDE_CODE_OAUTH_TOKEN`. That isolation is deliberate — it keeps the canonical sonnet scorer on real Anthropic, immune to this host's `~/.claude/settings.json` GLM/z.ai routing — but it **bypasses the CLI's own OAuth refresh**. When the access token is expired (observed: `expiresAt` ~9.5h in the past), every `claude -p` call 401s, and the old retry loop burned all 3 attempts into a generic `{error:scorer_failed}` corpse that read like a transient blip. This blocked all live re-scoring (`artifact_score.py`, `artifact_calibration_panel.py`, `promote.py` score-if-unscored, `run_duo.sh` lenses).

## Why not refresh the token in `score.sh`

Considered and **rejected**. Anthropic rotates the refresh token on each use; under the parallel scorer swarm, N concurrent refreshes race — one wins, the rest invalidate — and writing the rotated token back to the Keychain would race the real CLI and could **break the host's actual login**. OAuth refresh is the CLI's job (`claude login` / its background refresh). Re-implementing rotation in a QA script is the wrong layer.

## Fix — fail fast + diagnose, don't retry a guaranteed-401 (both arms mirror the existing 429 breaker)

1. **Proactive expiry pre-check (gate `(d)`):** derivation now captures `expiresAt` alongside the token. If a *derived* token is past expiry (60s skew), fail **before** the live call with a distinct `{"error":"scorer_auth_expired"}` sentinel, `rc=2`, and an actionable *"run `claude login`"* message. **No-op** when expiry is unknown/absent (caller-provided token, or an old Keychain blob) — byte-identical to today there.
2. **Live 401 arm:** a 401 / invalid-credential envelope also fails fast (won't heal across a 5s sleep) — covers mid-run lapse and caller-supplied `CLAUDE_CODE_OAUTH_TOKEN` we can't introspect.
3. `lib_beat_driver.sh`: the shared lens validator recognizes `scorer_auth_expired` as a sentinel → routes to `unscorable`, never a fake numeric score.
4. `test_release_gate_static.py`: asserts both fast-fail arms + validator recognition.

> Note: this makes the failure **loud and fast**; it does not itself unblock scoring — the Keychain token still needs a `claude login` refresh on the host.

## Verification
- `bash -n` clean on both scripts; **all 22** `test_release_gate_static.py` pass.
- Isolated logic test: expired blob (9.5h past — the #1404 case) → fast-fail rc=2; valid → live call; no-`expiresAt`/malformed → unchanged fall-through.
- **Live happy-path smoke** (valid Keychain token): `rc=0`, valid scorecard (`overall`, `.scores`, `prompt_construction_hash` present) in 41s — the derivation refactor doesn't disturb normal scoring.