### PR TITLE
feat(engine): quest authoring & consequence-capture cues — the flywheel's binding constraint (#1405)

### DIFF
--- a/content/campaigns/cellar-rats/adventure.json
+++ b/content/campaigns/cellar-rats/adventure.json
@@ -2,11 +2,23 @@
   "id": "cellar-rats",
   "title": "Cellar Rats",
   "ruleset": "SRD 5.2",
-  "level_range": [1, 2],
+  "level_range": [
+    1,
+    2
+  ],
   "session_length_minutes": 60,
   "premise": "The Sodden Crown is the only inn for a day's walk, and something has moved into its flooded cellar. The owner blames rats. The scratching in the walls is far too big for rats. Beneath the taproom, a crew of goblin scavengers has tunneled up out of the drowned undercity below — but they aren't raiders. They're fleeing something, and they brought the smell of it with them.",
   "hook": "A storm has stranded the party at the Sodden Crown for the night. Over a bowl of stew, the innkeeper Brakka admits her cellar has been 'rat-troubled' for a week — three barrels of ale fouled, a stable-hand bitten, and a sound at night like something dragging chains through water. She'll knock the whole night's lodging off the bill, and throw in coin, for anyone willing to go down and clear it before dawn.",
-  "themes": ["grounded low-level dungeon crawl", "a twist of unexpected mercy", "a monster you never quite see"],
+  "quest_objectives": [
+    "Descend into the flooded cellar and find the source of the innkeeper's 'rats'",
+    "Learn what the goblin scavengers are fleeing up from the drowned undercity",
+    "Make the Sodden Crown safe by dawn — clear the nest, or spare the goblins and seal what lurks below"
+  ],
+  "themes": [
+    "grounded low-level dungeon crawl",
+    "a twist of unexpected mercy",
+    "a monster you never quite see"
+  ],
   "voices": {
     "narrator-dm": "The Dungeon Master's narration voice. Used for boxed read-aloud text and scene description.",
     "companion-default": "The party's AI companion adventurer.",
@@ -22,26 +34,81 @@
       "voice_id": "companion-default",
       "race": "Half-Elf",
       "background": "Acolyte",
-      "classes": [{ "name": "Cleric", "level": 1 }],
-      "abilities": { "strength": 12, "dexterity": 12, "constitution": 14, "intelligence": 10, "wisdom": 16, "charisma": 11 },
+      "classes": [
+        {
+          "name": "Cleric",
+          "level": 1
+        }
+      ],
+      "abilities": {
+        "strength": 12,
+        "dexterity": 12,
+        "constitution": 14,
+        "intelligence": 10,
+        "wisdom": 16,
+        "charisma": 11
+      },
       "proficiency_bonus": 2,
       "armor_class": 16,
       "max_hp": 10,
       "hit_dice": "1d8",
       "hit_dice_remaining": 1,
-      "skill_proficiencies": ["Insight", "Medicine", "Religion", "Persuasion"],
-      "spells_known": ["Sacred Flame", "Guidance", "Cure Wounds", "Guiding Bolt", "Healing Word", "Bless"],
-      "spells_prepared": ["Cure Wounds", "Healing Word", "Guiding Bolt", "Bless"],
-      "spell_slots": { "1": { "maximum": 2, "used": 0 } },
+      "skill_proficiencies": [
+        "Insight",
+        "Medicine",
+        "Religion",
+        "Persuasion"
+      ],
+      "spells_known": [
+        "Sacred Flame",
+        "Guidance",
+        "Cure Wounds",
+        "Guiding Bolt",
+        "Healing Word",
+        "Bless"
+      ],
+      "spells_prepared": [
+        "Cure Wounds",
+        "Healing Word",
+        "Guiding Bolt",
+        "Bless"
+      ],
+      "spell_slots": {
+        "1": {
+          "maximum": 2,
+          "used": 0
+        }
+      },
       "personality": "A warm, quick-witted field medic who joined for the road and stayed for the people. Vesper fusses over everyone's scrapes, jokes about hazard pay, and keeps her chin up even when scared — and she IS scared, often, she just refuses to let it win. She argues for mercy and curiosity over the blade (she'll be the first to wonder aloud whether the 'monsters' are something sadder), patches the party up mid-fight with Healing Word, and will say so out loud when she thinks the player's plan is reckless — then back the play anyway, because that's what partners do.",
       "notes": "Healer/support. In combat she favors Healing Word on a downed ally, Guiding Bolt or Sacred Flame otherwise. The DM should give Vesper her own voiced line every scene and reach her combat decisions through companion_suggest_action.",
       "companion_dossier": {
         "wound": "a patient she couldn't save on the road — the reason she fusses so hard now",
-        "values": ["mercy", "compassion", "curiosity over the blade"],
-        "wants": ["to save the savable", "to be proven right that the monster is something sadder"],
-        "fears": ["freezing when someone needs her", "a cruelty she could have stopped"],
-        "approval_likes": ["show_mercy", "spare_a_frightened_foe", "tend_the_wounded", "ask_before_you_strike", "protect_the_helpless"],
-        "approval_dislikes": ["needless_cruelty", "kill_a_prisoner", "a_reckless_plan_that_risks_the_party", "torture"]
+        "values": [
+          "mercy",
+          "compassion",
+          "curiosity over the blade"
+        ],
+        "wants": [
+          "to save the savable",
+          "to be proven right that the monster is something sadder"
+        ],
+        "fears": [
+          "freezing when someone needs her",
+          "a cruelty she could have stopped"
+        ],
+        "approval_likes": [
+          "show_mercy",
+          "spare_a_frightened_foe",
+          "tend_the_wounded",
+          "ask_before_you_strike",
+          "protect_the_helpless"
+        ],
+        "approval_dislikes": [
+          "needless_cruelty",
+          "kill_a_prisoner",
+          "a_reckless_plan_that_risks_the_party",
+          "torture"
+        ]
       }
     }
   ],
@@ -100,7 +167,14 @@
       "armor_class": 15,
       "hit_dice": "2d6",
       "proficiency_bonus": 2,
-      "abilities": { "strength": 8, "dexterity": 14, "constitution": 10, "intelligence": 10, "wisdom": 8, "charisma": 8 }
+      "abilities": {
+        "strength": 8,
+        "dexterity": 14,
+        "constitution": 10,
+        "intelligence": 10,
+        "wisdom": 8,
+        "charisma": 8
+      }
     },
     {
       "id": "grett",
@@ -119,7 +193,14 @@
       "armor_class": 17,
       "hit_dice": "6d6",
       "proficiency_bonus": 2,
-      "abilities": { "strength": 10, "dexterity": 14, "constitution": 10, "intelligence": 10, "wisdom": 8, "charisma": 10 }
+      "abilities": {
+        "strength": 10,
+        "dexterity": 14,
+        "constitution": 10,
+        "intelligence": 10,
+        "wisdom": 8,
+        "charisma": 10
+      }
     }
   ],
   "locations": [
@@ -127,35 +208,50 @@
       "id": "loc-taproom",
       "name": "The Sodden Crown — Taproom",
       "description": "A low-beamed common room that smells of woodsmoke, wet wool, and old ale. Rain hammers the shutters. A peat fire keeps the dark at bay. The cellar trapdoor sits behind the bar, bolted, with a faint dragging-water sound rising through the boards when the room goes quiet.",
-      "connections": ["loc-cellar-stairs"],
+      "connections": [
+        "loc-cellar-stairs"
+      ],
       "notes": "Safe zone. Brakka and Dorn are here. The party can short rest, gear up, and gather information before descending. Returning here at the end is the natural place to resolve the adventure."
     },
     {
       "id": "loc-cellar-stairs",
       "name": "The Cellar Stairs",
       "description": "A steep run of damp stone steps descending into cold dark. Ale barrels are stacked along a brick landing halfway down. The lowest three steps vanish under standing black water. A taut cord, strung ankle-high across the landing and hung with bent tin cups, waits to announce anyone careless.",
-      "connections": ["loc-taproom", "loc-rat-run", "loc-crawlspace"],
+      "connections": [
+        "loc-taproom",
+        "loc-rat-run",
+        "loc-crawlspace"
+      ],
       "notes": "The EXPLORATION beat lives here: a Perception check to spot the goblin alarm-cord (trip-trap), and a navigation choice between the narrow flooded main passage (loc-rat-run) and a cramped dry crawlspace (loc-crawlspace)."
     },
     {
       "id": "loc-rat-run",
       "name": "The Rat-Run",
       "description": "A flooded storage passage. Shelves of ruined preserves loom out of knee-deep water; jars float and clink. Things move beneath the surface — and along the rafters, lean shapes with wet eyes track the intruders. The water tugs faintly, all of it draining toward a deeper dark at the far end.",
-      "connections": ["loc-cellar-stairs", "loc-sump"],
+      "connections": [
+        "loc-cellar-stairs",
+        "loc-sump"
+      ],
       "notes": "First COMBAT beat. The 'rats' Brakka complained of are real vermin swarming underfoot (atmosphere/hazard) plus the goblins' two scavenger-hounds — reflavored Wolves that den in the rafters. Difficult terrain (water) matters here."
     },
     {
       "id": "loc-crawlspace",
       "name": "The Dry Crawlspace",
       "description": "A cramped side-tunnel the goblins clawed open through a collapsed wall, just tall enough to stoop in. It is dry, close, and reeks of frightened goblin. A single scavenger has been left here as a lookout — small, cornered, and far more scared of what's below than of the party.",
-      "connections": ["loc-cellar-stairs", "loc-sump"],
+      "connections": [
+        "loc-cellar-stairs",
+        "loc-sump"
+      ],
       "notes": "The SOCIAL beat. Quill is here. This is the 'mercy' path: befriend her and the twist opens up, and the final fight can be turned into a parley. Players who skip the Rat-Run via the alarm-cord choice can arrive here first."
     },
     {
       "id": "loc-sump",
       "name": "The Sump",
       "description": "The cellar's flooded bottom: a brick pit that was once a drain, now clawed wide into a black throat of water. The goblin crew's salvage is heaped on the few dry stones — bolts of cloth, a strongbox, a child's wooden horse. The water here is deep and very still, and something far below makes it shiver in slow, wrong rings.",
-      "connections": ["loc-rat-run", "loc-crawlspace"],
+      "connections": [
+        "loc-rat-run",
+        "loc-crawlspace"
+      ],
       "notes": "Climax COMBAT beat AND the twist payoff. Grett and his crew make their stand here. The widened drain can be re-sealed (a STR/skill check or improvised barricade) to trap 'the Long Thing' below — the real resolution. The Long Thing is never fully seen: a tentacle, a ripple, a dragged chain. Do NOT stat it; it is the threat the goblins fled, not a fight to win."
     }
   ],
