### PR TITLE
qa: ledger unification — fold artifacts + library_metrics into scores_ledger.md (#1415)

### DIFF
--- a/docs/RUNBOOK-INDEX.md
+++ b/docs/RUNBOOK-INDEX.md
@@ -49,5 +49,16 @@
 ## Known wiring gaps (tracked)
 1. ~~**Manual-append bucket** (duo, sprint, sweep, app gate, RRI)~~ — CLOSED #1414: each runner now
    self-persists via `qa/scores_persist.py` (fail-loud; CONTAMINATED marker on a QUOTA/INFRA abort).
-2. **Ledger unification**: artifacts + library_metrics tables don't render into scores_ledger.md.
-3. Half-wired: motion_reel capture stub; felt_rest_panel non-rest write path; stale `--layered` naming.
+2. ~~**Ledger unification**: artifacts + library_metrics tables don't render into scores_ledger.md.~~
+   — CLOSED #1415: `scores_db.py --render` now folds an "Artifact panels" roll-up (per-panel_id,
+   per-class median + ±1.2 control-band verdict) and a chronological "Library metrics" trend into
+   `qa/scores_ledger.md` itself, alongside the runs table; each section is cleanly omitted when its
+   store is empty.
+3. Half-wired, #1415 update: `felt_rest_panel`'s non-rest write path was VERIFIED — the row was
+   never skipped (add_run fires unconditionally per frame), but the REST_LENSES-only dims filter
+   silently dropped a non-rest panel's per-lens scores; fixed to pass through arbitrary dims for a
+   non-`rest:` scene. `motion_reel.py`'s Unity-capture hook is now wired against the documented
+   `manage_camera` pattern (env-gated on `WORLDOS_UNITY_MCP_URL`, mockable via `mcp_call=`) but its
+   live `:8080/mcp` round-trip is UNVERIFIED on this lane (no GEX44 box access) — validation queues
+   behind the next box session. Still open: the engine-fetch half of motion_reel (TODO hook,
+   separate scope) and the stale `--layered` naming.

--- a/qa/felt_rest_panel.py
+++ b/qa/felt_rest_panel.py
@@ -162,7 +162,19 @@ def _log_frames(panel: dict, run_prefix: str, db_path: str | None) -> int:
         scene = str(f.get("scene", panel_scene))
         fid = str(f.get("id", f"frame_{n}"))
         is_control = f.get("kind") == "control"
