### PR TITLE
qa: auto-persist scores rows for the manual-append bucket (#1414)

### DIFF
--- a/docs/RUNBOOK-INDEX.md
+++ b/docs/RUNBOOK-INDEX.md
@@ -6,7 +6,8 @@
 > type = adding a row + wiring the five steps. Changing a runner = updating its row (bump
 > Last-verified). Dispatch packets MUST name the run type's row.
 >
-> _Last full verification sweep: 2026-07-08._
+> _Last full verification sweep: 2026-07-08._ Manual-append bucket auto-wired #1414 (2026-07-08):
+> duo/sprint/sweep/app-gate/RRI now self-persist via `qa/scores_persist.py` (fail-loud).
 
 ## Play / engine QA
 
@@ -14,11 +15,11 @@
 |---|---|---|---|---|---|
 | fast_gate | `qa/fast_gate.sh` | free, ~30s, EVERY change | pass log (iteration-only, never release evidence) | — (by design) | worldos-dev |
 | mechanism probe | `qa/mechanism_probe.sh` | ~$1, cue-adjacent PRs | fixture transcript + deterministic ACTED/IGNORED | engine-duo (auto-append) | OPERATIONS QA-econ v2 |
-| combat sprint | `qa/run_combat_sprint.sh` | ~$1.50, combat-adjacent | transcript + mech score + behavioral | engine-duo (⚠ manual add) | worldos-dev |
-| story/mech duo | `qa/run_duo.sh` | ~$6, BATCH/release only, solo-tenant | transcript + 3 lenses + behavioral + infra-health note | engine-duo (⚠ manual add) | worldos-dev + watcher contract |
-| 5-persona sweep | `qa/vm/sweep_v2.sh` (canonical: evaos-support VM) | ~$12, milestone | RRI json + persona score.json ×5 | GUI-headless-proxy (⚠ manual) | WorldOS-GUI-RUNBOOK |
-| app gate (native) | `qa/ui_playtest_app.sh` | ~$7, release | run.json + score.json + handoff.json | GUI-built-app (⚠ manual) | worldos-dev VM-GATE §; ⚠ `ui_playtest.sh` variant tests a non-shippable port |
-| release rollup | `qa/release_gate.sh` → `release_readiness.py` | wraps the above | RRI verdict json + closeout block | rows from parts (⚠ RRI itself manual) | OPERATIONS |
+| combat sprint | `qa/run_combat_sprint.sh` | ~$1.50, combat-adjacent | transcript + mech score + behavioral | engine-duo (auto-append #1414) | worldos-dev |
+| story/mech duo | `qa/run_duo.sh` | ~$6, BATCH/release only, solo-tenant | transcript + 3 lenses + behavioral + infra-health note | engine-duo (auto-append #1414; CONTAMINATED marker on QUOTA/INFRA abort) | worldos-dev + watcher contract |
+| 5-persona sweep | `qa/vm/sweep_v2.sh` (canonical: evaos-support VM) | ~$12, milestone | RRI json + persona score.json ×5 | GUI-headless-proxy (auto-append #1414, per persona) | WorldOS-GUI-RUNBOOK |
+| app gate (native) | `qa/ui_playtest_app.sh` | ~$7, release | run.json + score.json + handoff.json | GUI-built-app (auto-append #1414, from score.json) | worldos-dev VM-GATE §; ⚠ `ui_playtest.sh` variant tests a non-shippable port |
+| release rollup | `qa/release_gate.sh` → `release_readiness.py` | wraps the above | RRI verdict json + closeout block | rows from parts (RRI row itself auto-appends #1414 whenever --out is written) | OPERATIONS |
 
 ## Visual / render
 
@@ -46,7 +47,7 @@
 | character/asset gen | asset-gen skill (Meshy/Tripo/Scenario/PixelLab) | ~5-25 CU/asset | registry entry (gen_recipe) + grounded upright render per actor + evidence commit | ⚠ NONE today — gate via pre-gate + panel on first composed use | asset-gen skill |
 
 ## Known wiring gaps (tracked)
-1. **Manual-append bucket** (duo, sprint, sweep, app gate, RRI): the expensive runs don't auto-write
-   their rows — highest-leverage teeth to add (auto add_run at runner completion).
+1. ~~**Manual-append bucket** (duo, sprint, sweep, app gate, RRI)~~ — CLOSED #1414: each runner now
+   self-persists via `qa/scores_persist.py` (fail-loud; CONTAMINATED marker on a QUOTA/INFRA abort).
 2. **Ledger unification**: artifacts + library_metrics tables don't render into scores_ledger.md.
 3. Half-wired: motion_reel capture stub; felt_rest_panel non-rest write path; stale `--layered` naming.

--- a/qa/release_readiness.py
+++ b/qa/release_readiness.py
@@ -767,6 +767,9 @@ def main() -> int:
     ap.add_argument("--abort-marker", default="", help="path to a sweep QUOTA_ABORT marker; if it "
                     "exists the rollup is forced to an ABORTED status (infra abort, not a product RRI)")
     ap.add_argument("--out", default="qa/RRI.json")
+    ap.add_argument("--scores-db", dest="scores_db", default="",
+                    help="(#1414) override qa/scores.db path — TESTING ONLY; production runs "
+                    "always persist to the committed ledger (scores_db.DB_PATH) when omitted")
     ap.add_argument("--scorecard-row", action="store_true")
     ap.add_argument("--deterministic-only", dest="deterministic_only", action="store_true",
                     help="evaluate ONLY the gates that need no live LLM/persona evidence "
@@ -1466,6 +1469,32 @@ def main() -> int:
 
     out = Path(args.out)
     out.write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+    # #1414: auto-persist the RRI verdict row (surface=GUI-built-app) whenever --out is written —
+    # FAIL LOUD (never swallow; a failed write is a failed run per the Universal Run Contract,
+    # docs/OPERATIONS.md "No row = no run"). run_id is keyed on the build SHA so re-running the
+    # rollup at the SAME candidate SHA replaces this row instead of duplicating (scores_db.add_run's
+    # INSERT OR REPLACE-on-run_id), while a new SHA gets its own trend row.
+    try:
+        from scores_persist import persist_rri_row  # noqa: E402 (qa/ is on sys.path as the script dir)
+    except ImportError:  # imported from a different cwd than `python3 qa/release_readiness.py`
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from scores_persist import persist_rri_row
+    sha_for_id = (args.build_sha or result.get("build_sha") or "unknown").strip() or "unknown"
+    rri_run_id = f"rri-{sha_for_id[:12]}"
+    persist_kwargs = {"rri_json": str(out), "build_sha": args.build_sha or None}
+    if args.scores_db:
+        persist_kwargs["db_path"] = args.scores_db
+    try:
+        persist_rri_row(rri_run_id, **persist_kwargs)
+    except Exception as exc:  # FAIL LOUD — never swallow (Universal Run Contract: no row = no run)
+        print(
+            f"FATAL: scores_db row write failed for run_id={rri_run_id!r}: {exc} — a failed row "
+            "write is a failed run per the Universal Run Contract (docs/OPERATIONS.md). See the "
+            "error above.",
+            file=sys.stderr,
+        )
+        return 2
 
     # human line
     if aborted:

--- a/qa/run_combat_sprint.sh
+++ b/qa/run_combat_sprint.sh
@@ -16,6 +16,7 @@ cd "$ROOT" || exit 1
 . "$ROOT/qa/lib_beat_driver.sh"
 
 RUN="${1:-cs-$(date +%H%M%S)}"
+CURRENT_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 WORLDOS_DM_MODEL="$(worldos_env DM_MODEL opus)"
 # GLM-only settings profile (no-op for Claude). Sourced after model vars resolve, before any
 # timeout/budget/retry knob is consumed. See qa/glm_profile.sh.
@@ -143,4 +144,20 @@ jq -r '
 ' "$T/$RUN.angrydm.json" 2>/dev/null || { echo "(angry-dm parse failed; raw:)"; cat "$T/$RUN.angrydm.json"; }
 
 echo "[cs] behavioral=$([ "${GATE:-0}" = 0 ] && echo GREEN || echo RED)"
+
+# #1414: auto-persist the scores_ledger row at completion (surface=engine-duo, methodology=
+# combat-sprint) — FAIL LOUD (never `|| echo WARN`; a failed write is a failed run per the
+# Universal Run Contract, docs/OPERATIONS.md "No row = no run"). GATE_REASON is only set above
+# when the gate is RED.
+CS_GATE_ARG=()
+[ "${GATE:-0}" != "0" ] && CS_GATE_ARG=(--gate-reason "$GATE_REASON")
+if ! python3 "$ROOT/qa/scores_persist.py" combat-sprint \
+    --run-id "$RUN" --build-sha "$CURRENT_SHA" --dm-model "$WORLDOS_DM_MODEL" \
+    --behavioral "$([ "${GATE:-0}" = 0 ] && echo GREEN || echo RED)" \
+    --angry-json "$T/$RUN.angrydm.json" --source-path "$T/$RUN.md" \
+    ${CS_GATE_ARG[@]+"${CS_GATE_ARG[@]}"}; then
+  echo "[cs] FATAL: scores_db row write failed — a failed write is a failed run per the Universal Run Contract (docs/OPERATIONS.md). See the error above." >&2
+  exit 1
+fi
+
 exit "${GATE:-0}"

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -292,6 +292,24 @@ print(last)
 PY
 }
 
+# #1414: the CONTAMINATED-marker writer for every abort path below (QUOTA/INFRA aborts never
+# reach the normal scoring tail, so without this a contaminated run silently landed NO row at
+# all — the manual-append gap docs/RUNBOOK-INDEX.md calls out). FAIL LOUD like every other write
+# here: a failed marker write is itself a failed run (Universal Run Contract, docs/OPERATIONS.md
+# "No row = no run") — never `|| echo WARN`. Writes surface=engine-duo, behavioral=CONTAMINATED,
+# NO lens numbers (the watcher contract: infra-fail => no citable row).
+duo_persist_contaminated() {  # $1 = reason string
+  local reason="$1"; local cb_arg=()
+  [ "${LAST_COMPLETED_BEAT:--1}" -ge 0 ] && cb_arg=(--completed-beats "$LAST_COMPLETED_BEAT")
+  if ! python3 "$ROOT/qa/scores_persist.py" duo \
+      --run-id "$RUN" --build-sha "$CURRENT_SHA" --dm-model "$WORLDOS_DM_MODEL" \
+      --beats "$BEATS" ${cb_arg[@]+"${cb_arg[@]}"} \
+      --source-path "$T/$RUN" --contaminated-reason "$reason"; then
+    echo "[duo] FATAL: scores_db CONTAMINATED-marker write failed — a failed row write is a failed run per the Universal Run Contract (docs/OPERATIONS.md). See the error above." >&2
+    exit 1
+  fi
+}
+
 duo_acquire_lock
 
 if [ -s "$CHECKPOINT" ]; then
@@ -649,6 +667,7 @@ echo "[duo] DM opened: ${DMSG:0:120}…"
 if duo_quota_protocol_seen "$COMBINED" "$T/$RUN.dm.err" || duo_quota_error_seen "$T/$RUN.dm.err" "$STATE_DIR/.dm_last_result"; then
   echo "[duo] QUOTA ABORT — DM cold-open hit the account session limit (HTTP 429). Skipping scoring; this is an INFRA abort, NOT a product measurement." >&2
   echo "[duo] throttled at beat 0 — re-invoke the same command in a fresh window to resume" >&2
+  duo_persist_contaminated "QUOTA ABORT at cold-open (HTTP 429 session limit)"
   exit "$EX_TEMPFAIL"
 fi
 # SYN-01: an empty resolved reply is a FAILED beat (error-class result, recycled-only prose, or
@@ -657,6 +676,7 @@ fi
 if [ -z "$DMSG" ]; then
   worldos_chatlog_dm_failed
   echo "[duo] DM produced no opening — aborting (see $COMBINED)" >&2
+  duo_persist_contaminated "DM produced no opening at cold-open (empty resolved reply)"
   exit 1
 fi
 worldos_chatlog_dm "$DMSG"
@@ -755,6 +775,7 @@ $EVENT_ADV")"
     if duo_quota_protocol_seen "$STATE_DIR/.dm_last_result" "$COMBINED" "$T/$RUN.dm.err" || duo_quota_error_seen "$STATE_DIR/.dm_last_result" "$T/$RUN.dm.err"; then
       echo "[duo] QUOTA ABORT — DM beat $b hit the account session limit / rate limit. Skipping scoring; this is an INFRA abort, NOT a product measurement." >&2
       echo "[duo] throttled at beat $b — re-invoke the same command in a fresh window to resume" >&2
+      duo_persist_contaminated "QUOTA ABORT at beat $b (HTTP 429 / rate limit)"
       exit "$EX_TEMPFAIL"
     fi
     # #1285: worldos_chatlog_dm_failed stamps $STATE_DIR/.run_infra_invalid.json once the
@@ -766,6 +787,7 @@ $EVENT_ADV")"
     if [ -s "$STATE_DIR/.run_infra_invalid.json" ]; then
       cp "$STATE_DIR/.run_infra_invalid.json" "$T/$RUN.infra_invalid.json" 2>/dev/null || true
       echo "[duo] INFRA ABORT — $WORLDOS_DM_BEATS_FAILED_STREAK consecutive DM beat failures at beat $b (see $T/$RUN.infra_invalid.json). Skipping scoring; this is an INFRA collapse, NOT a product measurement." >&2
+      duo_persist_contaminated "INFRA ABORT — $WORLDOS_DM_BEATS_FAILED_STREAK consecutive DM beat failures at beat $b"
       exit 2
     fi
     echo "[duo] DM went silent at beat $b; stopping early"
@@ -792,6 +814,7 @@ turn dm "$DSID" 0 "We are out of time. Bring this beat to a clean stopping point
 if duo_quota_protocol_seen "$STATE_DIR/.dm_last_result" "$COMBINED" "$T/$RUN.dm.err" || duo_quota_error_seen "$STATE_DIR/.dm_last_result" "$T/$RUN.dm.err"; then
   echo "[duo] QUOTA ABORT — throttled after beat $LAST_COMPLETED_BEAT during session wrap-up. Skipping scoring; this is an INFRA abort, NOT a product measurement." >&2
   echo "[duo] throttled at beat $LAST_COMPLETED_BEAT — re-invoke the same command in a fresh window to resume" >&2
+  duo_persist_contaminated "QUOTA ABORT during session wrap-up (after beat $LAST_COMPLETED_BEAT)"
   exit "$EX_TEMPFAIL"
 fi
 echo "[duo] distilling + scoring…"
@@ -880,6 +903,27 @@ if python3 qa/latency_rollup.py --dir "$T" --run "$RUN" --tooltiming "$TOOLTIMIN
   LAT_SUMMARY="$(jq -r '"s/beat="+(.s_per_beat|tostring)+" cold-open="+(.coldopen_s|tostring)+"s turns/beat="+(.turns_per_beat|tostring)+(if .combat_s_per_beat then " combat="+(.combat_s_per_beat|tostring)+"s" else "" end)+(if .social_s_per_beat then " social="+(.social_s_per_beat|tostring)+"s" else "" end)+(if .tool_exec_pct then " tool="+((.tool_exec_pct*100)|floor|tostring)+"%" else "" end)+(if .slowest_tool then " slowest="+.slowest_tool else "" end)' "$LATENCY_JSON" 2>/dev/null)"
 else
   LAT_SUMMARY="latency=unavailable"
+fi
+# #1414: auto-persist the scores_ledger row at clean completion — FAIL LOUD (never `|| echo WARN`;
+# a failed write is a failed run per the Universal Run Contract, docs/OPERATIONS.md "No row = no
+# run"). Covers BOTH a GREEN and a behavioral-RED finish (RED is a real product measurement, not
+# an abort — only the QUOTA/INFRA abort paths above skip this in favor of the CONTAMINATED marker).
+DUO_GATE_ARG=()
+if [ "${GATE:-0}" != "0" ]; then
+  DUO_GATE_ARG=(--gate-reason "$GATE_REASON")
+fi
+DUO_UNSCORABLE_ARG=()
+[ "$UNSCORABLE" = "1" ] && DUO_UNSCORABLE_ARG=(--unscorable-detail "$UNSCORABLE_DETAIL")
+if ! python3 "$ROOT/qa/scores_persist.py" duo \
+    --run-id "$RUN" --build-sha "$CURRENT_SHA" --dm-model "$WORLDOS_DM_MODEL" \
+    --actor-model "$WORLDOS_ACTOR_MODEL" --beats "$BEATS" --completed-beats "$LAST_COMPLETED_BEAT" \
+    --behavioral "$([ "$GATE" = 0 ] && echo GREEN || echo RED)" \
+    --story-json "$T/$RUN.tolkien.json" --mech-json "$T/$RUN.score.json" --angry-json "$T/$RUN.angrydm.json" \
+    --latency-json "$LATENCY_JSON" --persona "$PLAYER_PROMPT_FILE" --source-path "$T/$RUN.md" \
+    ${DUO_GATE_ARG[@]+"${DUO_GATE_ARG[@]}"} ${DUO_UNSCORABLE_ARG[@]+"${DUO_UNSCORABLE_ARG[@]}"} \
+    --infra-note "checkpoint=$([ "$RESUME_MODE" = 1 ] && echo resumed || echo fresh); last_completed_beat=$LAST_COMPLETED_BEAT"; then
+  echo "[duo] FATAL: scores_db row write failed — a failed write is a failed run per the Universal Run Contract (docs/OPERATIONS.md). See the error above." >&2
+  exit 1
 fi
 # WS0a: print each lens via the shared validator so a scorer FAILURE shows as FAILED (not a blank
 # that misreads as a valid no-score). `worldos_lens_display` echoes the numeric .overall for a valid

--- a/qa/scores_persist.py
+++ b/qa/scores_persist.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""qa/scores_persist.py — the FAIL-LOUD glue between each QA runner and scores_db.add_run (#1414).
+
+WHY THIS EXISTS
+---------------
+Every EXPENSIVE run type used to rely on a MANUAL ``scores_db.py --add`` after completion (the
+"manual-append bucket": ``qa/run_duo.sh``, ``qa/run_combat_sprint.sh``, ``qa/vm/sweep_v2.sh``,
+``qa/ui_playtest_app.sh``, ``qa/release_readiness.py`` — see docs/RUNBOOK-INDEX.md "known wiring
+gaps" #1). A run could finish cleanly and never land a scores_ledger row (the Universal Run
+Contract's SCORE step had no teeth for exactly the runs that cost the most). This module is the
+auto-append each runner now calls at its own completion — ONE small, TESTED surface instead of
+five divergent inline heredocs (mirrors ``qa/mechanism_probe.sh``'s pioneering auto-append, but
+FAIL LOUD instead of ``|| echo WARN``).
+
+CONTRACT
+--------
+* **FAIL LOUD.** Every ``persist_*`` function either returns cleanly (the row landed) or raises.
+  Callers — bash runners via the CLI below, or ``release_readiness.py`` directly — MUST treat a
+  raise / non-zero exit as a FAILED RUN (Universal Run Contract: "No row = no run") — never
+  swallow it with ``|| echo WARN``.
+* **IDEMPOTENT-ISH.** Every ``persist_*`` function takes the run's own stable name as ``run_id``.
+  ``scores_db.add_run`` is INSERT OR REPLACE keyed on ``run_id`` (see scores_db.py's module
+  docstring + ``add_run``), so re-persisting the SAME run (a retry, a resumed checkpoint, a
+  re-run at the same SHA) overwrites rather than duplicating; a genuinely different run needs a
+  distinct run_id — exactly the discipline every existing ``add_run`` call site already follows.
+* **CONTAMINATED runs get a MARKER row, never a clean-looking one** (the watcher contract,
+  docs/OPERATIONS.md "Infra-fail => NO citable row" / docs/ACTIVE-GOAL.md "write a `*CONTAMINATED`
+  marker"): no lens numbers, ``behavioral="CONTAMINATED"``, and the reason lives in ``notes``.
+
+Field conventions (surface / methodology / column mapping) follow the historical rows
+``qa/scores_seed_forensics.py`` already seeded — that file is the ledger's own precedent for how
+each run type's fields map onto the ``runs`` table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+QA_DIR = Path(__file__).resolve().parent
+if str(QA_DIR) not in sys.path:
+    sys.path.insert(0, str(QA_DIR))
+import scores_db  # noqa: E402
+
+LATENCY_FIELDS = (
+    "s_per_beat", "coldopen_s", "turns_per_beat", "combat_s_per_beat",
+    "social_s_per_beat", "mean_tool_call_ms", "slowest_tool", "tool_exec_pct",
+    "duration_wall_s",
+)
+
+
+def _read_json(path: Optional[str]) -> dict:
+    """Best-effort JSON read: a missing/unparsable evidence file degrades to {} (the caller's
+    field ends up NULL) rather than crashing the persist call — the ROW WRITE is what must fail
+    loud, not a best-effort evidence read that a scorer failure may legitimately have skipped."""
+    if not path:
+        return {}
+    p = Path(path)
+    if not p.is_file():
+        return {}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _overall(path: Optional[str]) -> Optional[float]:
+    v = _read_json(path).get("overall")
+    return float(v) if isinstance(v, (int, float)) else None
+
+
+# ---------------------------------------------------------------------------
+# qa/run_duo.sh — surface=engine-duo
+# ---------------------------------------------------------------------------
+def persist_duo_row(
+    run_id: str,
+    *,
+    db_path: Path | str = scores_db.DB_PATH,
+    build_sha: Optional[str] = None,
+    dm_model: Optional[str] = None,
+    actor_model: Optional[str] = None,
+    scorer_model: str = "sonnet",
+    beats: Optional[int] = None,
+    completed_beats: Optional[int] = None,
+    behavioral: Optional[str] = None,
+    story_json: Optional[str] = None,
+    mech_json: Optional[str] = None,
+    angry_json: Optional[str] = None,
+    latency_json: Optional[str] = None,
+    gate_reason: Optional[str] = None,
+    unscorable_detail: Optional[str] = None,
+    infra_note: Optional[str] = None,
+    source_path: Optional[str] = None,
+    persona: Optional[str] = None,
+    contaminated_reason: Optional[str] = None,
+) -> None:
+    """qa/run_duo.sh's completion row. Pass ``contaminated_reason`` on a QUOTA/INFRA abort to
+    write the CONTAMINATED marker row instead of a scored one (never both)."""
+    fields: dict[str, Any] = {
+        "surface": "engine-duo",
+        "dm_model": dm_model,
+        "build_sha": build_sha,
+        "persona": persona,
+        "source_path": source_path,
+    }
+    if contaminated_reason:
+        fields["methodology"] = f"3-lens duo ({beats if beats is not None else '?'}-beat, CONTAMINATED)"
+        fields["behavioral"] = "CONTAMINATED"
+        fields["notes"] = (
+            f"CONTAMINATED — {contaminated_reason} completed_beats="
+            f"{completed_beats if completed_beats is not None else 'unknown'}. "
+            "No citable lens scores (watcher contract: infra-fail => no citable row)."
+        )
+        scores_db.add_run(run_id, db_path=db_path, **fields)
+        return
+
+    n_beats = completed_beats if completed_beats is not None else beats
+    fields["actor_model"] = actor_model
+    fields["scorer_model"] = scorer_model
+    fields["methodology"] = f"3-lens duo {n_beats if n_beats is not None else '?'}-beat"
+    fields["behavioral"] = behavioral
+    fields["story_overall"] = _overall(story_json)
+    fields["mech_overall"] = _overall(mech_json)
+    fields["angrydm_overall"] = _overall(angry_json)
+    lat = _read_json(latency_json)
+    for k in LATENCY_FIELDS:
+        if lat.get(k) is not None:
+            fields[k] = lat[k]
+    notes = [f"behavioral={behavioral or 'unknown'}"]
+    if gate_reason:
+        notes.append(f"gate_reason={gate_reason}")
+    if unscorable_detail:
+        notes.append(f"UNSCORABLE: {unscorable_detail}")
+    notes.append(f"infra: {infra_note or 'no throttle/checkpoint issue detected'}")
+    fields["notes"] = "; ".join(notes)
+    scores_db.add_run(run_id, db_path=db_path, **fields)
+
+
+# ---------------------------------------------------------------------------
+# qa/run_combat_sprint.sh — surface=engine-duo, methodology=combat-sprint
+# ---------------------------------------------------------------------------
+def persist_combat_sprint_row(
+    run_id: str,
+    *,
+    db_path: Path | str = scores_db.DB_PATH,
+    build_sha: Optional[str] = None,
+    dm_model: Optional[str] = None,
+    behavioral: Optional[str] = None,
+    angry_json: Optional[str] = None,
+    gate_reason: Optional[str] = None,
+    source_path: Optional[str] = None,
+) -> None:
+    """qa/run_combat_sprint.sh's completion row. The single Angry-DM (5e rules-fidelity) score
+    IS the run's mech reading here (docs/OPERATIONS.md: "mech = combat-sprint median") — stamped
+    into ``angrydm_overall``, matching the historical qa/scores_seed_forensics.py COMBAT_SPRINT
+    convention (methodology="combat-sprint...", angrydm_overall=..., no separate mech_overall)."""
+    notes = [f"behavioral={behavioral or 'unknown'}"]
+    if gate_reason:
+        notes.append(f"gate_reason={gate_reason}")
+    scores_db.add_run(
+        run_id, db_path=db_path, surface="engine-duo", methodology="combat-sprint",
+        dm_model=dm_model, actor_model=dm_model, scorer_model="sonnet",
+        angrydm_overall=_overall(angry_json), behavioral=behavioral,
+        build_sha=build_sha, source_path=source_path, notes="; ".join(notes),
+    )
+
+
+# ---------------------------------------------------------------------------
+# qa/vm/sweep_v2.sh — surface=GUI-headless-proxy (one row per persona)
+# ---------------------------------------------------------------------------
+def persist_sweep_persona_row(
+    run_id: str,
+    *,
+    db_path: Path | str = scores_db.DB_PATH,
+    persona: str,
+    build_sha: Optional[str] = None,
+    dm_model: Optional[str] = None,
+    actor_model: Optional[str] = None,
+    score_json: Optional[str] = None,
+    source_path: Optional[str] = None,
+    notes_extra: Optional[str] = None,
+) -> None:
+    """qa/vm/sweep_v2.sh's per-persona completion row."""
+    score = _read_json(score_json)
+    sat = score.get("persona_satisfaction")
+    sat_source = score.get("satisfaction_source")
+    crit = score.get("bug_reports_critical")
+    gave_up = score.get("gave_up")
+    per_persona = {
+        "persona": persona, "sat": sat, "gaveup": gave_up, "crit": crit,
+        "satisfaction_source": sat_source,
+    }
+    notes = [f"satisfaction_source={sat_source or 'unknown'}"]
+    if notes_extra:
+        notes.append(notes_extra)
+    scores_db.add_run(
+        run_id, db_path=db_path, surface="GUI-headless-proxy",
+        methodology="AI-playtester palette persona (ui_playtest_app.sh part-B, VM sweep)",
+        dm_model=dm_model, actor_model=actor_model,
+        scorer_model=sat_source or "derived/self-reported",
+        persona=persona, cross_persona_sat=sat, critical_bugs=crit,
+        per_persona_json=per_persona, build_sha=build_sha,
+        source_path=source_path or score_json, notes="; ".join(notes),
+    )
+
+
+# ---------------------------------------------------------------------------
+# qa/ui_playtest_app.sh — surface=GUI-built-app, from score.json
+# ---------------------------------------------------------------------------
+def persist_app_gate_row(
+    run_id: str,
+    *,
+    db_path: Path | str = scores_db.DB_PATH,
+    build_sha: Optional[str] = None,
+    dm_model: Optional[str] = None,
+    actor_model: Optional[str] = None,
+    part: Optional[str] = None,
+    provider: Optional[str] = None,
+    score_pass: Optional[bool] = None,
+    score_json: Optional[str] = None,
+    notes_extra: Optional[str] = None,
+    source_path: Optional[str] = None,
+) -> None:
+    """qa/ui_playtest_app.sh's completion row, from score.json. ``satisfaction_source`` is
+    preserved as this row's ``scorer_model`` (the model/method that produced the satisfaction
+    number is the row's provenance — matches the sweep-persona convention above)."""
+    score = _read_json(score_json)
+    sat = score.get("persona_satisfaction")
+    sat_source = score.get("satisfaction_source")
+    crit = score.get("bug_reports_critical")
+    notes = [f"satisfaction_source={sat_source or 'unknown'}", f"provider={provider or 'unknown'}"]
+    if notes_extra:
+        notes.append(notes_extra)
+    fields: dict[str, Any] = dict(
+        surface="GUI-built-app",
+        methodology=f"deterministic-ui-playtest (built dist/WorldOS.app, part {part or 'AB'})",
+        dm_model=dm_model, actor_model=actor_model,
+        scorer_model=sat_source or "derived/self-reported",
+        cross_persona_sat=sat, critical_bugs=crit,
+        build_sha=build_sha, source_path=source_path or score_json, notes="; ".join(notes),
+    )
+    if score_pass is not None:
+        fields["pass"] = int(bool(score_pass))
+    scores_db.add_run(run_id, db_path=db_path, **fields)
+
+
+# ---------------------------------------------------------------------------
+# qa/release_readiness.py — surface=GUI-built-app (the RRI verdict row)
+# ---------------------------------------------------------------------------
+def persist_rri_row(
+    run_id: str,
+    *,
+    db_path: Path | str = scores_db.DB_PATH,
+    rri_json: str,
+    build_sha: Optional[str] = None,
+) -> None:
+    """qa/release_readiness.py's completion row — persisted whenever ``--out`` is written
+    (matches the historical qa/scores_seed_forensics.py RRI_SWEEPS convention: surface=
+    "GUI-built-app", methodology="...RRI gate...", rri=..., story/mech/behavioral/cross_persona_sat
+    from the rollup). An ABORTED (quota) rollup gets the CONTAMINATED marker, never a citable RRI."""
+    rri = _read_json(rri_json)
+    sha = build_sha or rri.get("build_sha")
+    if rri.get("aborted"):
+        scores_db.add_run(
+            run_id, db_path=db_path, surface="GUI-built-app",
+            methodology="release-readiness gate rollup (release_readiness.py)",
+            behavioral="CONTAMINATED", build_sha=sha, source_path=str(rri_json),
+            notes=(f"CONTAMINATED — quota abort: {rri.get('abort_detail') or 'session limit hit'}. "
+                   "No citable RRI (watcher contract: infra-fail => no citable row)."),
+        )
+        return
+    signals = rri.get("signals") or {}
+    failed = rri.get("failed_gates") or []
+    notes = (f"status={rri.get('status')}; gates {rri.get('gates_passed')}/{rri.get('gates_total')}; "
+             f"failed={','.join(failed) or 'none'}; release_ready={rri.get('release_ready')}")
+    scores_db.add_run(
+        run_id, db_path=db_path, surface="GUI-built-app",
+        methodology="release-readiness gate rollup (release_readiness.py)",
+        scorer_model="claude/derived",
+        rri=rri.get("rri"), story_overall=signals.get("story_overall"),
+        mech_overall=signals.get("mech_overall"), behavioral=signals.get("behavioral") or None,
+        cross_persona_sat=signals.get("cross_persona_satisfaction"),
+        critical_bugs=signals.get("total_critical_bugs"),
+        image_render_rate=signals.get("image_render_rate"),
+        build_sha=sha, source_path=str(rri_json), notes=notes,
+        **{"pass": int(bool(rri.get("release_ready")))},
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI — the fail-loud entrypoint every bash runner calls
+# ---------------------------------------------------------------------------
+def _fail(cmd: str, run_id: str, exc: Exception) -> None:
+    print(
+        f"[scores_persist] FATAL: {cmd} row write failed for run_id={run_id!r}: {exc} — "
+        "a failed row write is a failed run (Universal Run Contract: 'No row = no run', "
+        "docs/OPERATIONS.md).",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    def _common(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--run-id", required=True)
+        p.add_argument("--db", default="", help="override scores.db path (testing only)")
+
+    p = sub.add_parser("duo", help="qa/run_duo.sh completion row")
+    _common(p)
+    p.add_argument("--build-sha")
+    p.add_argument("--dm-model")
+    p.add_argument("--actor-model")
+    p.add_argument("--scorer-model", default="sonnet")
+    p.add_argument("--beats", type=int)
+    p.add_argument("--completed-beats", type=int)
+    p.add_argument("--behavioral")
+    p.add_argument("--story-json")
+    p.add_argument("--mech-json")
+    p.add_argument("--angry-json")
+    p.add_argument("--latency-json")
+    p.add_argument("--gate-reason")
+    p.add_argument("--unscorable-detail")
+    p.add_argument("--infra-note")
+    p.add_argument("--source-path")
+    p.add_argument("--persona")
+    p.add_argument("--contaminated-reason")
+
+    p = sub.add_parser("combat-sprint", help="qa/run_combat_sprint.sh completion row")
+    _common(p)
+    p.add_argument("--build-sha")
+    p.add_argument("--dm-model")
+    p.add_argument("--behavioral")
+    p.add_argument("--angry-json")
+    p.add_argument("--gate-reason")
+    p.add_argument("--source-path")
+
+    p = sub.add_parser("sweep-persona", help="qa/vm/sweep_v2.sh per-persona completion row")
+    _common(p)
+    p.add_argument("--persona", required=True)
+    p.add_argument("--build-sha")
+    p.add_argument("--dm-model")
+    p.add_argument("--actor-model")
+    p.add_argument("--score-json")
+    p.add_argument("--source-path")
+    p.add_argument("--notes-extra")
+
+    p = sub.add_parser("app-gate", help="qa/ui_playtest_app.sh completion row")
+    _common(p)
+    p.add_argument("--build-sha")
+    p.add_argument("--dm-model")
+    p.add_argument("--actor-model")
+    p.add_argument("--part")
+    p.add_argument("--provider")
+    p.add_argument("--score-pass", choices=["true", "false"])
+    p.add_argument("--score-json")
+    p.add_argument("--notes-extra")
+    p.add_argument("--source-path")
+
+    p = sub.add_parser("rri", help="qa/release_readiness.py completion row")
+    _common(p)
+    p.add_argument("--rri-json", required=True)
+    p.add_argument("--build-sha")
+
+    return ap
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    db_path: Path | str = Path(args.db) if args.db else scores_db.DB_PATH
+    try:
+        if args.cmd == "duo":
+            persist_duo_row(
+                args.run_id, db_path=db_path, build_sha=args.build_sha, dm_model=args.dm_model,
+                actor_model=args.actor_model, scorer_model=args.scorer_model, beats=args.beats,
+                completed_beats=args.completed_beats, behavioral=args.behavioral,
+                story_json=args.story_json, mech_json=args.mech_json, angry_json=args.angry_json,
+                latency_json=args.latency_json, gate_reason=args.gate_reason,
+                unscorable_detail=args.unscorable_detail, infra_note=args.infra_note,
+                source_path=args.source_path, persona=args.persona,
+                contaminated_reason=args.contaminated_reason,
+            )
+        elif args.cmd == "combat-sprint":
+            persist_combat_sprint_row(
+                args.run_id, db_path=db_path, build_sha=args.build_sha, dm_model=args.dm_model,
+                behavioral=args.behavioral, angry_json=args.angry_json,
+                gate_reason=args.gate_reason, source_path=args.source_path,
+            )
+        elif args.cmd == "sweep-persona":
+            persist_sweep_persona_row(
+                args.run_id, db_path=db_path, persona=args.persona, build_sha=args.build_sha,
+                dm_model=args.dm_model, actor_model=args.actor_model, score_json=args.score_json,
+                source_path=args.source_path, notes_extra=args.notes_extra,
+            )
+        elif args.cmd == "app-gate":
+            persist_app_gate_row(
+                args.run_id, db_path=db_path, build_sha=args.build_sha, dm_model=args.dm_model,
+                actor_model=args.actor_model, part=args.part, provider=args.provider,
+                score_pass=(args.score_pass == "true") if args.score_pass else None,
+                score_json=args.score_json, notes_extra=args.notes_extra,
+                source_path=args.source_path,
+            )
+        elif args.cmd == "rri":
+            persist_rri_row(
+                args.run_id, db_path=db_path, rri_json=args.rri_json, build_sha=args.build_sha,
+            )
+        else:  # pragma: no cover — argparse's `required=True` on the subparsers makes this dead
+            raise ValueError(f"unknown subcommand {args.cmd!r}")
+    except Exception as exc:  # FAIL LOUD — never swallow (Universal Run Contract: no row = no run)
+        _fail(args.cmd, args.run_id, exc)
+        return 1  # unreachable (_fail calls sys.exit); keeps type checkers happy
+    print(f"[scores_persist] {args.cmd} row written (run_id={args.run_id}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/test_release_readiness.py
+++ b/qa/test_release_readiness.py
@@ -13,7 +13,10 @@ SCRIPT = ROOT / "qa" / "release_readiness.py"
 class ReleaseReadinessContractTests(unittest.TestCase):
     def run_rri(self, tmp: Path, *args: str) -> tuple[int, str, dict]:
         out = tmp / "RRI.json"
-        cmd = [sys.executable, str(SCRIPT), *args, "--out", str(out)]
+        # #1414: --scores-db points the auto-persist row at a TEMP db — NEVER the committed
+        # qa/scores.db (the same additive/read-only test discipline every scores_db test follows).
+        cmd = [sys.executable, str(SCRIPT), *args, "--out", str(out),
+               "--scores-db", str(tmp / "scores.db")]
         proc = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True, check=False)
         payload = json.loads(out.read_text(encoding="utf-8")) if out.exists() else {}
         return proc.returncode, proc.stdout + proc.stderr, payload

--- a/qa/test_scores_persist.py
+++ b/qa/test_scores_persist.py
@@ -1,0 +1,207 @@
+"""Tests for qa/scores_persist.py (#1414 — auto-persist scores rows for the manual-append bucket).
+
+Every test targets a TEMP scores.db (tmp_path) — NEVER the committed qa/scores.db (the same
+additive/read-only discipline qa/test_scores_db.py and qa/test_generate_release_notes.py follow).
+
+Run:
+    uv run --directory servers/engine python -m pytest ../../qa/test_scores_persist.py -q -p no:xdist
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+QA_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(QA_DIR))
+
+import scores_db  # noqa: E402
+import scores_persist as sp  # noqa: E402
+
+
+def _write(path: Path, payload: dict) -> str:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# qa/run_duo.sh
+# ---------------------------------------------------------------------------
+def test_persist_duo_row_clean_completion(tmp_path):
+    db = tmp_path / "scores.db"
+    story = _write(tmp_path / "duo.tolkien.json", {"overall": 4.2})
+    mech = _write(tmp_path / "duo.score.json", {"overall": 4.0})
+    angry = _write(tmp_path / "duo.angrydm.json", {"overall": 3.5})
+    latency = _write(tmp_path / "duo.latency.json", {"s_per_beat": 12.3, "coldopen_s": 45.0, "turns_per_beat": 3.1})
+
+    sp.persist_duo_row(
+        "duo-test1", db_path=db, build_sha="abc1234", dm_model="opus", actor_model="sonnet",
+        beats=8, completed_beats=8, behavioral="GREEN", story_json=story, mech_json=mech,
+        angry_json=angry, latency_json=latency, source_path="qa/transcripts/duo-test1",
+        infra_note="no throttle detected",
+    )
+    rows = {r["run_id"]: r for r in scores_db.fetch_rows(db)}
+    row = rows["duo-test1"]
+    assert row["surface"] == "engine-duo"
+    assert row["dm_model"] == "opus"
+    assert row["actor_model"] == "sonnet"
+    assert row["story_overall"] == 4.2
+    assert row["mech_overall"] == 4.0
+    assert row["angrydm_overall"] == 3.5
+    assert row["behavioral"] == "GREEN"
+    assert row["s_per_beat"] == 12.3
+    assert "3-lens duo 8-beat" == row["methodology"]
+    assert row["build_sha"] == "abc1234"
+
+
+def test_persist_duo_row_contaminated_writes_marker_not_clean_row(tmp_path):
+    db = tmp_path / "scores.db"
+    story = _write(tmp_path / "duo.tolkien.json", {"overall": 4.9})  # must NOT be cited
+    sp.persist_duo_row(
+        "duo-aborted1", db_path=db, build_sha="deadbee", dm_model="opus", beats=8,
+        completed_beats=3, story_json=story, contaminated_reason="QUOTA ABORT at beat 3 (HTTP 429)",
+    )
+    rows = {r["run_id"]: r for r in scores_db.fetch_rows(db)}
+    row = rows["duo-aborted1"]
+    assert row["behavioral"] == "CONTAMINATED"
+    assert row["story_overall"] is None  # no citable lens numbers on a contaminated run
+    assert row["mech_overall"] is None
+    assert "QUOTA ABORT" in row["notes"]
+    assert "CONTAMINATED" in row["notes"]
+
+
+def test_persist_duo_row_rerun_same_run_id_replaces_not_duplicates(tmp_path):
+    db = tmp_path / "scores.db"
+    sp.persist_duo_row("duo-dup", db_path=db, behavioral="RED", beats=6)
+    sp.persist_duo_row("duo-dup", db_path=db, behavioral="GREEN", beats=6)
+    rows = [r for r in scores_db.fetch_rows(db) if r["run_id"] == "duo-dup"]
+    assert len(rows) == 1
+    assert rows[0]["behavioral"] == "GREEN"
+
+
+# ---------------------------------------------------------------------------
+# qa/run_combat_sprint.sh
+# ---------------------------------------------------------------------------
+def test_persist_combat_sprint_row(tmp_path):
+    db = tmp_path / "scores.db"
+    angry = _write(tmp_path / "cs.angrydm.json", {"overall": 3.7})
+    sp.persist_combat_sprint_row(
+        "cs-test1", db_path=db, build_sha="c0ffee1", dm_model="opus", behavioral="GREEN",
+        angry_json=angry, source_path="qa/transcripts/cs-test1",
+    )
+    row = {r["run_id"]: r for r in scores_db.fetch_rows(db)}["cs-test1"]
+    assert row["surface"] == "engine-duo"
+    assert row["methodology"] == "combat-sprint"
+    assert row["angrydm_overall"] == 3.7
+    assert row["behavioral"] == "GREEN"
+
+
+# ---------------------------------------------------------------------------
+# qa/vm/sweep_v2.sh
+# ---------------------------------------------------------------------------
+def test_persist_sweep_persona_row(tmp_path):
+    db = tmp_path / "scores.db"
+    score = _write(tmp_path / "score-newbie.json", {
+        "persona_satisfaction": 7.5, "satisfaction_source": "self-reported",
+        "bug_reports_critical": 1, "gave_up": False,
+    })
+    sp.persist_sweep_persona_row(
+        "vm2-newbie-abc1234", db_path=db, persona="newbie", build_sha="abc1234",
+        dm_model="opus", actor_model="sonnet", score_json=score,
+    )
+    row = {r["run_id"]: r for r in scores_db.fetch_rows(db)}["vm2-newbie-abc1234"]
+    assert row["surface"] == "GUI-headless-proxy"
+    assert row["persona"] == "newbie"
+    assert row["cross_persona_sat"] == 7.5
+    assert row["critical_bugs"] == 1
+    assert row["scorer_model"] == "self-reported"
+    per = json.loads(row["per_persona_json"])
+    assert per["satisfaction_source"] == "self-reported"
+
+
+# ---------------------------------------------------------------------------
+# qa/ui_playtest_app.sh
+# ---------------------------------------------------------------------------
+def test_persist_app_gate_row_preserves_satisfaction_source(tmp_path):
+    db = tmp_path / "scores.db"
+    score = _write(tmp_path / "score.json", {
+        "persona_satisfaction": 8.0, "satisfaction_source": "derived", "bug_reports_critical": 0,
+    })
+    sp.persist_app_gate_row(
+        "app-test1", db_path=db, build_sha="f00d123", dm_model="opus", actor_model="sonnet",
+        part="B", provider="claude", score_pass=True, score_json=score,
+    )
+    row = {r["run_id"]: r for r in scores_db.fetch_rows(db)}["app-test1"]
+    assert row["surface"] == "GUI-built-app"
+    assert row["cross_persona_sat"] == 8.0
+    assert row["scorer_model"] == "derived"
+    assert row["pass"] == 1
+
+
+# ---------------------------------------------------------------------------
+# qa/release_readiness.py
+# ---------------------------------------------------------------------------
+def test_persist_rri_row_clean(tmp_path):
+    db = tmp_path / "scores.db"
+    rri_json = _write(tmp_path / "RRI.json", {
+        "rri": 8.2, "release_ready": True, "status": "READY", "build_sha": "abc1234",
+        "gates_passed": 10, "gates_total": 11, "failed_gates": [],
+        "signals": {"story_overall": 4.4, "mech_overall": 4.1, "behavioral": "GREEN",
+                    "cross_persona_satisfaction": 7.2, "total_critical_bugs": 0,
+                    "image_render_rate": 0.95},
+    })
+    sp.persist_rri_row("rri-abc1234", db_path=db, rri_json=rri_json, build_sha="abc1234")
+    row = {r["run_id"]: r for r in scores_db.fetch_rows(db)}["rri-abc1234"]
+    assert row["surface"] == "GUI-built-app"
+    assert row["rri"] == 8.2
+    assert row["story_overall"] == 4.4
+    assert row["behavioral"] == "GREEN"
+    assert row["pass"] == 1
+
+
+def test_persist_rri_row_aborted_writes_contaminated_marker(tmp_path):
+    db = tmp_path / "scores.db"
+    rri_json = _write(tmp_path / "RRI.json", {
+        "rri": 1.8, "release_ready": False, "aborted": True,
+        "abort_detail": "newbie resets 3:50pm UTC", "build_sha": "deadbee",
+        "signals": {"story_overall": 4.4},  # must NOT be cited on an aborted row
+    })
+    sp.persist_rri_row("rri-deadbee", db_path=db, rri_json=rri_json, build_sha="deadbee")
+    row = {r["run_id"]: r for r in scores_db.fetch_rows(db)}["rri-deadbee"]
+    assert row["behavioral"] == "CONTAMINATED"
+    assert row["rri"] is None
+    assert row["story_overall"] is None
+    assert "resets 3:50pm UTC" in row["notes"]
+
+
+# ---------------------------------------------------------------------------
+# CLI fail-loud contract
+# ---------------------------------------------------------------------------
+def test_cli_duo_writes_row_and_returns_zero(tmp_path):
+    db = tmp_path / "scores.db"
+    rc = sp.main(["duo", "--run-id", "cli-duo1", "--db", str(db), "--behavioral", "GREEN", "--beats", "4"])
+    assert rc == 0
+    row = {r["run_id"]: r for r in scores_db.fetch_rows(db)}["cli-duo1"]
+    assert row["surface"] == "engine-duo"
+
+
+def test_cli_missing_required_arg_exits_nonzero(tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        sp.main(["duo", "--db", str(tmp_path / "scores.db")])  # missing --run-id
+    assert exc.value.code != 0
+
+
+def test_cli_fails_loud_on_write_error(tmp_path, monkeypatch, capsys):
+    def _boom(*a, **kw):
+        raise RuntimeError("disk full (simulated)")
+
+    monkeypatch.setattr(sp, "persist_duo_row", _boom)
+    with pytest.raises(SystemExit) as exc:
+        sp.main(["duo", "--run-id", "cli-duo-boom", "--db", str(tmp_path / "scores.db")])
+    assert exc.value.code != 0
+    captured = capsys.readouterr()
+    assert "FATAL" in captured.err
+    assert "cli-duo-boom" in captured.err

--- a/qa/ui_playtest_app.sh
+++ b/qa/ui_playtest_app.sh
@@ -1383,6 +1383,29 @@ log "part A (#356 gate): $PART_A_RESULT   part B (persona loop): $PART_B_RESULT"
 log "spend: DM ~\$$FINAL_DM_SPEND + player ~\$$PART_B_PLAYER_COST = ~\$$TOTAL_SPEND (budget \$$BUDGET)"
 [ -f "$RUNDIR/run.json" ] && { echo "----- run.json -----"; cat "$RUNDIR/run.json"; }
 
+# #1414: auto-persist the scores_ledger row from score.json (surface=GUI-built-app) — FAIL LOUD
+# (never `|| echo WARN`; a failed write is a failed run per the Universal Run Contract,
+# docs/OPERATIONS.md "No row = no run"). Only fires when Part B actually produced a score (a
+# Part-A-only smoke run has no persona quality reading to persist — that is expected, not a
+# failure). satisfaction_source is preserved (scores_persist.py stamps it as this row's
+# scorer_model, the sweep-persona convention).
+if [ -f "$RUNDIR/score.json" ]; then
+  APP_NOTES_ARG=()
+  if [ "${PART_B_HARNESS_ERROR:-false}" = "true" ]; then
+    APP_NOTES_ARG=(--notes-extra "harness_error=true (non-quota player/process crash — read as INCONCLUSIVE, not a quality fail)")
+  fi
+  if ! python3 "$ROOT/qa/scores_persist.py" app-gate \
+      --run-id "$RUN" --build-sha "$BUILD_SHA" --dm-model "$TOP_DM_MODEL" \
+      --actor-model "$TOP_PLAYER_MODEL" --part "$PART" --provider "$PART_B_PROVIDER" \
+      --score-pass "$PART_B_SCORE_PASS" --score-json "$RUNDIR/score.json" \
+      --source-path "$RUNDIR/run.json" ${APP_NOTES_ARG[@]+"${APP_NOTES_ARG[@]}"}; then
+    log "FATAL: scores_db row write failed — a failed write is a failed run per the Universal Run Contract (docs/OPERATIONS.md). See the error above."
+    exit 1
+  fi
+else
+  log "no score.json in $RUNDIR — Part-A-only run or Part B produced no score; nothing to persist."
+fi
+
 EXIT_OK=1
 case "$PART" in
   A)

--- a/qa/vm/sweep_v2.sh
+++ b/qa/vm/sweep_v2.sh
@@ -10,6 +10,12 @@
 # the Mac. See the `worldos-dev` skill (sec. "VM GATE SWEEP" and sec. "RRI evidence-path
 # contract") and WorldOS-GUI-RUNBOOK.md sec. "Support VM lane".
 #
+# ⚠ SYNC REMINDER (#1414): this file is a REFERENCE COPY — editing it (including the per-persona
+# scores_persist.py auto-append this revision added to run_persona()) changes NOTHING on the VM
+# until you rsync/copy it over the canonical runnable copy at
+# /root/worldos-qa/sweep_v2.sh on the evaos-support VM. A change landed here and never synced is a
+# silent no-op for every real sweep run — always sync after editing this file.
+#
 # TWO load-bearing things this version gets right (cost a real diagnosis):
 #   1. RRI evidence-path contract - it passes the *evidence-path* flags
 #      (--behavioral-path / --ui-audit-log / --palette-source), not just value
@@ -217,6 +223,17 @@ run_persona(){  # $1=persona $2=port  -> writes results/score-$1.json
     SC_STRUCTURAL="$(python3 qa/inject_structural_coverage.py "$sc" "$bstore" 2>/dev/null)"
     cp "$sc" "$RES/score-$persona.json"
     note "  $persona rc=$rc $(python3 -c "import json;d=json.load(open('$sc'));print('sat=%s gaveup=%s crit=%s arc=%s turns=%s'%(d.get('persona_satisfaction'),d.get('gave_up'),d.get('bug_reports_critical'),d.get('completed_intro_flow'),d.get('in_story_turns')))" 2>/dev/null)${SC_STRUCTURAL:+ | $SC_STRUCTURAL}"
+    # #1414: auto-persist this persona's row (surface=GUI-headless-proxy) — FAIL LOUD (never
+    # `|| echo WARN`; a failed write is a failed run per the Universal Run Contract,
+    # docs/OPERATIONS.md "No row = no run"). run_id is keyed on persona+SHA so a re-run of the
+    # SAME sweep at the SAME commit replaces this persona's row instead of duplicating, while a
+    # new commit gets its own trend row (scores_db.add_run's INSERT OR REPLACE-on-run_id).
+    if ! python3 "$ROOT/qa/scores_persist.py" sweep-persona \
+        --run-id "vm2-$persona-$SHA" --persona "$persona" --build-sha "$SHA" \
+        --score-json "$sc" --source-path "$RES/score-$persona.json"; then
+      note "  FATAL: scores_db row write failed for persona=$persona — a failed write is a failed run per the Universal Run Contract (docs/OPERATIONS.md)."
+      exit 1
+    fi
   else
     note "  $persona rc=$rc - NO SCORE (see vm2-$persona.log)"
   fi


### PR DESCRIPTION
## Summary
- Closes #1414 (docs/RUNBOOK-INDEX.md wiring gap 1). Every expensive run type (duo, combat sprint, VM sweep, app gate, RRI rollup) used to rely on a *manual* `scores_db.py --add` after completion — a run could finish cleanly and never land a ledger row.
- Added `qa/scores_persist.py`: one small, tested module each runner's completion tail calls into. **Fail-loud** (never `|| echo WARN` — a failed write is a failed run per the Universal Run Contract, docs/OPERATIONS.md "No row = no run"); **idempotent-ish** (INSERT OR REPLACE keyed on the run's own stable `run_id`, following `scores_db.add_run`'s existing convention); **CONTAMINATED-marker rows** (no lens numbers) on a QUOTA/INFRA abort instead of a clean-looking one (the watcher contract).
- Wired all five runners:
  - `qa/run_duo.sh` — surface=engine-duo. Clean completion writes story/mech/angrydm + behavioral + latency ledger + dm/actor model + SHA. All 5 abort exit points (cold-open quota, cold-open no-opening, beat quota, beat infra-collapse streak, wrap-up quota) now write a `behavioral=CONTAMINATED` marker row instead of silently landing nothing.
  - `qa/run_combat_sprint.sh` — surface=engine-duo, methodology=combat-sprint, the Angry-DM score stamped into `angrydm_overall` (matches the historical `scores_seed_forensics.py` COMBAT_SPRINT convention: "mech = combat-sprint" per docs/OPERATIONS.md).
  - `qa/vm/sweep_v2.sh` (reference copy) — one row per persona, surface=GUI-headless-proxy, run_id keyed on persona+SHA. Added a sync reminder to the header (this file only takes effect after it's copied to the VM's canonical `/root/worldos-qa/sweep_v2.sh`).
  - `qa/ui_playtest_app.sh` — surface=GUI-built-app, sourced from score.json when Part B produced one; `satisfaction_source` preserved (stamped as the row's `scorer_model`).
  - `qa/release_readiness.py` — surface=GUI-built-app RRI row whenever `--out` is written, run_id keyed on build SHA; new `--scores-db` flag so tests can target a temp db (existing `test_release_readiness.py` updated to use it — never the committed ledger).
- Updated `docs/RUNBOOK-INDEX.md`: closed wiring gap #1, flipped each row's scores-surface annotation from "⚠ manual" to "auto-append #1414".

## Test plan
- [x] New `qa/test_scores_persist.py` (11 tests): clean completion field mapping for all 5 runner types, CONTAMINATED-marker (no lens numbers cited), idempotent rerun-replaces-not-duplicates, RRI aborted-marker, and the CLI fail-loud contract (missing arg exits nonzero, a simulated write failure exits nonzero with a FATAL stderr message).
- [x] Full focused pytest run green: `qa/test_scores_persist.py` + `qa/test_release_readiness.py` (52, updated to use a temp `--scores-db` so the committed ledger stays untouched) + `qa/test_release_readiness_scope.py` + `qa/test_scores_db.py` + `qa/test_scores_db_comparability.py` + `qa/test_generate_release_notes.py` = 156 passed.
- [x] `qa/fast_gate.sh` green (257 passed) — unaffected by this change.
- [x] `bash -n` syntax check on all 4 touched shell scripts + `shellcheck` (no new warnings introduced by this diff).
- [x] Manual CLI smoke test of all 5 `scores_persist.py` subcommands against a throwaway db, using the exact flag syntax embedded in each shell script (catches any flag-name drift between bash call sites and the argparse definitions).
- [x] Confirmed the committed `qa/scores.db` is untouched by the test suite (git status clean on that path after every test run above).

**Admin-merge note (#1389):** repo-wide GitHub auto-merge hangs on ~every PR (root cause open, #1389). Arming `--auto` now; once checks are green and threads are resolved this needs `gh pr merge --admin --squash`, not `--auto` alone.