@@ -209,8 +305,16 @@
       "navigation_choice": {
         "prompt": "From the landing the cellar forks: the flooded main passage (left) or the cramped dry crawlspace (right).",
         "options": [
-          {"to": "loc-rat-run", "label": "The flooded main passage — wider, but something is moving in the water and the rafters.", "leads_to_scene": "scene-3-ratrun"},
-          {"to": "loc-crawlspace", "label": "The dry crawlspace — tight and stinking of goblin, but quiet.", "leads_to_scene": "scene-4-quill"}
+          {
+            "to": "loc-rat-run",
+            "label": "The flooded main passage — wider, but something is moving in the water and the rafters.",
+            "leads_to_scene": "scene-3-ratrun"
+          },
+          {
+            "to": "loc-crawlspace",
+            "label": "The dry crawlspace — tight and stinking of goblin, but quiet.",
+            "leads_to_scene": "scene-4-quill"
+          }
         ],
         "note": "Both routes converge on loc-sump (scene-5). The order the party meets the wolves vs. Quill simply flips based on this choice. Either way, scenes 3, 4, and 5 should all happen before the conclusion."
       },
@@ -233,7 +337,11 @@
       ],
       "encounter": {
         "monsters": [
-          {"name": "Wolf", "count": 2, "reflavor": "Scavenger-hounds: lean, half-feral curs the goblins keep, denning in the dry rafters above the flood."}
+          {
+            "name": "Wolf",
+            "count": 2,
+            "reflavor": "Scavenger-hounds: lean, half-feral curs the goblins keep, denning in the dry rafters above the flood."
+          }
         ],
         "tactics": "The wolves use Pack Tactics — both pile onto a single target to gain advantage, aiming to knock a PC prone (DC 11 STR save on a hit) and then gang the prone target. They will not stand and trade in the open water; they dart in from the rafters, bite, and a wounded wolf retreats to a beam to be re-flanked. If one wolf drops, the survivor may flee toward the sump and join Grett's stand in scene-5. Vermin underfoot are flavor only unless the DM needs to dial difficulty up.",
         "scaling": "Party of 1-2 or all-squishy: 1 Wolf. Party of 4+ or running hot: 2 Wolves + a vermin swarm hazard.",
@@ -270,7 +378,11 @@
       ],
       "encounter": {
         "monsters": [
-          {"name": "Goblin", "count": 1, "reflavor": "Quill — a starving goblin lookout, more refugee than raider. Only fights if cornered with no mercy offered."}
+          {
+            "name": "Goblin",
+            "count": 1,
+            "reflavor": "Quill — a starving goblin lookout, more refugee than raider. Only fights if cornered with no mercy offered."
+          }
         ],
         "tactics": "Quill does NOT want to fight. If threatened or attacked she uses Nimble Escape (Disengage/Hide as a bonus action) to flee toward the sump and raise the alarm rather than trade blows. If befriended she sheathes the shiv entirely and becomes a non-combatant guide. Killing her is trivially easy (HP 7) and is meant to feel like a moral choice, not a challenge.",
         "xp": 50,
@@ -301,7 +413,11 @@
       ],
       "encounter": {
         "monsters": [
-          {"name": "Goblin", "count": 3, "reflavor": "Grett One-Eye and two scavengers. Driftwood clubs (reflavored scimitars). Refugees making a desperate last stand, not gleeful raiders."}
+          {
+            "name": "Goblin",
+            "count": 3,
+            "reflavor": "Grett One-Eye and two scavengers. Driftwood clubs (reflavored scimitars). Refugees making a desperate last stand, not gleeful raiders."
+          }
         ],
         "tactics": "Grett holds the front, body-blocking the path to the salvage and his crew. The two scavengers use Nimble Escape to dart between the dry stones, throw sling-stones or stab, then Disengage as a bonus action and reposition behind cover — slippery, not suicidal. They fight hardest when cornered and will try to surrender or flee once two of the three are down (a perfect window to flip the fight into the parley/seal resolution mid-combat). A wolf that fled scene-3 joins on round 2. The Long Thing in the water is NOT a combatant — but the DM can spend it as escalating dread: each round the drain stays open, the rings widen, until on the round it's left open too long a chain-thick tendril breaks the surface and drags a goblin (never a PC) screaming under, hammering home WHY the drain must be sealed now.",
         "scaling": "Party of 1-2 or all-squishy: 2 Goblins (Grett + 1). Party of 4+ or running hot: 3 Goblins + the fled Wolf. Either way the real objective is the drain, not a body count.",
@@ -324,10 +440,26 @@
       "note": "Brakka pays 10 gp flat, or 35 gp if her attitude was won over in scene-1. Free lodging for the night regardless. Add the strongbox find below to the haul."
     },
     "loot": [
-      {"item": "Goblin scavenger strongbox", "contents": "23 sp, 14 cp, a tarnished silver locket (10 gp), and a waterlogged but legible river-trade ledger.", "note": "Found on the dry stones in the sump."},
-      {"item": "Potion of Healing", "rarity": "common", "note": "One vial, stoppered with wax, among the salvage — the goblins scavenged it from the drowned undercity and couldn't read the label. 2d4+2 HP."},
-      {"item": "A child's wooden horse", "value": "0 gp", "note": "Worthless, but Brakka recognizes it — it belonged to a family lost when the river rose. Returning it is a quiet roleplay beat and earns the party a permanent free welcome at the Crown."},
-      {"item": "Bundle of river-stained cloth (3 bolts)", "value": "6 gp", "note": "Sellable salvage if the party hauls it up."}
+      {
+        "item": "Goblin scavenger strongbox",
+        "contents": "23 sp, 14 cp, a tarnished silver locket (10 gp), and a waterlogged but legible river-trade ledger.",
+        "note": "Found on the dry stones in the sump."
+      },
+      {
+        "item": "Potion of Healing",
+        "rarity": "common",
+        "note": "One vial, stoppered with wax, among the salvage — the goblins scavenged it from the drowned undercity and couldn't read the label. 2d4+2 HP."
+      },
+      {
+        "item": "A child's wooden horse",
+        "value": "0 gp",
+        "note": "Worthless, but Brakka recognizes it — it belonged to a family lost when the river rose. Returning it is a quiet roleplay beat and earns the party a permanent free welcome at the Crown."
+      },
+      {
+        "item": "Bundle of river-stained cloth (3 bolts)",
+        "value": "6 gp",
+        "note": "Sellable salvage if the party hauls it up."
+      }
     ],
     "story_rewards": [
       "If Quill and/or Grett's crew were spared and led to safety, the goblins owe the party a life-debt — a future-hook ally living rough on the town's edge.",
@@ -344,10 +476,23 @@
       "combat_2": "scene-5-sump — 3x Goblin incl. Grett (bundled)."
     },
     "bundled_assets_used": {
-      "monsters": ["Wolf (x2, scene-3, reflavored scavenger-hounds)", "Goblin (x1 Quill scene-4; x3 Grett+crew scene-5)"],
-      "monsters_optional": ["Bandit (only if Brakka/Dorn are ever forced to fight)"],
-      "spells_in_play": ["Healing Word / Cure Wounds (companion stabilizing a downed PC)", "Fire Bolt / Magic Missile (ranged options across the flooded Rat-Run)", "Mage Armor (a wizard/sorcerer PC pre-buff before descending)"],
-      "conditions_in_play": ["Prone (Wolf knockdown, DC 11 STR)", "Grappled (optional vermin-swarm hazard)", "Frightened (DM may apply via the Long Thing's presence as a narrative dread, optional)"]
+      "monsters": [
+        "Wolf (x2, scene-3, reflavored scavenger-hounds)",
+        "Goblin (x1 Quill scene-4; x3 Grett+crew scene-5)"
+      ],
+      "monsters_optional": [
+        "Bandit (only if Brakka/Dorn are ever forced to fight)"
+      ],
+      "spells_in_play": [
+        "Healing Word / Cure Wounds (companion stabilizing a downed PC)",
+        "Fire Bolt / Magic Missile (ranged options across the flooded Rat-Run)",
+        "Mage Armor (a wizard/sorcerer PC pre-buff before descending)"
+      ],
+      "conditions_in_play": [
+        "Prone (Wolf knockdown, DC 11 STR)",
+        "Grappled (optional vermin-swarm hazard)",
+        "Frightened (DM may apply via the Long Thing's presence as a narrative dread, optional)"
+      ]
     },
     "pacing_for_one_hour": "Scene 1 ~10 min (hook + bargain), Scene 2 ~10 min (descent + trap + fork), Scene 3 ~12 min (wolf fight), Scene 4 ~10 min (Quill + twist), Scene 5 ~15 min (climax + seal), Conclusion ~3 min. Trim the optional vermin swarm and run Grett's crew at 2 goblins to stay inside the hour for a smaller party.",
     "originality_note": "This adventure is 100% original prose written for WorldOS and is shippable under CC-BY. It uses only SRD 5.2 mechanics and the bundled Goblin/Wolf/Bandit stat blocks. No published or copyrighted adventure text is reproduced."