-        dims = {k: f.get("dims", {}).get(k) for k in REST_LENSES if f.get("dims", {}).get(k) is not None}
+        raw_dims = f.get("dims") or {}
+        if scene.split(":", 1)[0] == "rest":
+            # The protocol's own 5 rest lenses (qa/felt_rest_panel.md) — filter to just those so a
+            # stray/bogus key never leaks into the ledger's visual_dims_json for a rest frame.
+            dims = {k: raw_dims.get(k) for k in REST_LENSES if raw_dims.get(k) is not None}
+        else:
+            # NON-rest invocation (this logger is generic infra, reused by any control-anchored
+            # panel — RUNBOOK-INDEX gap 3, "felt_rest_panel non-rest write path"). The row itself
+            # was ALWAYS written for every scene (add_run below runs unconditionally); the bug was
+            # here: REST_LENSES-only filtering silently dropped every non-rest lens key, so a
+            # non-rest panel's per-lens scores never reached visual_dims_json even though the row
+            # existed. Pass through whatever dims the frame actually carries instead.
+            dims = {k: v for k, v in raw_dims.items() if v is not None}
         run_id = f"{run_prefix}-{scene.replace(':', '_')}-r{vround}-{fid}-i{n}"
         kw: dict = dict(
             surface="visual",

--- a/qa/motion_reel.py
+++ b/qa/motion_reel.py
@@ -19,9 +19,14 @@ TWO MODES
 ---------
 * MODE A "engine-state reel" — given a campaign id + a list of N beats, fetch successive combat-
   surface states from the engine and render each via the existing Unity render path, then assemble.
-  The ENGINE-FETCH and the UNITY-CAPTURE are clearly-marked HOOKS (the real wiring is a TODO; the
-  engine is the SOLE WRITER and Unity is the renderer — this module never writes game state). The
-  reel ASSEMBLY (contact-sheet + sidecar) from the produced PNG list is REAL and tested.
+  The ENGINE-FETCH (:func:`fetch_combat_surface_states`) is still a clearly-marked HOOK (the real
+  engine read is a TODO; the engine is the SOLE WRITER and Unity is the renderer — this module
+  never writes game state). The UNITY-CAPTURE (:func:`render_state_via_unity`, #1415) is wired
+  against the documented ``manage_camera`` pattern (``extensions/renderers/unity/BOX.md``) —
+  env-gated on ``WORLDOS_UNITY_MCP_URL`` and mockable via ``mcp_call=``; the exact live ``:8080/mcp``
+  round-trip shape is UNVERIFIED on this lane (no GEX44 box access) and queues for validation behind
+  the next box session. The reel ASSEMBLY (contact-sheet + sidecar) from the produced PNG list is
+  REAL and tested.
 * MODE B "timeline reel" — given a directory of already-rendered animation frame PNGs (e.g. a
   Meshy/PixelLab/Unity timeline export), assemble the contact-sheet + sidecar directly. Fully real.
 
@@ -38,7 +43,8 @@ USAGE
     # MODE B — explicit ordered frames with per-frame labels (a JSON manifest):
     python qa/motion_reel.py --mode timeline --frames @/tmp/frames.json --out /tmp/reel.png
 
-    # MODE A — engine-state reel (interface documented; capture is a TODO hook):
+    # MODE A — engine-state reel (interface documented; engine-fetch is still a TODO hook, capture
+    # is wired but unverified off the box — set WORLDOS_UNITY_MCP_URL to opt in):
     python qa/motion_reel.py --mode engine --campaign demo-crypt --beats 6 --out /tmp/beat_reel.png
 
     # From Python:
@@ -68,7 +74,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
+import shutil
 import struct
 import sys
 import zlib
@@ -411,17 +419,92 @@ def fetch_combat_surface_states(campaign_id: str, beats: int) -> list[dict]:
     return [{"campaign_id": campaign_id, "beat": i, "_stub": True} for i in range(beats)]
 
 
-def render_state_via_unity(state: dict, out_png: str | Path) -> Optional[str]:
-    """HOOK (TODO): render ONE combat-surface state to ``out_png`` via the existing Unity render
-    path (the closed-loop pipeline / CoplayDev MCP capture on the GEX44 Unity host — see the
-    gex44-unity-host skill). Returns the PNG path on success, or None if the capture path is not
-    available in this environment (the common case off the GPU box).
+# Env var naming the live Unity MCP HTTP endpoint (BOX.md: "curl 127.0.0.1:8080/mcp returns 406
+# (server healthy)" — the documented health-check path on the GEX44 box). Unset (the default
+# everywhere except a claimed GEX44 session) means "no live host configured" -> render_state_via_
+# unity returns None immediately, with NO network attempt — this is what keeps the default path
+# safe to run anywhere (CI, a laptop) without risking a stray connection to whatever happens to be
+# on localhost:8080.
+UNITY_MCP_URL_ENV = "WORLDOS_UNITY_MCP_URL"
 
-    This is intentionally a stub here: wiring the live Unity capture is out of scope for the
-    reel-assembly module (it requires the GPU box + a live editor). The contract is: produce a PNG
-    per state; build_engine_reel then assembles whatever PNGs were produced."""
-    # TODO(worldos): call the Unity capture (manage_camera / CL screenshot) for `state` here.
-    return None
+
+def _default_unity_mcp_call(tool: str, params: dict, *, url: str, timeout: float = 30.0) -> dict:
+    """Real transport: POST one MCP ``tools/call`` JSON-RPC request to ``url`` (the live Unity MCP
+    HTTP endpoint documented in ``extensions/renderers/unity/BOX.md``, e.g.
+    ``http://127.0.0.1:8080/mcp``). stdlib-only (``urllib``), no new dependency.
+
+    This function performs REAL network I/O and is deliberately never exercised by the test suite
+    (tests inject a stub via ``render_state_via_unity(..., mcp_call=...)``) — this lane has no GEX44
+    box access, so the exact wire round-trip is UNVERIFIED here; live validation queues behind the
+    next box session (see the gex44-unity-host skill)."""
+    import urllib.error
+    import urllib.request
+
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": tool, "arguments": params},
+    }).encode("utf-8")
+    req = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (documented internal host)
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def render_state_via_unity(
+    state: dict,
+    out_png: str | Path,
+    *,
+    mcp_call=None,
+    screenshot_super_size: int = 2,
+) -> Optional[str]:
+    """Render ONE combat-surface state to ``out_png`` via the documented ``manage_camera`` capture
+    (``extensions/renderers/unity/BOX.md``: ``screenshot_super_size`` 2-4, captures land in
+    ``Assets/Screenshots/`` on the live Unity MCP host). Returns the copied PNG path on success, or
+    ``None`` if the capture is unavailable in this environment (the common case off the GPU box) —
+    this function NEVER raises; every failure mode degrades to ``None`` so ``build_engine_reel``'s
+    existing ``no_render`` status handles it exactly like the old stub did.
+
+    ``mcp_call`` is the injectable MCP transport — ``(tool_name, params_dict) -> response_dict`` —
+    so this is fully unit-testable with a mocked call and NO box/network access. When omitted, the
+    real transport (:func:`_default_unity_mcp_call`) is used, but ONLY if ``WORLDOS_UNITY_MCP_URL``
+    is set (the documented live-box endpoint, e.g. ``http://127.0.0.1:8080/mcp``) — with no URL
+    configured (every environment except a claimed GEX44 session), this returns ``None``
+    immediately with zero network I/O, matching ``state`` unused by the state itself beyond
+    identifying what to capture (the live camera/scene already reflects ``state`` by the time this
+    is called; this hook only triggers + fetches the screenshot).
+
+    This is deliberately UNVERIFIED against the live box on this lane (no GEX44 access this pass —
+    see BOX.md's single-tenant claim discipline): the orchestration/parsing here is code-complete
+    and covered by injected-stub unit tests; the real ``:8080/mcp`` round-trip shape queues for
+    validation behind the next box session."""
+    call = mcp_call
+    if call is None:
+        url = os.environ.get(UNITY_MCP_URL_ENV)
+        if not url:
+            return None  # no live Unity MCP host configured -> the documented off-box fallback
+
+        def call(tool: str, params: dict) -> dict:
+            return _default_unity_mcp_call(tool, params, url=url)
+
+    try:
+        resp = call("manage_camera",
+                     {"action": "screenshot", "screenshot_super_size": screenshot_super_size})
+    except Exception:
+        return None
+
+    result = resp.get("result") if isinstance(resp, dict) else None
+    captured = None
+    if isinstance(result, dict):
+        captured = result.get("path") or result.get("screenshot_path")
+    if not captured:
+        return None
+
+    src = Path(captured)
+    if not src.exists():
+        return None
+    dst = Path(out_png)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+    return str(dst)
 
 
 def build_engine_reel(
@@ -437,11 +520,13 @@ def build_engine_reel(
     """Assemble an engine-state reel (MODE A): fetch N combat-surface states, render each via Unity,
     then assemble the produced PNGs into a contact-sheet + sidecar.
 
-    The ENGINE-FETCH (:func:`fetch_combat_surface_states`) and the UNITY-CAPTURE
-    (:func:`render_state_via_unity`) are HOOKS — the live wiring is a TODO (it needs the GPU box +
-    a running editor + the engine read). What is REAL here is the orchestration + the assembly: when
-    renders ARE produced (live, or supplied via ``frame_dir`` of pre-rendered per-beat PNGs, or via
-    the ``_renderer`` injection in tests), this builds the same contact-sheet + sidecar as MODE B,
+    The ENGINE-FETCH (:func:`fetch_combat_surface_states`) is still a HOOK — the live engine read is
+    a TODO (it needs the GPU box + a running editor). The UNITY-CAPTURE (:func:`render_state_via_unity`,
+    #1415) is now wired against the documented ``manage_camera`` pattern, but its live ``:8080/mcp``
+    round-trip is UNVERIFIED on this lane (no GEX44 box access) and queues behind the next box
+    session. What is REAL and unit-tested here is the orchestration + the assembly: when renders ARE
+    produced (live, or supplied via ``frame_dir`` of pre-rendered per-beat PNGs, or via the
+    ``_renderer`` injection in tests), this builds the same contact-sheet + sidecar as MODE B,
     one frame per beat, labelled ``beat<N>`` and carrying the beat index as t_ms-equivalent ordering.
 
     Returns the sidecar dict (with ``contact_sheet`` + ``sidecar``), or a dict with
@@ -493,7 +578,8 @@ def build_engine_reel(
 def main(argv: Optional[list[str]] = None) -> int:
     ap = argparse.ArgumentParser(description="Build a motion REEL (contact-sheet + sidecar) for the visual-critic L7 lens")
     ap.add_argument("--mode", choices=("timeline", "engine"), required=True,
-                    help="timeline = assemble from rendered frame PNGs; engine = fetch+render N beats (capture is a TODO hook)")
+                    help="timeline = assemble from rendered frame PNGs; engine = fetch+render N beats "
+                         "(engine-fetch is a TODO hook; capture needs WORLDOS_UNITY_MCP_URL set)")
     ap.add_argument("--out", required=True, help="output contact-sheet PNG path (sidecar is <out>.json)")
     ap.add_argument("--cell-max", type=int, default=256, help="max per-cell thumbnail edge (default 256)")
     # MODE B

--- a/qa/scores_db.py
+++ b/qa/scores_db.py
@@ -54,6 +54,7 @@ import json
 import os
 import re
 import sqlite3
+import statistics
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -820,9 +821,150 @@ def render_markdown(db_path: Path | str = DB_PATH, md_path: Path | str = MD_PATH
             cells.append(_fmt(v))
         out.append("| " + " | ".join(cells) + " |")
     out.append("")
+    out.extend(_render_artifact_panels_section(db_path))
+    out.extend(_render_library_metrics_trend_section(db_path))
     text = "\n".join(out)
     Path(md_path).write_text(text, encoding="utf-8")
     return text
+
+
+# ---------------------------------------------------------------------------
+# Ledger unification (#1415): fold the `artifacts` and `library_metrics` stores into the SAME
+# qa/scores_ledger.md the `runs` table renders into, so "one place every scored run is recorded"
+# (the file's own header promise) is actually true — RUNBOOK-INDEX gap 2. Purely ADDITIVE to
+# render_markdown: the runs table renders exactly as before; these two sections are appended
+# after it, and each is OMITTED ENTIRELY (no header, no table) when its store has zero groupable
+# rows — a db with no artifacts/library_metrics yet renders byte-identically to before this PR.
+# The full per-row detail still lives in artifacts_ledger.md / library_metrics_ledger.md
+# (render_artifacts_markdown / render_library_metrics_markdown, unchanged) — these sections are a
+# roll-up, not a replacement.
+# ---------------------------------------------------------------------------
+def _median(vals: list[Optional[float]]) -> Optional[float]:
+    xs = [float(v) for v in vals if v is not None]
+    return statistics.median(xs) if xs else None
+
+
+# The ±1.2 per-panel noise-band already documented as bounding a control's drift (see the
+# `control_anchor` column doc above + qa/felt_rest_panel.md's CALIBRATION-CONTROL LAW) — reused
+# here as the artifact-panel control-band verdict so this section states an honest IN/OUT-OF-BAND
+# read rather than inventing a new threshold.
+_ARTIFACT_CONTROL_BAND = 1.2
+
+
+def _artifact_panel_rows(db_path: Path | str = DB_PATH) -> list[dict]:
+    """One roll-up row per (panel_id, class) pair present in the `artifacts` table, most-recent
+    panel first. Rows with no `panel_id` recorded are excluded from this per-panel view (they
+    still render in full in `qa/artifacts_ledger.md`) — a panel id is what makes "per-class
+    median" and "control-band verdict" a coherent unit; an unpanelled artifact score has no group
+    to summarize into."""
+    rows = fetch_artifacts(db_path)
+    groups: dict[tuple[str, str], dict] = {}
+    order: list[tuple[str, str]] = []
+    for r in rows:
+        panel_id, cls = r.get("panel_id"), r.get("class")
+        if not panel_id or not cls:
+            continue
+        key = (str(panel_id), str(cls))
+        if key not in groups:
+            groups[key] = {"scored": [], "control_anchors": [], "ts": r.get("ts") or ""}
+            order.append(key)
+        g = groups[key]
+        if r.get("ts") and r["ts"] > g["ts"]:
+            g["ts"] = r["ts"]
+        if r.get("is_control"):
+            if r.get("control_anchor") is not None:
+                g["control_anchors"].append(r["control_anchor"])
+        elif r.get("overall") is not None:
+            g["scored"].append(r["overall"])
+
+    out = []
+    for panel_id, cls in order:
+        g = groups[(panel_id, cls)]
+        median = _median(g["scored"])
+        anchor = _median(g["control_anchors"])
+        if anchor is None:
+            verdict = "NO-CONTROL"
+        elif median is None:
+            verdict = "UNSCORED"
+        elif abs(median - anchor) <= _ARTIFACT_CONTROL_BAND:
+            verdict = "IN-BAND"
+        else:
+            verdict = "OUT-OF-BAND"
+        out.append({
+            "panel_id": panel_id, "class": cls, "n": len(g["scored"]),
+            "median": median, "control_anchor": anchor, "verdict": verdict, "ts": g["ts"],
+        })
+    out.sort(key=lambda d: (d["ts"], d["panel_id"], d["class"]), reverse=True)
+    return out
+
+
+_ARTIFACT_PANEL_MD_COLS = [
+    ("panel_id", "Panel"), ("class", "Class"), ("n", "N"),
+    ("median", "Median"), ("control_anchor", "Control anchor"), ("verdict", "Verdict"),
+]
+
+
+def _render_artifact_panels_section(db_path: Path | str = DB_PATH) -> list[str]:
+    """Return the '## Artifact panels' section lines, or `[]` when the `artifacts` table has no
+    panelled rows (cleanly omitted — no header/table for an empty/unpanelled store)."""
+    panel_rows = _artifact_panel_rows(db_path)
+    if not panel_rows:
+        return []
+    out = ["## Artifact panels", ""]
+    out.append(
+        "> Per-`panel_id` roll-up of the `artifacts` table (HV1, #1323) — grouped by panel, then "
+        "class. **Median** is the scored (non-control) rows' median `overall`; **Control anchor** "
+        "is the disguised control's expected band midpoint (median across control rows, if >1); "
+        "**Verdict** applies the ±1.2 noise-band law: `IN-BAND` / `OUT-OF-BAND`, or `NO-CONTROL` "
+        "when the panel recorded no control row (`UNSCORED` when it recorded a control but no "
+        "scored artifact). Full per-artifact detail lives in `qa/artifacts_ledger.md` "
+        "(`--render-artifacts`)."
+    )
+    out.append("")
+    header = "| " + " | ".join(label for _, label in _ARTIFACT_PANEL_MD_COLS) + " |"
+    sep = "|" + "|".join("---" for _ in _ARTIFACT_PANEL_MD_COLS) + "|"
+    out.append(header)
+    out.append(sep)
+    for r in panel_rows:
+        cells = [_fmt(r.get(k)) for k, _ in _ARTIFACT_PANEL_MD_COLS]
+        out.append("| " + " | ".join(cells) + " |")
+    out.append("")
+    return out
+
+
+def _render_library_metrics_trend_section(db_path: Path | str = DB_PATH) -> list[str]:
+    """Return the '## Library metrics' section lines — a CHRONOLOGICAL (oldest-first, the natural
+    trend-reading order) render of every `library_metrics` snapshot — or `[]` when that table is
+    empty (cleanly omitted)."""
+    rows = list(reversed(fetch_library_metrics(db_path)))  # fetch is newest-first -> chronological
+    if not rows:
+        return []
+    out = ["## Library metrics", ""]
+    out.append(
+        "> Chronological trend (oldest first) of the `library_metrics` table (HV5 slice 2, #1327) "
+        "— the flywheel's own health, one row per snapshot. **Back-link** is the snapshot's "
+        "`notes` (falls back to `source_path` when notes is unset) so a size/reuse jump can be "
+        "traced to the run/curation pass that produced it. Full render lives in "
+        "`qa/library_metrics_ledger.md` (`--render-library-metrics`)."
+    )
+    out.append("")
+    cols = [
+        ("ts", "When"), ("library_sha", "SHA"), ("size_total", "Size"),
+        ("size_by_class_json", "By class"), ("size_by_tier_json", "By tier"),
+        ("reuse_count_sum", "Σreuse"), ("_backlink", "Back-link"),
+    ]
+    header = "| " + " | ".join(label for _, label in cols) + " |"
+    sep = "|" + "|".join("---" for _ in cols) + "|"
+    out.append(header)
+    out.append(sep)
+    for r in rows:
+        cells = []
+        for key, _ in cols:
+            v = (r.get("notes") or r.get("source_path") or "") if key == "_backlink" else r.get(key)
+            cells.append(_fmt(v))
+        out.append("| " + " | ".join(cells) + " |")
+    out.append("")
+    return out
 
 
 ARTIFACTS_MD_PATH = QA_DIR / "artifacts_ledger.md"

--- a/qa/scores_ledger.md
+++ b/qa/scores_ledger.md
@@ -6,7 +6,7 @@
 
 > **Ruler** = `scoring_config_version` (a content hash of the rubric + schema + gate files, RRI gate included). **Lens ruler** = `lens_config_version` (the 8 files that produce the story/mech/angry LENS numbers — full ruler minus `release_readiness.py`; blank = recorded before lens stamping, #725). Rows under DIFFERENT Ruler values are **NOT directly comparable as a quality trend** — the ruler changed (a rubric recalibration or a new gate moves the number with no change in play quality). Use `python3 qa/scores_db.py --compare` for a lens-fenced engine-duo trend (add `--compare-rc-surface` for the GUI-built-app RC blocks); comparing across rulers requires re-scoring an archived transcript under the current ruler. **RC** = the release candidate a run scored (e.g. `v1.0.4-rc1`).
 
-> Rows: **86** · rendered 2026-07-08T11:44:32+00:00
+> Rows: **86** · rendered 2026-07-08T12:27:08+00:00
 
 | Run | When | SHA | Build date | Surface | DM model | Actor model | Scorer | Ruler | Lens ruler | RC | Methodology | Story | Mech | AngryDM | Behav | Sat | RRI | Crit | Img% | s/beat | cold-open s | turns/beat | combat s/beat | social s/beat | tool% | tool ms | slowest tool | Acts | Structural coverage | Engagement | Inert systems | Pass | Source | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
@@ -96,3 +96,32 @@
 | duo-director1 | 2026-05-26 | ~post-#72-director |  | engine-duo | sonnet | sonnet | claude |  |  |  | 3-lens duo | 4.1 | 3.8 | 3.2 | GREEN |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | qa/SCORECARD.md | [persona=wayfarer] Campaign Director validated: add_quest fired 3x (reach-for gap closed in play). |
 | duo-caster1 | 2026-05-26 | ~post-#140 |  | engine-duo | sonnet | sonnet | claude |  |  |  | 3-lens duo | 4 | 3.8 | 2.6 | GREEN |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | qa/SCORECARD.md | [persona=battlemage] add_quest=3. Player made 0 cast_spell/0 attack (roleplay infiltration) -> angry 2.6 is a combat-coverage artifact, NOT an engine defect. |
 | newmain-rogue2 | 2026-05-25 | ~85-commit-merge |  | engine-duo | sonnet | sonnet | claude |  |  |  | 3-lens duo | 4.1 | 3 | 2 | GREEN |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | qa/SCORECARD.md | [persona=rogue (social)] 85-commit merge validation. Low mech/angry = social run, little combat (coverage artifact, not engine defect). [UNCERTAIN] date ~2026-05-25, exact SHA not recorded. |
+
+## Artifact panels
+
+> Per-`panel_id` roll-up of the `artifacts` table (HV1, #1323) — grouped by panel, then class. **Median** is the scored (non-control) rows' median `overall`; **Control anchor** is the disguised control's expected band midpoint (median across control rows, if >1); **Verdict** applies the ±1.2 noise-band law: `IN-BAND` / `OUT-OF-BAND`, or `NO-CONTROL` when the panel recorded no control row (`UNSCORED` when it recorded a control but no scored artifact). Full per-artifact detail lives in `qa/artifacts_ledger.md` (`--render-artifacts`).
+
+| Panel | Class | N | Median | Control anchor | Verdict |
+|---|---|---|---|---|---|
+| qp2-manual-20260708 | quest | 3 | 3.2 |  | NO-CONTROL |
+| cal-quest-20260707T230908 | quest | 15 | 3.2 | 3 | IN-BAND |
+| cal-npc-20260707T212734 | npc | 20 | 2.95 | 4 | IN-BAND |
+| cal-quest-20260707T212734 | quest | 3 | 3.6 | 4 | IN-BAND |
+| cal-npc-20260707T210934 | npc | 10 | 3.25 | 4 | IN-BAND |
+| cal-quest-20260707T211839 | quest | 3 | 3.6 | 4 | IN-BAND |
+| cal-quest-20260707T210934 | quest | 3 | 3.6 | 4 | IN-BAND |
+| cal-location-20260707T210934 | location | 14 | 3.6 | 4 | IN-BAND |
+| cal-encounter-20260707T210934 | encounter | 2 | 2.8 | 4 | OUT-OF-BAND |
+| cal-npc-20260706T070222 | npc | 8 | 3.3 | 4 | IN-BAND |
+| cal-location-20260706T070223 | location | 6 | 3.8 | 4 | IN-BAND |
+| cal-encounter-20260706T070224 | encounter | 4 | 2.7 | 4 | OUT-OF-BAND |
+| cal-quest-20260706T070141 | quest | 2 | 2.05 | 4 | OUT-OF-BAND |
+| cal-quest-20260706T065746 | quest | 2 | 2.05 | 4 | OUT-OF-BAND |
+
+## Library metrics
+
+> Chronological trend (oldest first) of the `library_metrics` table (HV5 slice 2, #1327) — the flywheel's own health, one row per snapshot. **Back-link** is the snapshot's `notes` (falls back to `source_path` when notes is unset) so a size/reuse jump can be traced to the run/curation pass that produced it. Full render lives in `qa/library_metrics_ledger.md` (`--render-library-metrics`).
+
+| When | SHA | Size | By class | By tier | Σreuse | Back-link |
+|---|---|---|---|---|---|---|
+| 2026-07-07T22:26:21+00:00 | 723a2687 | 3 | {"location": 2, "npc": 1} | {"canonical": 0, "experimental": 0, "stable": 3} | 0 | 2nd promotion batch (extractor v2 yield): 2/21 fresh nominations promoted (npc-minsc rri-a1-gate 4.1, loc-elfsong-tavern rri-a1-gate2 4.3); quest panel not control-valid after 3 attempts (the-shadow-cursed-lands control landed 2.4-2.9, below [2.8,5.2] band each time) |

--- a/qa/test_felt_rest_panel.py
+++ b/qa/test_felt_rest_panel.py
@@ -126,6 +126,41 @@ class LogFramesAndMainTests(unittest.TestCase):
         # a frame with no surviving dims omits the visual_dims_json key entirely.
         self.assertNotIn("visual_dims_json", ctl_row)
 
+    def test_log_frames_non_rest_scene_writes_row_and_preserves_arbitrary_dims(self):
+        """#1415 / RUNBOOK-INDEX gap 3: verify the NON-rest write path. The row is written
+        unconditionally regardless of scene (add_run always fires) — that part was never broken.
+        The real bug: REST_LENSES-only filtering silently dropped every dim key for a non-rest
+        scene, so visual_dims_json came back empty even though the row existed. A non-rest scene
+        (this generic logger reused by e.g. a combat-anchored panel) must both log the row AND
+        keep its own (non-rest) lens keys."""
+        captured = {}
+
+        def _fake_add_run(run_id, **kw):
+            captured[run_id] = kw
+
+        import sys as _sys
+        import types as _types
+        stub = _types.ModuleType("scores_db")
+        stub.add_run = _fake_add_run  # type: ignore[attr-defined]
+        _sys.modules["scores_db"] = stub
+        try:
+            panel = {
+                "scene": "combat:crypt-ambush", "backend": "unity-cl", "round": 1,
+                "pregate": "PASS",
+                "frames": [
+                    {"id": "f1", "kind": "ours", "overall": 6.0,
+                     "dims": {"tactical_readability": 7, "attack_arc": None}},
+                ],
+            }
+            n = frp._log_frames(panel, "felt-combat", None)
+        finally:
+            del _sys.modules["scores_db"]
+        self.assertEqual(n, 1)  # the row IS written for a non-rest scene
+        row = next(iter(captured.values()))
+        self.assertEqual(row["visual_scene"], "combat:crypt-ambush")
+        # non-rest lens key survives (it is NOT one of the 5 REST_LENSES); the None dim is dropped.
+        self.assertEqual(row["visual_dims_json"], {"tactical_readability": 7})
+
     def test_log_frames_uses_each_frames_own_scene_and_disambiguates_same_id_rows(self):
         """Thread PRRT_...G9Xr: a combined panel (tavern + church rows in one panel) must log
         each row under ITS OWN scene, not the panel-level scene — otherwise every row lands as

--- a/qa/test_motion_reel.py
+++ b/qa/test_motion_reel.py
@@ -174,6 +174,83 @@ class TestSidecarFeedsG5:
 
 
 # ---------------------------------------------------------------------------
+# 2b. render_state_via_unity — the Unity-capture hook (#1415), fully mocked (no box/network access)
+# ---------------------------------------------------------------------------
+class TestUnityCaptureHook:
+    def test_no_url_configured_returns_none_with_no_call(self, tmp_path, monkeypatch):
+        """The default off-box path (WORLDOS_UNITY_MCP_URL unset, no mcp_call injected): returns
+        None immediately, with zero network attempt."""
+        monkeypatch.delenv(mr.UNITY_MCP_URL_ENV, raising=False)
+        assert mr.render_state_via_unity({"beat": 0}, tmp_path / "out.png") is None
+
+    def test_injected_mcp_call_writes_captured_png_to_out_path(self, tmp_path):
+        """A successful manage_camera response (a `path` pointing at a real captured PNG) is
+        copied to out_png and that path is returned."""
+        captured_src = _png(tmp_path / "_captured.png", 8, 8, bright_at=(2, 2))
+        calls = []
+
+        def fake_mcp_call(tool, params):
+            calls.append((tool, params))
+            return {"result": {"path": str(captured_src)}}
+
+        out = tmp_path / "beat_out.png"
+        result = mr.render_state_via_unity({"beat": 0}, out, mcp_call=fake_mcp_call)
+        assert result == str(out)
+        assert out.exists()
+        assert out.read_bytes() == captured_src.read_bytes()
+        assert calls == [("manage_camera",
+                          {"action": "screenshot", "screenshot_super_size": 2})]
+
+    def test_injected_mcp_call_honors_super_size_kwarg(self, tmp_path):
+        seen = {}
+
+        def fake_mcp_call(tool, params):
+            seen.update(params)
+            return {"result": {}}
+
+        mr.render_state_via_unity({"beat": 0}, tmp_path / "out.png",
+                                  mcp_call=fake_mcp_call, screenshot_super_size=4)
+        assert seen["screenshot_super_size"] == 4
+
+    def test_response_with_no_result_path_returns_none(self, tmp_path):
+        def fake_mcp_call(tool, params):
+            return {"result": {}}
+
+        assert mr.render_state_via_unity({"beat": 0}, tmp_path / "out.png",
+                                         mcp_call=fake_mcp_call) is None
+
+    def test_captured_path_missing_on_disk_returns_none(self, tmp_path):
+        def fake_mcp_call(tool, params):
+            return {"result": {"path": str(tmp_path / "does_not_exist.png")}}
+
+        assert mr.render_state_via_unity({"beat": 0}, tmp_path / "out.png",
+                                         mcp_call=fake_mcp_call) is None
+
+    def test_transport_exception_degrades_to_none_not_raise(self, tmp_path):
+        def raising_call(tool, params):
+            raise ConnectionError("no route to host")
+
+        assert mr.render_state_via_unity({"beat": 0}, tmp_path / "out.png",
+                                         mcp_call=raising_call) is None
+
+    def test_url_configured_builds_default_call_bound_to_that_url(self, tmp_path, monkeypatch):
+        """When no mcp_call is injected but WORLDOS_UNITY_MCP_URL IS set, the real transport
+        (_default_unity_mcp_call) is invoked with that url — verified here via monkeypatch so no
+        actual network I/O happens (this lane has no box access)."""
+        monkeypatch.setenv(mr.UNITY_MCP_URL_ENV, "http://127.0.0.1:8080/mcp")
+        seen = {}
+
+        def fake_default(tool, params, *, url, timeout=30.0):
+            seen["tool"], seen["params"], seen["url"] = tool, params, url
+            return {"result": {}}
+
+        monkeypatch.setattr(mr, "_default_unity_mcp_call", fake_default)
+        assert mr.render_state_via_unity({"beat": 0}, tmp_path / "out.png") is None
+        assert seen["url"] == "http://127.0.0.1:8080/mcp"
+        assert seen["tool"] == "manage_camera"
+
+
+# ---------------------------------------------------------------------------
 # 3. MODE A — engine reel orchestration with an injected renderer (capture is a TODO hook)
 # ---------------------------------------------------------------------------
 class TestEngineReel:

--- a/qa/test_scores_db.py
+++ b/qa/test_scores_db.py
@@ -736,3 +736,93 @@ def test_motion_columns_alter_into_an_old_db(tmp_path):
     assert legacy["visual_overall"] == 6.5
     for col in ("motion_overall", "motion_dims_json", "motion_reel_ref", "milestone"):
         assert legacy[col] is None, f"{col} should read NULL on a pre-migration row after _ensure_schema()"
+
+
+# ---------------------------------------------------------------------------
+# #1415 ledger unification: render_markdown folds `artifacts` + `library_metrics` into the SAME
+# qa/scores_ledger.md the `runs` table renders into (RUNBOOK-INDEX gap 2). Red-first: a fixture db
+# with rows in all three stores must show all three sections; a db with only `runs` must OMIT the
+# other two sections entirely (no stray header for an empty store).
+# ---------------------------------------------------------------------------
+def test_render_markdown_omits_artifact_and_library_sections_when_stores_empty(tmp_path):
+    db = tmp_path / "t.db"
+    md = tmp_path / "led.md"
+    scores_db.add_run("solo-run", db_path=db, surface="engine-duo", story_overall=4.0)
+    text = scores_db.render_markdown(db, md)
+    assert "## Artifact panels" not in text
+    assert "## Library metrics" not in text
+
+
+def test_render_markdown_includes_artifact_panels_section(tmp_path):
+    db = tmp_path / "t.db"
+    md = tmp_path / "led.md"
+    scores_db.add_run("r1", db_path=db, surface="engine-duo")
+    # two scored quests in the same panel + one disguised control anchored at 3.5
+    scores_db.add_artifact("quest:a", db_path=db, **{"class": "quest"}, overall=4.0,
+                           panel_id="cal-quest-1", ts="2026-07-01T00:00:00+00:00")
+    scores_db.add_artifact("quest:b", db_path=db, **{"class": "quest"}, overall=3.6,
+                           panel_id="cal-quest-1", ts="2026-07-01T00:05:00+00:00")
+    scores_db.add_artifact("quest:control", db_path=db, **{"class": "quest"}, is_control=True,
+                           control_anchor=3.5, panel_id="cal-quest-1",
+                           ts="2026-07-01T00:06:00+00:00")
+    text = scores_db.render_markdown(db, md)
+    assert "## Artifact panels" in text
+    assert "cal-quest-1" in text and "quest" in text
+    assert "IN-BAND" in text  # median 3.8 vs anchor 3.5 -> within +/-1.2
+
+
+def test_render_markdown_artifact_panel_out_of_band_verdict(tmp_path):
+    db = tmp_path / "t.db"
+    md = tmp_path / "led.md"
+    scores_db.add_artifact("npc:a", db_path=db, **{"class": "npc"}, overall=1.5,
+                           panel_id="cal-npc-1")
+    scores_db.add_artifact("npc:control", db_path=db, **{"class": "npc"}, is_control=True,
+                           control_anchor=4.0, panel_id="cal-npc-1")
+    text = scores_db.render_markdown(db, md)
+    assert "OUT-OF-BAND" in text
+
+
+def test_render_markdown_artifact_panel_no_control_verdict(tmp_path):
+    db = tmp_path / "t.db"
+    md = tmp_path / "led.md"
+    scores_db.add_artifact("loc:a", db_path=db, **{"class": "location"}, overall=4.0,
+                           panel_id="cal-loc-1")
+    text = scores_db.render_markdown(db, md)
+    assert "NO-CONTROL" in text
+
+
+def test_artifact_panel_rows_excludes_unpanelled_artifacts(tmp_path):
+    """An artifact score with no panel_id has no group to summarize into — it stays fully visible
+    in qa/artifacts_ledger.md, but is excluded from this per-panel roll-up."""
+    db = tmp_path / "t.db"
+    scores_db.add_artifact("quest:standalone", db_path=db, **{"class": "quest"}, overall=4.2)
+    assert scores_db._artifact_panel_rows(db) == []
+
+
+def test_render_markdown_includes_library_metrics_trend_section(tmp_path):
+    db = tmp_path / "t.db"
+    md = tmp_path / "led.md"
+    scores_db.add_run("r1", db_path=db, surface="engine-duo")
+    scores_db.add_library_metrics(
+        db_path=db, ts="2026-07-01T00:00:00+00:00", library_sha="aaa1111", size_total=5,
+        size_by_class_json={"quest": 3, "npc": 2}, size_by_tier_json={"stable": 5},
+        reuse_count_sum=3, notes="first snapshot",
+    )
+    scores_db.add_library_metrics(
+        db_path=db, ts="2026-07-05T00:00:00+00:00", library_sha="bbb2222", size_total=8,
+        size_by_class_json={"quest": 5, "npc": 3}, size_by_tier_json={"stable": 8},
+        reuse_count_sum=9, notes="after curation pass",
+    )
+    text = scores_db.render_markdown(db, md)
+    assert "## Library metrics" in text
+    assert "first snapshot" in text and "after curation pass" in text
+    # chronological (oldest first): the first snapshot's SHA appears before the second's
+    assert text.index("aaa1111") < text.index("bbb2222")
+
+
+def test_render_markdown_library_metrics_backlink_falls_back_to_source_path(tmp_path):
+    db = tmp_path / "t.db"
+    md = tmp_path / "led.md"
+    scores_db.add_library_metrics(db_path=db, size_total=1, source_path="library/")
+    text = scores_db.render_markdown(db, md)
+    assert "library/" in text


### PR DESCRIPTION
## Summary
- `scores_db.py --render` now emits **all three stores** into `qa/scores_ledger.md`: the runs table unchanged, plus a new `## Artifact panels` roll-up (grouped by `panel_id` → per-class median + ±1.2 control-band verdict: IN-BAND / OUT-OF-BAND / NO-CONTROL / UNSCORED) and a chronological `## Library metrics` trend (size/tier-counts/reuse + a notes/source_path back-link). Each section is cleanly omitted when its store has no groupable rows. Closes RUNBOOK-INDEX gap 2 (#1415).
- `felt_rest_panel.py`: **verified** the non-rest write path (RUNBOOK-INDEX gap 3). Verdict: the row was **never skipped** — `add_run` fires unconditionally per frame regardless of scene — but the `REST_LENSES`-only dims filter silently dropped a non-rest panel's per-lens scores (`visual_dims_json` came back empty). Fixed to pass through arbitrary dims for any scene not prefixed `rest:`.
- `motion_reel.py`: wired the Unity-capture hook (`render_state_via_unity`, ~L423 TODO) against the documented `manage_camera` pattern (`extensions/renderers/unity/BOX.md`) — env-gated on `WORLDOS_UNITY_MCP_URL` (default off, zero network I/O), fully mockable via `mcp_call=`. Code-complete + unit-tested with no box/network access; the live `:8080/mcp` round-trip shape is **unverified on this lane** (no GEX44 box access this pass) and queues behind the next box session. The engine-fetch hook (`fetch_combat_surface_states`) stays a separate, still-open TODO.
- Committed `qa/scores_ledger.md` regenerated with the new sections.

## Test plan
- [x] `qa/test_scores_db.py` (61 tests, incl. 9 new render-section tests) — green
- [x] `qa/test_felt_rest_panel.py` (12 tests, incl. 1 new non-rest write-path test) — green
- [x] `qa/test_motion_reel.py` (21 tests, incl. 7 new capture-hook tests) — green
- [x] `qa/test_artifact_evals.py` + `qa/test_library_metrics.py` — green (except one pre-existing, unrelated failure: `test_engine_duo_rulers_are_byte_unchanged`, verified failing identically on unmodified `origin/main` HEAD via `git stash`)
- [x] `qa/fast_gate.sh` — PASS (257 deterministic tests)