--- a/qa/probe_fixtures/quest_created_bare.py
+++ b/qa/probe_fixtures/quest_created_bare.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""quest_created_bare — the #1405(a) quest-AUTHORING mechanism-probe fixture.
+
+Builds a deterministic campaign whose ONE active quest was created BARE — no objectives, no
+giver, no location — so a short live-beat probe can ask the authoring-cue question directly:
+"does the DM ACT on quest_authoring_incomplete (author the quest's spine) — or only narrate a
+job with no trackable goals?" This is the flywheel's NEW binding constraint (#1405: objectives
+empty in 2/3 sampled quests AT THE SNAPSHOT LEVEL — no engine data exists to extract).
+
+The parked state (all engine-written; the engine remains SOLE WRITER — this only calls
+server.* + save_campaign, exactly like wrap_window_active_quest.py / the qa/seed_gfx_*.py seeds):
+  * a LIVING PC (Aldric, human fighter L4) seated + in the party — a real, alive protagonist;
+  * ONE active quest created via add_quest WITHOUT objectives / giver_id / location_id — the
+    spine-less thread the authoring cue names.
+
+SOLO PC ON PURPOSE: the authoring cue is MED severity; an un-gauged recruited companion would
+emit a competing MED companion_gauge_unauthored that (appended earlier) would outrank it as
+next_action. A solo living PC keeps quest_authoring_incomplete the single top obligation the
+probe's cue-check reads — the same discipline wrap_window_active_quest.py relies on for its
+HIGH cue.
+
+At that state _compute_beat_obligations yields a single MED ``quest_authoring_incomplete`` cue,
+which becomes the beat's ``next_action`` — the deterministic pre-check this builder ASSERTS
+before returning (free, no LLM). If that invariant ever breaks, the fixture fails LOUDLY here
+rather than shipping a probe that measures nothing.
+
+The probe's DETERMINISTIC verdict (qa/probe_verdict.py) reads "did engine state MOVE?" for this
+cue as quest_authoring_progressed: an existing quest gained objectives/giver/location, OR a new
+quest arrived carrying an objective spine (the realistic "DM re-called add_quest with the fields"
+path — there is no update-fields tool). ACTED = cue present at start + the DM called add_quest /
+set_quest_status + that authoring movement.
+
+⚠ ITERATION SIGNAL ONLY — a seeded fixture SKIPS the cold-open / seat-path / free-play surfaces
+where our real bugs live (see docs/qa/FAST_GATE.md "the trap"). NEVER cite a probe built on this
+fixture as release evidence.
+
+Usage (WORLDOS_STATE_DIR is set by the caller; uv --directory cd's into servers/engine, so pass
+this script by ABSOLUTE path):
+  WORLDOS_STATE_DIR=<dir> uv run --directory servers/engine python "$PWD/qa/probe_fixtures/quest_created_bare.py" <state_dir>
+
+Prints a one-line JSON manifest (campaign_id, pc_id, quest_id, cue, next_action) on the last
+line, for the probe runner to consume.
+"""
+import json
+import os
+import sys
+
+
+# Pin a well-known campaign id so "same fixture → same snapshot" holds (create_campaign
+# auto-ids, so build the Campaign directly the way wrap_window_active_quest.py does).
+CID = "camp_probe_questbare"
+QUEST_TITLE = "A Word from the Docks"
+
+
+def _build(server) -> dict:
+    from models import Campaign  # noqa: PLC0415
+
+    # 1. A campaign + a place to stand in (so the scene has a location). Pin the id.
+    server.save_campaign(Campaign(
+        id=CID, title="Mechanism Probe — bare quest authoring",
+        summary="Tier-1.5 mechanism-probe fixture: one active quest created with no objectives/giver/location.",
+    ))
+    server.add_location(
+        campaign_id=CID, name="Lower City — the docks", make_current=True,
+        description="A rain-slick dock in the Lower City; a nervous longshoreman keeps glancing over his shoulder.",
+    )
+
+    server.start_session(CID, title="Mechanism Probe")
+
+    # 2. A LIVING PC — a real, alive protagonist. Deterministic create_character seat (not a canon
+    #    pull) so the snapshot is reproducible byte-for-byte across runs; the probe measures the
+    #    CUE mechanism, not seating.
+    pc = server.create_character(
+        campaign_id=CID, name="Aldric", kind="player",
+        race="human", class_name="fighter", level=4,
+        abilities={"strength": 16, "dexterity": 14, "constitution": 15,
+                   "intelligence": 10, "wisdom": 12, "charisma": 10},
+        apply_srd_defaults=True, add_to_party=True,
+    )
+    pc_id = pc["id"]
+
+    # 3. THE bare quest — created via add_quest with NO objectives, giver_id, or location_id. This
+    #    is exactly the under-authored quest #1405 diagnoses (a job with no trackable spine). The
+    #    engine verb is the sole writer; we deliberately reproduce the state the DM leaves behind.
+    q = server.add_quest(CID, QUEST_TITLE, description="The longshoreman wants to hire the party for something.")
+    quest_id = q["id"]
+
+    # 4. Park the arc a few beats in (beats_in_act == _QUEST_AUTHORING_BEATS) so the per-beat
+    #    quest_authoring_incomplete cue has ESCALATED — the quest was narrated a stretch and STILL
+    #    has no spine (the create-moment nudge is the add_quest result cue; this is the escalation).
+    #    Set directly the way wrap_window_active_quest.py parks its arc; save_campaign persists it.
+    c = server._require(CID)
+    c.narrative_arc.beats_in_act = server._QUEST_AUTHORING_BEATS
+    server.save_campaign(c)
+
+    return {"campaign_id": CID, "pc_id": pc_id, "quest_id": quest_id}
+
+
+def _precheck(server, quest_id: str) -> dict:
+    """The deterministic (free, no-LLM) pre-check: _compute_beat_obligations on the fixture must
+    yield ``quest_authoring_incomplete`` as the beat's ``next_action``, naming our bare quest.
+    RAISES if the invariant is broken so the fixture can never ship a probe that measures nothing."""
+    c = server._require(CID)
+    obligations = server._compute_beat_obligations(c)
+    kinds = [o.get("kind") for o in obligations]
+    next_action = server._next_action(obligations)
+    na_kind = (next_action or {}).get("kind")
+
+    if "quest_authoring_incomplete" not in kinds:
+        raise AssertionError(
+            "pre-check FAILED: expected a quest_authoring_incomplete obligation for the bare quest, "
+            f"got kinds={kinds}. The fixture no longer parks an un-authored quest — a probe on it "
+            "would measure nothing."
+        )
+    if na_kind != "quest_authoring_incomplete":
+        raise AssertionError(
+            "pre-check FAILED: expected next_action.kind == 'quest_authoring_incomplete' (the sole "
+            f"top obligation on a solo-PC bare-quest fixture), got {na_kind!r} from kinds={kinds}."
+        )
+    authoring = next(o for o in obligations if o.get("kind") == "quest_authoring_incomplete")
+    if authoring.get("quest_id") != quest_id:
+        raise AssertionError(
+            f"pre-check FAILED: quest_authoring_incomplete names quest {authoring.get('quest_id')!r}, "
+            f"expected the fixture's bare quest {quest_id!r}."
+        )
+    return {"cue": "quest_authoring_incomplete", "next_action": na_kind, "obligation_kinds": kinds}
+
+
+def build_and_precheck() -> dict:
+    """Build the fixture into WORLDOS_STATE_DIR and run the deterministic pre-check.
+
+    Importable (the pytest determinism + pre-check tests call this) as well as CLI-runnable.
+    Returns the manifest dict merged with the pre-check observation. RAISES on a broken invariant.
+    """
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "servers", "engine"))
+    import server  # noqa: PLC0415
+
+    manifest = _build(server)
+    manifest.update(_precheck(server, manifest["quest_id"]))
+    return manifest
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: quest_created_bare.py <state_dir>", file=sys.stderr)
+        return 2
+    os.environ["WORLDOS_STATE_DIR"] = sys.argv[1]
+    manifest = build_and_precheck()
+    print(json.dumps(manifest))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/probe_fixtures/quest_resolved_no_consequence.py
+++ b/qa/probe_fixtures/quest_resolved_no_consequence.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""quest_resolved_no_consequence — the #1405(b) consequence-CAPTURE mechanism-probe fixture.
+
+Builds a deterministic campaign whose ONE quest RESOLVED (status=completed) with NO branch
+outcome recorded — empty evolves_to AND no Consequence naming it — so a short live-beat probe can
+ask the capture-cue question directly: "does the DM ACT to capture a resolved quest's
+consequence (complete_quest(evolves_to=…) / add_consequence / record_decision) — or leave the win
+a dead end?" This is the flywheel's other measured gap (#1405: consequences empty in 3/3 sampled
+quests AT THE SNAPSHOT LEVEL — the promised dilemmas never actually branch in the engine).
+
+The seeded cue is the EXISTING ``quest_no_echo`` beat obligation (a RESOLVED quest with empty
+evolves_to and no naming consequence) — #1405(b) reuses it as the capture cue's per-beat surface
+rather than adding a parallel obligation kind, and the resolution-time TOOL results
+(complete_quest / complete_objective / record_decision) additionally carry the same nudge as a
+``consequence_cue`` payload.
+
+The parked state (all engine-written; engine = SOLE WRITER — only server.* + save_campaign):
+  * a LIVING PC (Aldric, human fighter L4) seated + in the party;
+  * ONE quest with every objective completed and status flipped to `completed`, evolves_to left
+    EMPTY, and NO consequence in the campaign that names it — the dead-end win the cue flags.
+
+SOLO PC ON PURPOSE: quest_no_echo is LOW severity; any MED companion cue (e.g.
+companion_gauge_unauthored on an un-gauged recruit) would outrank it as next_action. A solo
+living PC keeps quest_no_echo the single top obligation the probe's cue-check reads.
+
+At that state _compute_beat_obligations yields a single LOW ``quest_no_echo`` cue → the beat's
+``next_action`` — the deterministic pre-check this builder ASSERTS (free, no LLM). The probe's
+verdict reads movement for this cue as quest_echo_captured: a new consequence was recorded OR a
+quest gained a non-empty evolves_to. ACTED = cue present at start + the DM called
+complete_quest / add_consequence / record_decision + that capture movement.
+
+⚠ ITERATION SIGNAL ONLY — a seeded fixture SKIPS the cold-open / seat-path / free-play surfaces
+where our real bugs live (docs/qa/FAST_GATE.md "the trap"). NEVER cite a probe on it as release
+evidence.
+
+Usage (WORLDOS_STATE_DIR is set by the caller; pass this script by ABSOLUTE path):
+  WORLDOS_STATE_DIR=<dir> uv run --directory servers/engine python "$PWD/qa/probe_fixtures/quest_resolved_no_consequence.py" <state_dir>
+
+Prints a one-line JSON manifest (campaign_id, pc_id, quest_id, cue, next_action) on the last line.
+"""
+import json
+import os
+import sys
+
+
+CID = "camp_probe_questnoconseq"
+QUEST_TITLE = "The Silenced Bell"
+QUEST_OBJECTIVES = ["Find who muffled the temple bell", "Confront the saboteur"]
+
+
+def _build(server) -> dict:
+    from models import Campaign  # noqa: PLC0415
+
+    server.save_campaign(Campaign(
+        id=CID, title="Mechanism Probe — resolved quest, no consequence",
+        summary="Tier-1.5 mechanism-probe fixture: one completed quest with empty evolves_to and no naming consequence.",
+    ))
+    server.add_location(
+        campaign_id=CID, name="Temple ward", make_current=True,
+        description="The temple ward, quiet again now the bell hangs silent and the saboteur is caught.",
+    )
+
+    server.start_session(CID, title="Mechanism Probe")
+
+    pc = server.create_character(
+        campaign_id=CID, name="Aldric", kind="player",
+        race="human", class_name="fighter", level=4,
+        abilities={"strength": 16, "dexterity": 14, "constitution": 15,
+                   "intelligence": 10, "wisdom": 12, "charisma": 10},
+        apply_srd_defaults=True, add_to_party=True,
+    )
+    pc_id = pc["id"]
+
+    # A quest whose objectives were all cleared, then resolved via complete_objective — the LAST
+    # objective auto-resolves it to `completed` WITHOUT setting evolves_to (that path only sets the
+    # rule-of-three fields when the DM passes them). So the quest lands `completed` + empty
+    # evolves_to + no consequence: exactly the dead-end win quest_no_echo flags. All engine verbs.
+    q = server.add_quest(
+        CID, QUEST_TITLE,
+        description="Someone muffled the great temple bell on the eve of the festival.",
+        location_id=server._require(CID).current_location_id or "",
+        objectives=list(QUEST_OBJECTIVES),
+    )
+    quest_id = q["id"]
+    for obj in QUEST_OBJECTIVES:
+        server.complete_objective(CID, quest_id, obj)
+
+    return {"campaign_id": CID, "pc_id": pc_id, "quest_id": quest_id}
+
+
+def _precheck(server, quest_id: str) -> dict:
+    """The deterministic (free, no-LLM) pre-check: the quest must be `completed` with empty
+    evolves_to, and _compute_beat_obligations must yield ``quest_no_echo`` as the beat's
+    ``next_action`` naming it. RAISES on a broken invariant."""
+    c = server._require(CID)
+    q = c.quests[quest_id]
+    if getattr(q, "status", None) != "completed":
+        raise AssertionError(
+            f"pre-check FAILED: expected the quest `completed` (all objectives cleared), got "
+            f"status={getattr(q, 'status', None)!r}."
+        )
+    if (getattr(q, "evolves_to", "") or "").strip():
+        raise AssertionError(
+            "pre-check FAILED: the quest already has a non-empty evolves_to — the fixture must park "
+            "a CONSEQUENCE-LESS resolution or the capture cue never fires."
+        )
+    obligations = server._compute_beat_obligations(c)
+    kinds = [o.get("kind") for o in obligations]
+    next_action = server._next_action(obligations)
+    na_kind = (next_action or {}).get("kind")
+
+    if "quest_no_echo" not in kinds:
+        raise AssertionError(
+            "pre-check FAILED: expected a quest_no_echo obligation for the resolved-no-consequence "
+            f"quest, got kinds={kinds}. The fixture no longer parks a dead-end win."
+        )
+    if na_kind != "quest_no_echo":
+        raise AssertionError(
+            "pre-check FAILED: expected next_action.kind == 'quest_no_echo' (the sole top obligation "
+            f"on a solo-PC resolved-no-consequence fixture), got {na_kind!r} from kinds={kinds}."
+        )
+    echo = next(o for o in obligations if o.get("kind") == "quest_no_echo")
+    if echo.get("quest_id") != quest_id:
+        raise AssertionError(
+            f"pre-check FAILED: quest_no_echo names quest {echo.get('quest_id')!r}, expected the "
+            f"fixture's resolved quest {quest_id!r}."
+        )
+    return {"cue": "quest_no_echo", "next_action": na_kind, "obligation_kinds": kinds}
+
+
+def build_and_precheck() -> dict:
+    """Build the fixture into WORLDOS_STATE_DIR and run the deterministic pre-check. Importable
+    (the pytest tests call this) as well as CLI-runnable. RAISES on a broken invariant."""
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "servers", "engine"))
+    import server  # noqa: PLC0415
+
+    manifest = _build(server)
+    manifest.update(_precheck(server, manifest["quest_id"]))
+    return manifest
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: quest_resolved_no_consequence.py <state_dir>", file=sys.stderr)
+        return 2
+    os.environ["WORLDOS_STATE_DIR"] = sys.argv[1]
+    manifest = build_and_precheck()
+    print(json.dumps(manifest))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/probe_verdict.py
+++ b/qa/probe_verdict.py
@@ -50,6 +50,12 @@ CUE_ENGAGEMENT_TOOLS: dict[str, tuple[str, ...]] = {
     "camp_overdue": ("long_rest", "camp_scene"),
     "act_climax_owed": ("mark_climax", "complete_quest"),
     "act_midpoint_owed": ("mark_reversal", "record_decision"),
+    # #1405 authoring cues. authoring: the DM re-authors the spine-less quest (add_quest with
+    # objectives/giver/location, or resolves it away with set_quest_status). capture (quest_no_echo):
+    # the DM records the resolved quest's branch outcome via complete_quest(evolves_to=...) /
+    # add_consequence / record_decision.
+    "quest_authoring_incomplete": ("add_quest", "set_quest_status"),
+    "quest_no_echo": ("complete_quest", "add_consequence", "record_decision"),
 }
 
 
@@ -162,6 +168,96 @@ def quest_moved(before: dict, after: dict) -> bool:
     return False
 
 
+def _raw_quests(state: dict):
+    """The quests as an iterable of dicts from a RAW engine snapshot (dict-of-Quest or list).
+    The #1405 movement checks need the giver/location/objectives/evolves_to fields the projected
+    get_state list drops, so they always read the raw snapshot the probe passes."""
+    quests = state.get("quests")
+    if isinstance(quests, dict):
+        return [q for q in quests.values() if isinstance(q, dict)]
+    if isinstance(quests, list):
+        return [q for q in quests if isinstance(q, dict)]
+    return []
+
+
+def _authoring_signature(state: dict) -> dict:
+    """Per-quest authoring richness from a raw snapshot: objective count + whether a giver /
+    location is set. The quest_authoring_incomplete movement check compares this before vs after."""
+    sig: dict = {}
+    for q in _raw_quests(state):
+        qid = q.get("id") or q.get("quest_id")
+        if qid is None:
+            continue
+        objectives = q.get("objectives")
+        sig[qid] = {
+            "n_objectives": len(objectives) if isinstance(objectives, (list, tuple)) else 0,
+            "has_giver": bool(q.get("giver_id")),
+            "has_location": bool(q.get("location_id")),
+        }
+    return sig
+
+
+def quest_authoring_progressed(before: dict, after: dict) -> bool:
+    """True iff the DM actually AUTHORED richness (#1405(a)): an existing quest gained objectives /
+    a giver / a location, OR a brand-new quest arrived already carrying an objective spine (the
+    realistic 'DM re-called add_quest with the fields' path). Ground truth over prose."""
+    b = _authoring_signature(before)
+    a = _authoring_signature(after)
+    for qid, a_sig in a.items():
+        b_sig = b.get(qid)
+        if b_sig is None:
+            if a_sig["n_objectives"] > 0:  # a new quest authored WITH a spine
+                return True
+            continue
+        if a_sig["n_objectives"] > b_sig["n_objectives"]:
+            return True
+        if a_sig["has_giver"] and not b_sig["has_giver"]:
+            return True
+        if a_sig["has_location"] and not b_sig["has_location"]:
+            return True
+    return False
+
+
+def _echo_signature(state: dict) -> tuple[dict, int]:
+    """Per-quest evolves_to-set flag + the campaign's total consequence count, from a raw
+    snapshot. The quest_no_echo capture check compares this before vs after."""
+    q_echo: dict = {}
+    for q in _raw_quests(state):
+        qid = q.get("id") or q.get("quest_id")
+        if qid is None:
+            continue
+        q_echo[qid] = bool((q.get("evolves_to") or "").strip())
+    consequences = state.get("consequences")
+    n = len(consequences) if isinstance(consequences, (list, tuple)) else 0
+    return q_echo, n
+
+
+def quest_echo_captured(before: dict, after: dict) -> bool:
+    """True iff the DM captured a resolved quest's branch outcome (#1405(b) / quest_no_echo): a new
+    consequence was recorded (add_consequence / a scheduled evolution) OR a quest gained a
+    non-empty evolves_to. Ground truth over prose."""
+    b_echo, b_n = _echo_signature(before)
+    a_echo, a_n = _echo_signature(after)
+    if a_n > b_n:
+        return True
+    for qid, has in a_echo.items():
+        if has and not b_echo.get(qid, False):
+            return True
+    return False
+
+
+def state_progressed(cue: str, before: dict, after: dict) -> bool:
+    """The cue-appropriate 'did engine state MOVE' ground-truth signal. #1405 authoring/capture
+    cues clear by AUTHORING (fields populated) or CAPTURE (a consequence recorded), neither of
+    which is a quest status/objective flip — so they read their own signals. Every other cue keeps
+    the quest_moved status/objective signal it always used (byte-identical for existing cues)."""
+    if cue == "quest_authoring_incomplete":
+        return quest_authoring_progressed(before, after)
+    if cue == "quest_no_echo":
+        return quest_echo_captured(before, after)
+    return quest_moved(before, after)
+
+
 def compute_verdict(
     cue: str,
     cue_present_at_start: bool,
@@ -249,7 +345,7 @@ def build_report(
     # DM resolved the thread — surfaced for observability alongside the each-beat fact.
     cue_cleared_after_action = cue_present_at_start and not cue_present_each_beat
     engagement = engagement_tally(transcript_path, cue)
-    state_moved = quest_moved(state_before, state_after)
+    state_moved = state_progressed(cue, state_before, state_after)
     verdict = compute_verdict(cue, cue_present_at_start, engagement, state_moved, any_beat_failed)
     return {
         "cue": cue,

--- a/qa/test_mechanism_probe.py
+++ b/qa/test_mechanism_probe.py
@@ -294,5 +294,118 @@ def test_build_report_end_to_end_ignored(tmp_path):
     assert report["dm_engagement_tools_called"] == {}
 
 
+# ── #1405 authoring/capture cues: verdict movement signals + the two new fixtures ───────────────
+
+def test_quest_authoring_progressed_detects_gained_objectives():
+    before = {"quests": {"q1": {"id": "q1", "objectives": [], "giver_id": None, "location_id": None}}}
+    after = {"quests": {"q1": {"id": "q1", "objectives": ["ask around"], "giver_id": None, "location_id": None}}}
+    assert probe_verdict.quest_authoring_progressed(before, after) is True
+
+
+def test_quest_authoring_progressed_detects_new_authored_quest():
+    before = {"quests": {"q1": {"id": "q1", "objectives": [], "giver_id": None, "location_id": None}}}
+    # The realistic path: no update-fields tool, so the DM re-calls add_quest WITH a spine.
+    after = {"quests": {
+        "q1": {"id": "q1", "objectives": [], "giver_id": None, "location_id": None},
+        "q2": {"id": "q2", "objectives": ["meet the contact"], "giver_id": "npc_1", "location_id": "loc_1"},
+    }}
+    assert probe_verdict.quest_authoring_progressed(before, after) is True
+
+
+def test_quest_authoring_progressed_false_when_still_bare():
+    same = {"quests": {"q1": {"id": "q1", "objectives": [], "giver_id": None, "location_id": None}}}
+    assert probe_verdict.quest_authoring_progressed(same, json.loads(json.dumps(same))) is False
+
+
+def test_quest_echo_captured_detects_new_consequence():
+    before = {"quests": {"q1": {"id": "q1", "evolves_to": ""}}, "consequences": []}
+    after = {"quests": {"q1": {"id": "q1", "evolves_to": ""}}, "consequences": [{"id": "c1", "text": "fallout"}]}
+    assert probe_verdict.quest_echo_captured(before, after) is True
+
+
+def test_quest_echo_captured_detects_evolves_to_set():
+    before = {"quests": {"q1": {"id": "q1", "evolves_to": ""}}, "consequences": []}
+    after = {"quests": {"q1": {"id": "q1", "evolves_to": "the patron seeks revenge"}}, "consequences": []}
+    assert probe_verdict.quest_echo_captured(before, after) is True
+
+
+def test_quest_echo_captured_false_when_nothing_recorded():
+    same = {"quests": {"q1": {"id": "q1", "evolves_to": ""}}, "consequences": []}
+    assert probe_verdict.quest_echo_captured(same, json.loads(json.dumps(same))) is False
+
+
+def test_state_progressed_routes_by_cue():
+    # authoring cue reads the authoring signal, not quest_moved (status/objective flip).
+    b_auth = {"quests": {"q1": {"id": "q1", "objectives": [], "giver_id": None, "location_id": None}}}
+    a_auth = {"quests": {"q1": {"id": "q1", "objectives": ["x"], "giver_id": None, "location_id": None}}}
+    assert probe_verdict.state_progressed("quest_authoring_incomplete", b_auth, a_auth) is True
+    # capture cue reads the echo signal.
+    b_echo = {"quests": {"q1": {"id": "q1", "evolves_to": ""}}, "consequences": []}
+    a_echo = {"quests": {"q1": {"id": "q1", "evolves_to": "echo"}}, "consequences": []}
+    assert probe_verdict.state_progressed("quest_no_echo", b_echo, a_echo) is True
+
+
+def test_build_report_authoring_acted(tmp_path):
+    """A full synthetic ACTED case for the authoring cue: it held, the DM re-authored via add_quest,
+    a spine-bearing quest now exists."""
+    _write_transcript(tmp_path / "t.jsonl", [
+        ("mcp__worldos-engine__add_quest", {"title": "A Word from the Docks", "objectives": ["meet the contact"]}),
+    ])
+    before = {"quests": {"q1": {"id": "q1", "objectives": [], "giver_id": None, "location_id": None}}}
+    after = {"quests": {
+        "q1": {"id": "q1", "objectives": [], "giver_id": None, "location_id": None},
+        "q2": {"id": "q2", "objectives": ["meet the contact"], "giver_id": "npc_1", "location_id": "loc_1"},
+    }}
+    report = probe_verdict.build_report("quest_authoring_incomplete", [True], tmp_path / "t.jsonl", before, after)
+    assert report["verdict"] == "ACTED"
+    assert report["dm_engagement_tools_called"] == {"add_quest": 1}
+
+
+def test_build_report_capture_ignored_when_only_narrated(tmp_path):
+    """The IGNORED case for the capture cue: quest_no_echo fired, the DM only narrated the fallout,
+    no consequence / evolves_to was recorded."""
+    _write_transcript(tmp_path / "t.jsonl", [("scene_context", {})],
+                       texts=["The bell hangs silent; the town will remember this."])
+    before = {"quests": {"q1": {"id": "q1", "evolves_to": ""}}, "consequences": []}
+    after = json.loads(json.dumps(before))
+    report = probe_verdict.build_report("quest_no_echo", [True, True], tmp_path / "t.jsonl", before, after)
+    assert report["verdict"] == "IGNORED"
+
+
+# ── The two #1405 fixtures: precheck + structural determinism (runnable as-is) ───────────────────
+
+def _load_named_fixture(name: str):
+    path = _QA_DIR / "probe_fixtures" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize("name,expected_cue", [
+    ("quest_created_bare", "quest_authoring_incomplete"),
+    ("quest_resolved_no_consequence", "quest_no_echo"),
+])
+def test_new_fixture_precheck_yields_expected_next_action(tmp_path, name, expected_cue):
+    os.environ["WORLDOS_STATE_DIR"] = str(tmp_path / name)
+    manifest = _load_named_fixture(name).build_and_precheck()
+    assert manifest["cue"] == expected_cue
+    assert manifest["next_action"] == expected_cue
+    # Solo-PC fixtures: the seeded cue is the SINGLE top obligation (no competing companion/party cue).
+    assert manifest["obligation_kinds"][0] == expected_cue
+    assert manifest["quest_id"]
+
+
+@pytest.mark.parametrize("name", ["quest_created_bare", "quest_resolved_no_consequence"])
+def test_new_fixture_determinism_same_structure_across_builds(tmp_path, name):
+    os.environ["WORLDOS_STATE_DIR"] = str(tmp_path / "a")
+    m1 = _load_named_fixture(name).build_and_precheck()
+    snap1 = _snapshot(m1, tmp_path / "a")
+    os.environ["WORLDOS_STATE_DIR"] = str(tmp_path / "b")
+    m2 = _load_named_fixture(name).build_and_precheck()
+    snap2 = _snapshot(m2, tmp_path / "b")
+    assert _normalize(snap1) == _normalize(snap2), f"{name} is not structurally deterministic"
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q", "-p", "no:xdist"]))

--- a/servers/engine/consequences.py
+++ b/servers/engine/consequences.py
@@ -13,10 +13,14 @@ from __future__ import annotations
 from models import Campaign, Consequence
 
 
-def schedule(campaign: Campaign, in_days: int, text: str, note: str = "") -> Consequence:
-    """Schedule a consequence to fire ``in_days`` from the current day (mutates)."""
+def schedule(campaign: Campaign, in_days: int, text: str, note: str = "",
+             quest_id: str = "") -> Consequence:
+    """Schedule a consequence to fire ``in_days`` from the current day (mutates). ``quest_id``
+    (#1405, default "" == today) records the Quest this consequence is the branch-outcome OF, so
+    the capture cue can see a natural-prose consequence as captured via a structured link."""
     conseq = Consequence(
-        trigger_day=campaign.day + max(0, int(in_days)), text=text, note=note
+        trigger_day=campaign.day + max(0, int(in_days)), text=text, note=note,
+        quest_id=(quest_id or ""),
     )
     campaign.consequences.append(conseq)
     return conseq

--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -855,7 +855,16 @@ def seed_campaign(adv: dict) -> Campaign:
         c.factions[faction.id] = faction
 
     if adv.get("hook"):
-        quest = Quest(title=adv.get("title", "Adventure"), description=adv["hook"])
+        # #1405: an adventure MAY ship an authored objective spine for its opening quest via an
+        # optional top-level `quest_objectives` list. ADDITIVE — an adventure without the key seeds
+        # an objective-less opening quest exactly as before. Authoring these makes the flagship
+        # adventures model the rich-authoring behavior the quest_authoring cue nudges the DM toward
+        # (a content-seeded objective-less starter otherwise, correctly, trips the beat-4 cue).
+        quest = Quest(
+            title=adv.get("title", "Adventure"),
+            description=adv["hook"],
+            objectives=[str(o) for o in (adv.get("quest_objectives") or []) if str(o).strip()],
+        )
         c.quests[quest.id] = quest
 
     # F06-10/F06-11 (audit 2026-06-18): fold an OPTIONAL top-level `companion_quest_arcs` block

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -1561,6 +1561,27 @@ class Consequence(_StrictModel):
     note: str = ""  # why / source (e.g. "the player let the cultist escape")
     fired: bool = False
     thread_id: str = ""  # non-empty => a recurring background "world beat" from a standing thread (world-sim); reschedules itself on tick
+    # #1405: the Quest this consequence is the recorded branch-outcome OF (add_consequence(quest_id=…)
+    # / a scheduled quest evolution). ADDITIVE + default "" == today. The authoring/capture cue's
+    # _quest_consequence_recorded checks this STRUCTURED link FIRST so a DM who captures a
+    # consequence in natural in-world prose (no literal quest title in the text) is correctly seen as
+    # captured — the lowercase-substring match on text/note is only a legacy/unlinked fallback.
+    quest_id: str = ""
+
+    @model_serializer(mode="wrap")
+    def _ser_omit_empty_quest_id(self, handler):
+        """OMIT ``quest_id`` from the dump when it is "" so a consequence with no quest link
+        serializes BYTE-IDENTICALLY to a pre-#1405 snapshot (which never carried the key). Same
+        narrowly-scoped guard as Location._ser_omit_none_scene_grid, and for the same reason: the
+        store's F08-2 dirty-skip byte-compares the candidate dump to disk so a pure load->save with
+        no mutation is a no-op that must NOT bump updated_at / steal the #640 live pointer. An
+        unconditional dump would emit ``"quest_id": ""`` for EVERY (incl. unlinked) consequence — a
+        key an un-migrated snapshot lacks — defeating the dirty-skip on any cross-campaign inspect.
+        A quest-LINKED consequence serializes ``quest_id`` normally; all other keys/order unchanged."""
+        data = handler(self)
+        if not self.quest_id:
+            data.pop("quest_id", None)
+        return data
 
 
 class ApprovalEvent(_StrictModel):

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -11349,7 +11349,7 @@ def recall_decisions(campaign_id: str, query: str = "", limit: int = 12) -> dict
 
 @mcp.tool()
 def add_consequence(campaign_id: str, in_days: int = 0, text: str = "", note: str = "",
-                    message: str = "", content: str = "") -> dict:
+                    message: str = "", content: str = "", quest_id: str = "") -> dict:
     """Schedule a time-deferred world event to come due `in_days` from now (the
     in-world Campaign.day). Use it whenever the present sets up the future — a
     ritual that completes in 3 days, a spared villain who returns in a week, a
@@ -11358,20 +11358,30 @@ def add_consequence(campaign_id: str, in_days: int = 0, text: str = "", note: st
 
     Pass the event as ``text`` (canonical) or the aliases ``message`` / ``content`` —
     ``text`` wins if more than one is given. (``note`` is a SEPARATE optional field, not an
-    alias.)"""
+    alias.)
+
+    ``quest_id`` (#1405, optional): when this consequence IS the recorded branch-outcome of a
+    resolved quest, pass its id — that STRUCTURED link is what clears the `consequence_cue`
+    capture nudge, so you can phrase ``text`` as natural in-world prose without echoing the
+    quest's title. Omit it for a free-standing world event (default "" == today)."""
     text = text or message or content  # accept the text the DM reaches for (NOT `note` — distinct field)
     if not text:
         raise ValueError("add_consequence needs text (pass `text` or an alias: `message`/`content`)")
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
-        conseq = consequences_mod.schedule(c, in_days, text, note)
+        conseq = consequences_mod.schedule(c, in_days, text, note, quest_id=(quest_id or "").strip())
         save_campaign(c)
-        return {
+        out = {
             "id": conseq.id,
             "trigger_day": conseq.trigger_day,
             "current_day": c.day,
             "text": conseq.text,
         }
+        # ADDITIVE: echo the structured link back only when set, so an unlinked consequence returns
+        # the exact four-key shape it always has.
+        if conseq.quest_id:
+            out["quest_id"] = conseq.quest_id
+        return out
 
 
 @mcp.tool()
@@ -11925,16 +11935,28 @@ def _quest_authoring_cue(q: Quest) -> Optional[dict]:
 
 
 def _quest_consequence_recorded(c: Campaign, q: Quest) -> bool:
-    """True iff a resolved quest already has its branch outcome captured: a non-empty evolves_to
-    (the follow-on the extractor reads as resolution.evolves_to) OR a Consequence whose note/text
-    names the quest (the sink complete_quest(evolves_to=...) schedules and add_consequence writes).
-    Mirrors the quest_no_echo beat-obligation's own echo check so the result cue and the digest
-    agree on what 'has a consequence' means."""
+    """True iff a resolved quest already has its branch outcome captured. Three signals, in order:
+      1. a non-empty ``evolves_to`` (the follow-on the extractor reads as resolution.evolves_to);
+      2. a Consequence STRUCTURALLY linked to this quest (``Consequence.quest_id == q.id``) — the
+         #1405 machine-checkable link add_consequence(quest_id=…) writes, so a DM who captures the
+         outcome in NATURAL in-world prose (no literal quest title in the text) is correctly seen
+         as captured (the false-positive hole the substring-only check had);
+      3. FALLBACK for legacy / unlinked consequences: a Consequence whose text/note lowercased
+         mentions the quest's title or id. This is best-effort only — a natural-prose consequence
+         with NO structured link and no literal title will not match, so the cue may re-fire; the
+         remediation the cue names is passing quest_id, which lands signal 2.
+    Mirrors the quest_no_echo digest's echo check so the result cue and the digest agree."""
     if (getattr(q, "evolves_to", "") or "").strip():
         return True
+    qid = str(getattr(q, "id", "") or "").strip()
+    consequences = getattr(c, "consequences", None) or []
+    # Signal 2 — the structured link (exact match, no substring guesswork).
+    if qid and any(str(getattr(cs, "quest_id", "") or "").strip() == qid for cs in consequences):
+        return True
+    # Signal 3 — legacy substring fallback (unlinked consequences from before quest_id existed).
     needle_title = (getattr(q, "title", "") or "").strip().lower()
-    needle_id = (str(getattr(q, "id", "") or "")).strip().lower()
-    for cs in getattr(c, "consequences", None) or []:
+    needle_id = qid.lower()
+    for cs in consequences:
         blob = f"{getattr(cs, 'text', '')} {getattr(cs, 'note', '')}".lower()
         if (needle_title and needle_title in blob) or (needle_id and needle_id in blob):
             return True
@@ -11955,8 +11977,10 @@ def _quest_consequence_cue(c: Campaign, q: Quest) -> Optional[dict]:
         "quest_id": getattr(q, "id", None),
         "imperative": (
             f"'{getattr(q, 'title', None) or 'this quest'}' resolved with no branch outcome "
-            "recorded — capture it: complete_quest(quest_id, evolves_to='...') or "
-            "add_consequence(...) so the win/loss leaves a mark the world (and the extractor) sees."
+            "recorded — capture it: complete_quest(quest_id, evolves_to='...'), or "
+            "add_consequence(text='...', quest_id=<this quest's id>) — pass quest_id so the link is "
+            "recorded even when you phrase the fallout as natural prose. This leaves a mark the "
+            "world (and the extractor) can see."
         ),
     }
 

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -366,6 +366,15 @@ _QUEST_STALL_BEATS = 8
 # beats in gets a cue to enlist, so a seeded faction questline isn't left narrated-not-engined.
 _FACTION_JOIN_BEATS = 8
 
+# #1405: quest_authoring_incomplete beats-reach. A quest CREATED without objectives (no spine the
+# engine can track) that is STILL objective-less this many act-local beats later is the flywheel's
+# binding-constraint failure (objectives empty 2/3 at snapshot level). The one-time add_quest
+# `authoring_cue` result already nudges at creation; this per-beat cue only ESCALATES once the
+# quest has been narrated a stretch with no authored spine — so a freshly-introduced quest on
+# beat 0 (the healthy/early case) is NOT nagged. Below _PARTY_STUCK_BEATS(=8) on purpose so it
+# fires before the party_stuck / quest_unresolved_late run-end cues, not stacked on top of them.
+_QUEST_AUTHORING_BEATS = 4
+
 # WS3a party_stuck_one_location beats-reach. PINNED to assert_behavioral's SINGLE_SCENE_MIN_BEATS —
 # the FATAL party_traveled boundary (qa/assert_behavioral.py:676): a substantial run (>= 8 act-local
 # beats) that never left the opening scene AND never progressed in place is a stuck DM. The proactive
@@ -11869,6 +11878,101 @@ def set_flag(campaign_id: str, flag: str, value: bool = True) -> dict:
         return {"flags": dict(c.flags)}
 
 
+# ── #1405: quest authoring & consequence-capture cues ─────────────────────────────────────────
+# ADVISORY return-payload nudges — the same next_action cue-stack family (#1313/#1286/#1334)
+# applied to the AUTHORING seam the flywheel's 3.9→4.0 quest-promotion gap now bottlenecks on:
+# objectives/giver/location empty at creation, and consequences never recorded at resolution
+# (issue #1405 — measured objectives empty 2/3, consequences empty 3/3 at snapshot level). Each
+# helper is a PURE read that returns None/[] when the quest is already rich, so the caller omits
+# the key and the tool result is BYTE-IDENTICAL to today's shape for a complete quest. Cues are
+# text the DM MAY act on — the engine takes NO auto-action and NEVER rejects/blocks the quest
+# (gates-read-gauges preserved; the teeth question is owner-reserved, #1313).
+
+# The richness-critical authoring fields a quest needs a spine (objectives) and grounding
+# (a giver, a place) to be trackable and promotable.
+_QUEST_AUTHORING_FIELDS = ("objectives", "giver_id", "location_id")
+
+
+def _quest_missing_fields(q: Quest) -> list[str]:
+    """Which of the richness-critical authoring fields (objectives / giver_id / location_id) a
+    quest left empty. PURE read; [] == a fully-authored quest (today's happy path)."""
+    missing = []
+    if not (getattr(q, "objectives", None) or []):
+        missing.append("objectives")
+    if not (getattr(q, "giver_id", None) or ""):
+        missing.append("giver_id")
+    if not (getattr(q, "location_id", None) or ""):
+        missing.append("location_id")
+    return missing
+
+
+def _quest_authoring_cue(q: Quest) -> Optional[dict]:
+    """#1405(a): the add_quest-time authoring nudge. next_action-style (kind/severity/imperative,
+    mirroring _next_action) plus the concrete `missing` list. Returns None when the quest is fully
+    authored, so add_quest's result stays byte-identical for a complete quest."""
+    missing = _quest_missing_fields(q)
+    if not missing:
+        return None
+    return {
+        "kind": "quest_authoring_incomplete",
+        "severity": "med",
+        "missing": missing,
+        "imperative": (
+            "Author this quest's " + ", ".join(missing) + " now (re-call add_quest with them) — "
+            "a quest with no objectives / giver / location has no spine to track or promote."
+        ),
+    }
+
+
+def _quest_consequence_recorded(c: Campaign, q: Quest) -> bool:
+    """True iff a resolved quest already has its branch outcome captured: a non-empty evolves_to
+    (the follow-on the extractor reads as resolution.evolves_to) OR a Consequence whose note/text
+    names the quest (the sink complete_quest(evolves_to=...) schedules and add_consequence writes).
+    Mirrors the quest_no_echo beat-obligation's own echo check so the result cue and the digest
+    agree on what 'has a consequence' means."""
+    if (getattr(q, "evolves_to", "") or "").strip():
+        return True
+    needle_title = (getattr(q, "title", "") or "").strip().lower()
+    needle_id = (str(getattr(q, "id", "") or "")).strip().lower()
+    for cs in getattr(c, "consequences", None) or []:
+        blob = f"{getattr(cs, 'text', '')} {getattr(cs, 'note', '')}".lower()
+        if (needle_title and needle_title in blob) or (needle_id and needle_id in blob):
+            return True
+    return False
+
+
+def _quest_consequence_cue(c: Campaign, q: Quest) -> Optional[dict]:
+    """#1405(b): the resolution-time consequence-capture nudge. Fires when a TERMINAL quest
+    (completed/failed) has NO recorded branch outcome. next_action-style. Returns None when the
+    quest already has a consequence/echo, so a resolution that recorded one stays byte-identical."""
+    if getattr(q, "status", "active") not in ("completed", "failed"):
+        return None
+    if _quest_consequence_recorded(c, q):
+        return None
+    return {
+        "kind": "quest_consequence_uncaptured",
+        "severity": "med",
+        "quest_id": getattr(q, "id", None),
+        "imperative": (
+            f"'{getattr(q, 'title', None) or 'this quest'}' resolved with no branch outcome "
+            "recorded — capture it: complete_quest(quest_id, evolves_to='...') or "
+            "add_consequence(...) so the win/loss leaves a mark the world (and the extractor) sees."
+        ),
+    }
+
+
+def _first_uncaptured_quest_cue(c: Campaign) -> Optional[dict]:
+    """The consequence-capture cue for the FIRST terminal quest in the campaign that has no
+    recorded branch outcome, or None when every resolved quest already has one. Used by
+    record_decision (which is not tied to a single quest) to nudge the DM toward capturing a
+    resolved thread's outcome while they are already recording choices."""
+    for q in (getattr(c, "quests", None) or {}).values():
+        cue = _quest_consequence_cue(c, q)
+        if cue is not None:
+            return cue
+    return None
+
+
 @mcp.tool()
 def add_quest(
     campaign_id: str,
@@ -11880,7 +11984,11 @@ def add_quest(
 ) -> dict:
     """Add a quest, optionally linked to the NPC who gave it (giver_id) and the
     location it's anchored to (location_id), so the dashboard and DM can trace
-    who-wants-what-where. A campaign has many quests; the opening hook is just one."""
+    who-wants-what-where. A campaign has many quests; the opening hook is just one.
+
+    #1405: when the quest is created MISSING objectives / giver_id / location_id the result
+    carries an ADVISORY `authoring_cue` (next_action-style) nudging the DM to populate them now
+    — never a rejection; omitted entirely once the quest is fully authored."""
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         q = Quest(
@@ -11899,7 +12007,13 @@ def add_quest(
         )
         c.quests[q.id] = q
         save_campaign(c)
-        return {"id": q.id, "title": q.title, "status": q.status}
+        out = {"id": q.id, "title": q.title, "status": q.status}
+        # #1405(a): ADDITIVE — only present when the quest is under-authored, so a complete quest
+        # returns the exact three-key shape it always has.
+        cue = _quest_authoring_cue(q)
+        if cue is not None:
+            out["authoring_cue"] = cue
+        return out
 
 
 def _evolution_note(quest_id: str) -> str:
@@ -11993,6 +12107,13 @@ def complete_quest(
         if milestone is not None:
             out["xp_awarded"] = milestone["xp_awarded"]
             out["grants"] = milestone["grants"]
+        # #1405(b): ADDITIVE — nudge the DM to capture the branch outcome when the quest resolved
+        # with none (empty evolves_to AND no consequence naming it). Computed AFTER the evolves_to
+        # kwarg + any scheduled evolution above, so a resolution that already recorded a
+        # consequence returns byte-identical to today.
+        cue = _quest_consequence_cue(c, q)
+        if cue is not None:
+            out["consequence_cue"] = cue
         return out
 
 
@@ -12083,6 +12204,12 @@ def complete_objective(campaign_id: str, quest_id: str, objective: str) -> dict:
                 "trigger_day": evolution.trigger_day,
                 "evolves_to": q.evolves_to,
             }
+        # #1405(b): when the last objective auto-resolved the quest with no branch outcome
+        # recorded, nudge to capture one. ADDITIVE — None (and thus omitted) whenever the quest
+        # stayed active OR already had an echo/consequence, so today's shape is byte-identical.
+        cue = _quest_consequence_cue(c, q)
+        if cue is not None:
+            out["consequence_cue"] = cue
         return out
 
 
@@ -12810,6 +12937,14 @@ def record_decision(
         # (today's default) returns the exact four-key shape it always has.
         if approval_results:
             out["approval_results"] = approval_results
+        # #1405(b): record_decision is the branch-outcome sink — while the DM is here recording a
+        # choice, nudge them to also capture the outcome of any resolved quest that still has none
+        # (empty evolves_to + no naming consequence). ADDITIVE — omitted when every terminal quest
+        # already has its consequence, so an untagged decision in a fully-captured campaign returns
+        # byte-identical to today.
+        cue = _first_uncaptured_quest_cue(c)
+        if cue is not None:
+            out["consequence_cue"] = cue
         return out
 
 
@@ -13568,6 +13703,29 @@ def _compute_beat_obligations(c: Campaign) -> list[dict]:
                 ),
             })
             continue  # the endgame cue owns this quest in the wrap window (not ALSO resolvable/stalled)
+        # #1405(a): an ACTIVE quest with NO objectives has no spine the engine can track toward a
+        # resolution — surface the authoring gap (the flywheel's binding constraint, #1405) as a
+        # per-beat cue so the DM populates it. This owns the quest's cue (continue) so a spine-less
+        # quest isn't ALSO flagged stalled. Fires only on the load-bearing OBJECTIVES gap; a
+        # giver/location-only gap rides the one-time add_quest `authoring_cue` result, not a
+        # per-beat nag. BEATS-GATED (_QUEST_AUTHORING_BEATS) so a freshly-introduced quest on beat 0
+        # is NOT nagged — only a quest left spine-less across a stretch of play escalates here. The
+        # one-time add_quest `authoring_cue` covers the create moment. ADDITIVE: every authored
+        # (objective-bearing) quest, and every early/healthy campaign, skips this untouched.
+        if not objectives and _beats_in_act >= _QUEST_AUTHORING_BEATS:
+            obligations.append({
+                "kind": "quest_authoring_incomplete",
+                "quest_id": qid,
+                "title": title,
+                "severity": "med",
+                "missing": _quest_missing_fields(q),
+                "detail": (
+                    f"Quest '{title}' has no objectives — it has no spine to track or resolve. "
+                    "Author its objectives (and giver_id / location_id) now (re-call add_quest) so "
+                    "the party has concrete goals and the quest can be advanced and promoted."
+                ),
+            })
+            continue  # a spine-less quest isn't ALSO flagged resolvable/stalled
         # ALL objectives done -> the quest is mechanically resolvable; the DM should close
         # it AND give it an echo (evolves_to) so a win isn't one-and-done (rule of three).
         if objectives and all(o in completed for o in objectives):
@@ -13633,7 +13791,8 @@ def _compute_beat_obligations(c: Campaign) -> list[dict]:
     #     In the #1313 wrap window the endgame cue (quest_endgame_unresolved) already names concrete
     #     active quests to close, so this campaign-level "nothing has moved" cue is redundant there too.
     _already_flagged_quest = any(
-        o.get("kind") in ("quest_resolvable", "quest_stalled", "quest_endgame_unresolved")
+        o.get("kind") in ("quest_resolvable", "quest_stalled", "quest_endgame_unresolved",
+                          "quest_authoring_incomplete")
         for o in obligations
     )
     if _beats_in_act >= _PARTY_STUCK_BEATS and quests and not _already_flagged_quest:

--- a/servers/engine/tests/test_quest_authoring_cues.py
+++ b/servers/engine/tests/test_quest_authoring_cues.py
@@ -1,0 +1,211 @@
+"""#1405 — quest AUTHORING & consequence-CAPTURE cues (the flywheel's binding constraint).
+
+The measured failure (PR #1404 honest re-score): extraction is no longer the binding constraint
+on the 3.9→4.0 quest-promotion gap — CONTENT AUTHORING is. Objectives empty in 2/3 sampled
+quests and consequences empty in 3/3 AT THE SNAPSHOT LEVEL (no engine data to extract). The fix
+is the same cue-stack family S1 proved works (#1313/#1286/#1334): ADVISORY return-payload nudges
+that the DM may act on — never engine-judged fiction, never a block.
+
+These guard the two seams:
+  (a) add_quest emits an `authoring_cue` when a quest is created MISSING
+      objectives / giver_id / location_id (and _compute_beat_obligations surfaces the
+      load-bearing objectives gap as a per-beat quest_authoring_incomplete cue);
+  (b) complete_quest / complete_objective / record_decision emit a `consequence_cue` when a
+      resolved quest has no recorded branch outcome (empty evolves_to + no naming consequence).
+
+THE ADDITIVE INVARIANT is load-bearing: a fully-authored / fully-captured quest returns
+BYTE-IDENTICAL to today (the cue key is simply absent). Every test that asserts a happy-path
+shape checks the EXACT dict, not just cue-absence.
+"""
+
+import pytest
+
+import server
+from models import Campaign, Consequence, Quest
+
+
+@pytest.fixture
+def cid(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    return server.create_campaign("Authoring Cues")["id"]
+
+
+# ── (a) add_quest authoring cue ──────────────────────────────────────────────────────────────
+
+
+def test_add_quest_bare_emits_authoring_cue_for_all_three_fields(cid):
+    out = server.add_quest(cid, "A Word from the Docks")
+    assert "authoring_cue" in out
+    cue = out["authoring_cue"]
+    assert cue["kind"] == "quest_authoring_incomplete"
+    assert cue["severity"] == "med"
+    assert cue["missing"] == ["objectives", "giver_id", "location_id"]
+    assert "objectives" in cue["imperative"]
+
+
+def test_add_quest_partial_missing_only_names_the_empty_fields(cid):
+    # objectives supplied, giver + location omitted → only those two are flagged.
+    out = server.add_quest(cid, "A Half-Authored Job", objectives=["ask around the docks"])
+    assert out["authoring_cue"]["missing"] == ["giver_id", "location_id"]
+
+
+def test_add_quest_complete_is_byte_identical_no_cue(cid):
+    # A giver NPC + a location so add_quest can be fully authored.
+    npc = server.create_character(campaign_id=cid, name="Longshoreman", kind="npc")
+    loc = server.add_location(campaign_id=cid, name="The Docks")
+    out = server.add_quest(
+        cid, "A Fully Authored Job",
+        giver_id=npc["id"], location_id=loc["id"], objectives=["meet the contact"],
+    )
+    # BYTE-IDENTICAL: the exact three keys, no authoring_cue.
+    assert set(out.keys()) == {"id", "title", "status"}
+    assert "authoring_cue" not in out
+
+
+# ── (a) per-beat obligation: quest_authoring_incomplete ──────────────────────────────────────
+
+
+def _kinds(obligations):
+    return {o["kind"] for o in obligations}
+
+
+def _obligations_at_authoring_beats(c):
+    # The per-beat authoring cue is beats-gated (a fresh beat-0 quest is not nagged); park the arc
+    # at the escalation threshold so the cue is live.
+    c.narrative_arc.beats_in_act = server._QUEST_AUTHORING_BEATS
+    return server._compute_beat_obligations(c)
+
+
+def test_beat_obligation_fires_for_objectiveless_active_quest():
+    c = Campaign(title="Obligations")
+    q = Quest(title="A spine-less thread")  # no objectives
+    c.quests[q.id] = q
+    obligations = _obligations_at_authoring_beats(c)
+    assert "quest_authoring_incomplete" in _kinds(obligations)
+    cue = next(o for o in obligations if o["kind"] == "quest_authoring_incomplete")
+    assert cue["quest_id"] == q.id
+    assert "objectives" in cue["missing"]
+
+
+def test_beat_obligation_not_fired_beat_zero_for_fresh_quest():
+    # A freshly-introduced spine-less quest (arc at beat 0) is NOT nagged — the create-moment
+    # nudge is add_quest's result cue; the per-beat cue only escalates after a stretch of play.
+    c = Campaign(title="Obligations")
+    q = Quest(title="Just introduced")  # no objectives, arc.beats_in_act == 0
+    c.quests[q.id] = q
+    assert "quest_authoring_incomplete" not in _kinds(server._compute_beat_obligations(c))
+
+
+def test_beat_obligation_absent_for_authored_quest():
+    c = Campaign(title="Obligations")
+    q = Quest(title="An authored thread", objectives=["step one"])
+    c.quests[q.id] = q
+    assert "quest_authoring_incomplete" not in _kinds(_obligations_at_authoring_beats(c))
+
+
+def test_beat_obligation_suppresses_stalled_on_same_spineless_quest():
+    # A spine-less quest that is also stale must surface ONLY the authoring cue (it owns the quest),
+    # not ALSO quest_stalled — the anti-double-nag `continue`.
+    c = Campaign(title="Obligations", day=10)
+    q = Quest(title="Old and empty", last_progress_day=1)  # no objectives, stale
+    c.quests[q.id] = q
+    kinds = _kinds(_obligations_at_authoring_beats(c))
+    assert "quest_authoring_incomplete" in kinds
+    assert "quest_stalled" not in kinds
+
+
+# ── (b) complete_quest consequence cue ───────────────────────────────────────────────────────
+
+
+def test_complete_quest_no_consequence_emits_capture_cue(cid):
+    qid = server.add_quest(cid, "The Silenced Bell", objectives=["find the saboteur"])["id"]
+    out = server.complete_quest(cid, qid)
+    assert "consequence_cue" in out
+    cue = out["consequence_cue"]
+    assert cue["kind"] == "quest_consequence_uncaptured"
+    assert cue["quest_id"] == qid
+
+
+def test_complete_quest_with_evolves_to_has_no_cue(cid):
+    qid = server.add_quest(cid, "The Silenced Bell", objectives=["find the saboteur"])["id"]
+    out = server.complete_quest(cid, qid, evolves_to="the saboteur's patron seeks revenge")
+    assert "consequence_cue" not in out
+
+
+def test_complete_quest_failed_also_nudges_capture(cid):
+    # A FAILED resolution is a branch outcome too — it should nudge for a recorded consequence.
+    qid = server.add_quest(cid, "The Lost Caravan", objectives=["reach the caravan in time"])["id"]
+    out = server.complete_quest(cid, qid, status="failed")
+    assert out["consequence_cue"]["kind"] == "quest_consequence_uncaptured"
+
+
+def test_complete_quest_with_naming_consequence_has_no_cue(cid):
+    qid = server.add_quest(cid, "The Silenced Bell", objectives=["find the saboteur"])["id"]
+    # A consequence whose text names the quest counts as a recorded branch outcome.
+    server.add_consequence(cid, in_days=3, text="Fallout from The Silenced Bell reaches the temple.")
+    out = server.complete_quest(cid, qid)
+    assert "consequence_cue" not in out
+
+
+# ── (b) complete_objective auto-resolve consequence cue ──────────────────────────────────────
+
+
+def test_complete_objective_autoresolve_emits_capture_cue(cid):
+    qid = server.add_quest(cid, "One-Step Quest", objectives=["do the thing"])["id"]
+    out = server.complete_objective(cid, qid, "do the thing")  # last objective → auto-completes
+    assert out["status"] == "completed"
+    assert out["consequence_cue"]["kind"] == "quest_consequence_uncaptured"
+
+
+def test_complete_objective_nonterminal_has_no_cue(cid):
+    qid = server.add_quest(cid, "Two-Step Quest", objectives=["step one", "step two"])["id"]
+    out = server.complete_objective(cid, qid, "step one")  # quest still active
+    assert out["status"] == "active"
+    assert "consequence_cue" not in out
+
+
+# ── (b) record_decision consequence cue (campaign-scoped) ────────────────────────────────────
+
+
+def test_record_decision_nudges_when_a_resolved_quest_is_uncaptured(cid):
+    qid = server.add_quest(cid, "The Silenced Bell", objectives=["x"])["id"]
+    server.complete_quest(cid, qid)  # resolved, no consequence
+    out = server.record_decision(cid, summary="The party spared the saboteur")
+    assert out["consequence_cue"]["quest_id"] == qid
+
+
+def test_record_decision_byte_identical_when_all_captured(cid):
+    # No resolved-but-uncaptured quest → record_decision returns its exact today shape.
+    qid = server.add_quest(cid, "The Silenced Bell", objectives=["x"])["id"]
+    server.complete_quest(cid, qid, evolves_to="a lingering echo")
+    out = server.record_decision(cid, summary="A plain decision, nothing owed")
+    assert set(out.keys()) == {"id", "summary", "chosen", "day"}
+    assert "consequence_cue" not in out
+
+
+# ── helper unit tests (the additive invariant, at the source) ────────────────────────────────
+
+
+def test_quest_missing_fields_empty_for_full_quest():
+    q = Quest(title="Full", objectives=["a"], giver_id="npc_1", location_id="loc_1")
+    assert server._quest_missing_fields(q) == []
+
+
+def test_quest_authoring_cue_none_for_full_quest():
+    q = Quest(title="Full", objectives=["a"], giver_id="npc_1", location_id="loc_1")
+    assert server._quest_authoring_cue(q) is None
+
+
+def test_quest_consequence_cue_none_for_active_quest():
+    # An ACTIVE (not-yet-resolved) quest is never nagged for a consequence.
+    c = Campaign(title="C")
+    q = Quest(title="Ongoing", objectives=["a"], status="active")
+    assert server._quest_consequence_cue(c, q) is None
+
+
+def test_quest_consequence_recorded_true_on_naming_consequence():
+    c = Campaign(title="C")
+    q = Quest(title="The Bell", status="completed", objectives=["x"], completed_objectives=["x"])
+    c.quests[q.id] = q
+    c.consequences.append(Consequence(text=f"echo of {q.id}", trigger_day=3))
+    assert server._quest_consequence_recorded(c, q) is True

--- a/servers/engine/tests/test_quest_authoring_cues.py
+++ b/servers/engine/tests/test_quest_authoring_cues.py
@@ -209,3 +209,101 @@ def test_quest_consequence_recorded_true_on_naming_consequence():
     c.quests[q.id] = q
     c.consequences.append(Consequence(text=f"echo of {q.id}", trigger_day=3))
     assert server._quest_consequence_recorded(c, q) is True
+
+
+# ── the false-positive hole: natural-prose consequence, structured quest_id link ─────────────
+# (Coordinator invariant-verify, live-reproduced twice: substring-only capture detection treated a
+#  DM who did EXACTLY what the cue said — complete_quest → add_consequence in natural in-world prose
+#  — as un-captured, so every later unrelated record_decision re-emitted the cue for the closed quest.)
+
+
+def test_add_consequence_with_quest_id_clears_cue_natural_prose(cid):
+    # The DM resolves the quest and records the fallout as NATURAL prose (no literal title/id) but
+    # passes the structured quest_id — a later, unrelated record_decision must NOT re-nag.
+    qid = server.add_quest(cid, "The Silenced Bell", objectives=["find the saboteur"])["id"]
+    server.complete_quest(cid, qid)
+    server.add_consequence(
+        cid, in_days=5, quest_id=qid,
+        text="Word spreads through the temple ward; the priests will not soon forget the night the peal died.",
+    )
+    out = server.record_decision(cid, summary="Later, the party debates where to camp")
+    assert "consequence_cue" not in out
+
+
+def test_add_consequence_natural_prose_without_quest_id_still_nags(cid):
+    # DOCUMENTED LIMITATION / fallback intact: the SAME natural-prose consequence WITHOUT the
+    # structured link (and with no literal title) does not match, so the cue still fires. The
+    # remediation the cue names is exactly `quest_id` (the case above).
+    qid = server.add_quest(cid, "The Silenced Bell", objectives=["find the saboteur"])["id"]
+    server.complete_quest(cid, qid)
+    server.add_consequence(
+        cid, in_days=5,
+        text="Word spreads through the temple ward; the priests will not soon forget the night the peal died.",
+    )
+    out = server.record_decision(cid, summary="Later, the party debates where to camp")
+    assert out["consequence_cue"]["quest_id"] == qid
+
+
+def test_add_consequence_echoes_quest_id_only_when_set(cid):
+    qid = server.add_quest(cid, "A Quest", objectives=["x"])["id"]
+    linked = server.add_consequence(cid, text="the fallout", quest_id=qid)
+    assert linked["quest_id"] == qid
+    unlinked = server.add_consequence(cid, text="a free-standing world event")
+    # BYTE-IDENTICAL default: no quest_id key when unset.
+    assert set(unlinked.keys()) == {"id", "trigger_day", "current_day", "text"}
+
+
+def test_quest_consequence_recorded_true_on_structured_link_prose():
+    c = Campaign(title="C")
+    q = Quest(title="The Bell", status="completed", objectives=["x"], completed_objectives=["x"])
+    c.quests[q.id] = q
+    # Natural prose, NO literal title/id in text — only the structured link.
+    c.consequences.append(Consequence(text="the ward remembers the silence", trigger_day=3, quest_id=q.id))
+    assert server._quest_consequence_recorded(c, q) is True
+
+
+# ── content fix: the flagship starter is authored WITH a spine (no beat-4 nag) ───────────────
+# (Coordinator verify-2: content_mod.seed_campaign built the cellar-rats "Cellar Rats" quest with
+#  objectives=[], so at beats_in_act>=4 the nag fired on every fresh playthrough of the flagship.
+#  Product decision: the cue on a genuinely-bare quest is CORRECT — fix the CONTENT, not the cue.)
+
+
+def test_cellar_rats_starter_quest_is_authored_with_objectives(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.start_adventure("cellar-rats")["campaign_id"]
+    c = server._require(cid)
+    quest = next(iter(c.quests.values()))
+    assert len(quest.objectives) >= 2  # a real spine the engine can track
+
+
+def test_healthy_starter_no_authoring_cue_at_beat_four(tmp_path, monkeypatch):
+    # The regression the suite missed: push the healthy flagship fixture PAST the beat gate. With
+    # the content fix (authored objectives) it must STILL yield no quest_authoring_incomplete.
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.start_adventure("cellar-rats")["campaign_id"]
+    c = server._require(cid)
+    c.narrative_arc.beats_in_act = server._QUEST_AUTHORING_BEATS
+    assert "quest_authoring_incomplete" not in _kinds(server._compute_beat_obligations(c))
+
+
+def test_bare_quest_still_nags_at_beat_four_mechanism_intact(tmp_path, monkeypatch):
+    # The mechanism is NOT disabled by the content fix: a genuinely-bare quest added to the same
+    # campaign at beats_in_act==_QUEST_AUTHORING_BEATS DOES fire the cue.
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.start_adventure("cellar-rats")["campaign_id"]
+    bare_qid = server.add_quest(cid, "A Bare Side Thread")["id"]  # no objectives
+    c = server._require(cid)
+    c.narrative_arc.beats_in_act = server._QUEST_AUTHORING_BEATS
+    kinds_by_quest = {o.get("quest_id"): o for o in server._compute_beat_obligations(c)
+                      if o["kind"] == "quest_authoring_incomplete"}
+    assert bare_qid in kinds_by_quest
+
+
+def test_consequence_without_quest_id_serializes_byte_identical():
+    # The omit-when-empty serializer: an unlinked consequence must NOT emit a `quest_id` key (the
+    # store's dirty-skip byte-compare depends on it — a pre-#1405 snapshot never carried the key).
+    cs = Consequence(text="a plain world event", trigger_day=3)
+    assert "quest_id" not in cs.model_dump()
+    assert "quest_id" not in cs.model_dump_json()
+    linked = Consequence(text="linked", trigger_day=3, quest_id="quest_abc")
+    assert linked.model_dump()["quest_id"] == "quest_abc"


### PR DESCRIPTION
## Why

Extractor quality pass 2 (#1404, charter #1386 item 5b) delivered its fixes, but the honest re-score verdict is: **extraction is no longer the binding constraint on the 3.9→4.0 quest-promotion gap — content authoring is.** Measured on panel `qp2-manual-20260708`: **objectives empty in 2/3** sampled quests and **consequences empty in 3/3 AT THE SNAPSHOT LEVEL** (no engine data exists to extract). Next lever is DM-craft + engine cueing, not extraction — the same cue-stack family S1 proved works (advance_time/closures fired organically post-#1334). Closes #1405.

## What (additive, engine-side, gates-read-gauges preserved)

Cues are **advisory return-payload text** the DM MAY act on — the engine takes **no auto-action** and **never rejects/blocks** a quest (the teeth question is owner-reserved, #1313). A fully-authored / fully-captured quest returns **byte-identical** to today (the cue key is simply absent).

1. **add_quest authoring cue** — when a quest is created MISSING `objectives` / `giver_id` / `location_id`, the result carries a next_action-style `authoring_cue` (`kind`/`severity`/`missing`/`imperative`) nudging the DM to populate them. Omitted entirely once fully authored.
2. **Per-beat escalation** — `_compute_beat_obligations` gains a `quest_authoring_incomplete` cue for a quest left **spine-less** (no objectives). **Beats-gated** (`_QUEST_AUTHORING_BEATS=4`) so a fresh beat-0 quest is NOT nagged (the create-moment nudge is the add_quest result cue); only a quest narrated a stretch with no spine escalates. It owns the quest's cue (suppresses `quest_stalled` / `quest_unresolved_late` double-nag).
3. **Resolution-time consequence capture** — `complete_quest` / `complete_objective` (auto-resolve) / `record_decision` emit a `consequence_cue` when a resolved quest has **no recorded branch outcome** (empty `evolves_to` AND no consequence naming it). **Sink = the existing `evolves_to` field + `add_consequence`** — no new state (the extractor already reads `evolves_to` as `resolution.evolves_to` and consequences by note/title match). The existing `quest_no_echo` beat obligation is the per-beat surface.

## Mechanism-probe fixtures (QA-econ v2 — the ~\$1 validation tier, never duos)

Two new `qa/probe_fixtures/` builders, both **solo-PC single-cue** with deterministic free pre-checks:
- `quest_created_bare` → seeds a bare active quest, parks the arc at the escalation threshold → `next_action == quest_authoring_incomplete`.
- `quest_resolved_no_consequence` → seeds a completed quest (empty `evolves_to`, no consequence) → `next_action == quest_no_echo`.

`qa/probe_verdict.py` gains cue-aware movement signals (`quest_authoring_progressed` — a quest gained objectives/giver/location or a new spine-bearing quest appeared; `quest_echo_captured` — a consequence recorded or `evolves_to` set) so **ACTED/IGNORED/INCONCLUSIVE stays deterministic** for the new cues.

> ⚠ **Probe RUNS are the orchestrator's to fire** (DM `claude -p` auth-token gating). The **fixtures are runnable as-is** — pre-checks + determinism are covered by unit tests, no live DM needed.

## Tests / verification (all local single-process on the allowlisted repo)

- `servers/engine/tests/test_quest_authoring_cues.py` — **19** tests, red-first, asserting the additive invariant (cue present when fields missing, **absent + byte-identical exact-dict** when complete).
- `qa/test_mechanism_probe.py` — **+11** tests: the new verdict movement fns, end-to-end ACTED/IGNORED for both cues, and the two fixtures' pre-check + structural determinism.
- **Full engine suite: 3460 passed** (+ codex-wrapper 34, mechanism-probe 30). `qa/fast_gate.sh` **PASS** (257 deterministic).

## Merge

Auto-merge armed; **not merging here.** Admin-merge per #1389 once CI is green.

> **#1405 authoring note (verify-2):** content-seeded objective-less quests intentionally trip the beat-4 `quest_authoring_incomplete` cue — that IS the flywheel lever, so there is no content-seeded exemption. The flagship adventures (cellar-rats starter) are instead authored WITH an objective spine via the new optional `quest_objectives` seed key.
