### PR TITLE
fix(content): re-calibrate crypt_dense_v1 impassable cells to match the painted plate (#1396)

### DIFF
--- a/qa/seed_gfx_combat.py
+++ b/qa/seed_gfx_combat.py
@@ -4,13 +4,28 @@
 The playable PoE2 3D-on-2D combat-demo seed. Pins the well-known campaign id the box
 renderer hardcodes (paint_combat_v1.cs / paint_backdrop_p0.cs CID="camp_gfxdemo01"),
 seats a fighter PC + a goblin on a 14x11 grid whose OBSTACLE cells match the crypt's
-painted-prop occluders (pillarL(2,3) / pillarR(11,3) / sarcophagus(7,1)), places
-hero@(6,6) / goblin@(9,5), and starts combat. After this, GET /combat-surface?campaign=
-camp_gfxdemo01 returns real engine cells (positionAuthority='grid') for the READ-ONLY
-renderer to consume + the M-B bridge routes movement around exactly the painted props.
+painted-prop occluders on the deployed `crypt_dense_v1.png` plate (pillarL(2,4) /
+pillarR(9,9) / sarcophagus(3,8)+(4,8) — see #1396), places hero@(6,6) / goblin@(9,5),
+and starts combat. After this, GET /combat-surface?campaign=camp_gfxdemo01 returns real
+engine cells (positionAuthority='grid') for the READ-ONLY renderer to consume + the M-B
+bridge routes movement around exactly the painted props.
 
   # NOTE: uv --directory cd's into servers/engine first, so pass the script by ABSOLUTE path:
   WORLDOS_STATE_DIR=<dir> uv run --directory servers/engine python "$PWD/qa/seed_gfx_combat.py" <state_dir>
+
+#1396 content fix (2026-07-08): the ORIGINAL cells here — pillarL(2,3) / pillarR(11,3) /
+sarcophagus(7,1) — matched the OLDER `crypt_firelit_v2` greybox-conditioned plate
+(`paint_backdrop_p0.cs` OCC_ cells), but the currently-deployed `crypt_dense_v1.png` went
+through a later Gemini polish+populate repaint pass (CANONICAL.md) that recomposed the
+room WITHOUT re-deriving prop cells from the greybox — so the engine's impassable set
+drifted from the paint (#1396: "actor on the sarcophagus"). The cells below were
+RE-CALIBRATED against the deployed plate: the `qa/export_scene_grid.py`-style contract
+camera (orthographic, size=13, `Euler(30,45,0)`, `cellToWorld`) was replayed against the
+real capture frames in `qa/evidence/1397/` + `qa/evidence/1408/` (their logical_cell ->
+screen_bbox/floor_y_px manifests reproduce EXACTLY, pixel-for-pixel, confirming the
+camera model), then the SAME projection was grid-overlaid on `qa/evidence/1392/*.jpg`
+(live captures of `crypt_dense_v1.png`) to read off where the pillars/sarcophagus
+actually sit in the paint. Engine untouched; this is a content-only re-authoring.
 
 Engine = SOLE WRITER: writes only via server.* engine calls + save_campaign. Additive
 (a new seed; touches no existing seed/contract).
@@ -22,15 +37,21 @@ import sys
 
 CID = "camp_gfxdemo01"
 GRID_W, GRID_H = 14, 11
-OBSTACLES = [[2, 3], [11, 3], [7, 1]]  # == paint_backdrop_p0.cs OCC_ cells == engine impassable
+# Prop footprints re-calibrated to the DEPLOYED crypt_dense_v1.png plate (#1396). Each entry is a
+# footprint (list of [c, r] cells); OBSTACLES flattens them for the printed summary below.
+PILLAR_L_CELLS = [[2, 4]]
+PILLAR_R_CELLS = [[9, 9]]
+SARCOPHAGUS_CELLS = [[3, 8], [4, 8]]  # ~2-cell footprint under the painted sarcophagus box
+OBSTACLES = PILLAR_L_CELLS + PILLAR_R_CELLS + SARCOPHAGUS_CELLS
 HERO_CELL = [6, 6]
 GOBLIN_CELL = [9, 5]
 
 
-def _author_crypt_grid(server, cid: str) -> None:
-    """Attach a 14x11 crypt scene_grid whose PROP footprints are EXACTLY the combat OBSTACLES, so the
-    greybox->img2img painted room and the combat pathing share one source (the props ARE the obstacles).
-    Replaces the auto-generated dungeon grid (14..17 wide -> mismatched the fixed 14x11 combat contract)."""
+def _build_crypt_grid(cid: str, location_id: str = ""):
+    """Pure grid builder (no server dependency) — a 14x11 crypt scene_grid whose PROP footprints
+    match the painted crypt_dense_v1.png plate (#1396), so the pathing and the paint agree. Kept
+    separate from `_author_crypt_grid` so it's directly unit-testable (validate_scene_grid +
+    impassable_cells) without spinning up a full campaign/server."""
     from scene_grid import (  # noqa: PLC0415
         SceneGrid, SceneGridSpec, SceneCell, SceneCellDefault, SceneProp, SceneLighting, _layout_hash,
     )
@@ -47,19 +68,22 @@ def _author_crypt_grid(server, cid: str) -> None:
 
     props: list = []
 
-    def _prop(pid: str, kind: str, cell: list, band: str, sil: str) -> None:
-        props.append(SceneProp(id=pid, kind=kind, cells=[(cell[0], cell[1])],
-                               anchor_cell=(cell[0], cell[1]), occluder=True,
+    def _prop(pid: str, kind: str, footprint: list, band: str, sil: str) -> None:
+        anchor = footprint[0]
+        props.append(SceneProp(id=pid, kind=kind, cells=[(c0, r0) for (c0, r0) in footprint],
+                               anchor_cell=(anchor[0], anchor[1]), occluder=True,
                                height_band=band, silhouette=sil))
-        cells.append(SceneCell(c=cell[0], r=cell[1], type="prop", walkable=False, prop_ref=pid))
+        for (c0, r0) in footprint:
+            cells.append(SceneCell(c=c0, r=r0, type="prop", walkable=False, prop_ref=pid))
 
-    # the THREE obstacle props — footprints == OBSTACLES (kept in lock-step with set_grid below).
-    _prop("pillar_l", "stone_pillar", OBSTACLES[0], "tall", "ancient cracked stone pillar")
-    _prop("pillar_r", "stone_pillar", OBSTACLES[1], "tall", "ancient mossy stone pillar")
-    _prop("sarcophagus", "sarcophagus", OBSTACLES[2], "tall", "carved stone sarcophagus, lid ajar")
+    # the THREE obstacle props — footprints == PILLAR_L_CELLS/PILLAR_R_CELLS/SARCOPHAGUS_CELLS
+    # (kept in lock-step with set_grid below via OBSTACLES).
+    _prop("pillar_l", "stone_pillar", PILLAR_L_CELLS, "tall", "ancient cracked stone pillar")
+    _prop("pillar_r", "stone_pillar", PILLAR_R_CELLS, "tall", "ancient mossy stone pillar")
+    _prop("sarcophagus", "sarcophagus", SARCOPHAGUS_CELLS, "tall", "carved stone sarcophagus, lid ajar")
 
     grid = SceneGrid(
-        scene_id=f"{cid}:crypt", location_id="", kind="dungeon",
+        scene_id=f"{cid}:crypt", location_id=location_id, kind="dungeon",
         biome="ancient stone crypt, flickering brazier light",
         grid=SceneGridSpec(cols=cols, rows=rows, cell_size_ft=5, projection="dimetric-2to1"),
         cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
@@ -68,10 +92,15 @@ def _author_crypt_grid(server, cid: str) -> None:
                                mood="dim torchlit crypt, warm brazier glow, cold blue shadow fill"),
     )
     grid.art.layout_hash = _layout_hash(grid)
+    return grid
 
+
+def _author_crypt_grid(server, cid: str):
+    """Attach a 14x11 crypt scene_grid (see `_build_crypt_grid`) to the campaign's current location.
+    Replaces the auto-generated dungeon grid (14..17 wide -> mismatched the fixed 14x11 combat contract)."""
     c = server._require(cid)
     loc = c.locations.get(c.current_location_id)
-    grid.location_id = loc.id
+    grid = _build_crypt_grid(cid, loc.id)
     loc.scene_grid = grid
     server.save_campaign(c)
     return grid

--- a/qa/test_seed_gfx_combat.py
+++ b/qa/test_seed_gfx_combat.py
@@ -1,0 +1,84 @@
+"""Self-tests for qa/seed_gfx_combat.py's authored crypt scene_grid (#1396).
+
+#1396: crypt_dense_v1's engine impassable cells didn't match the PAINTED plate props — the
+scene_grid carried the OLDER crypt_firelit_v2 greybox cells (pillarL(2,3) / pillarR(11,3) /
+sarcophagus(7,1)), but the deployed crypt_dense_v1.png plate (after a Gemini polish+populate
+repaint pass) shows the pillars + sarcophagus at different cells, so actors could be placed
+"on" the painted sarcophagus with no pathing obstacle underneath them.
+
+This is a RED-FIRST regression: before the #1396 content fix, the sarcophagus footprint
+below was NOT impassable (it sat at the stale (7,1) cell instead), so this test would have
+failed against the pre-fix seed. Cell values re-derived by projecting the qa/export_scene_grid.py
+contract camera (orthographic, size=13, Euler(30,45,0)) onto the live crypt_dense_v1.png
+captures in qa/evidence/1392/*.jpg, calibrated against the logical_cell -> screen_bbox/
+floor_y_px manifests in qa/evidence/1397/ + qa/evidence/1408/ (which reproduce pixel-exact
+under that camera model).
+
+Run with the engine venv (pydantic + pytest live there):
+    uv run --directory servers/engine python -m pytest ../../qa/test_seed_gfx_combat.py -p no:cacheprovider
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "qa"))
+sys.path.insert(0, str(_ROOT / "servers" / "engine"))
+
+import server  # noqa: E402,F401  imported FIRST: resolves the models<->scene_grid import cycle
+import seed_gfx_combat as sg  # noqa: E402
+from scene_grid import validate_scene_grid, impassable_cells  # noqa: E402
+
+
+def _grid():
+    return sg._build_crypt_grid(sg.CID, "loc-test")
+
+
+def test_scene_grid_has_zero_validate_violations():
+    """The pre-greybox gate (door zones / protected lanes / connectivity) must stay clean."""
+    grid = _grid()
+    assert validate_scene_grid(grid, sg.GRID_W, sg.GRID_H) == []
+
+
+def test_sarcophagus_footprint_is_impassable():
+    """#1396 RED-FIRST: the painted sarcophagus's footprint on crypt_dense_v1.png — (3,8) and
+    (4,8) — must be an engine pathing obstacle, so no actor can be placed standing on it. This
+    is the exact "actor on the sarcophagus" felt-bug the issue names; before the fix, the
+    scene_grid's only sarcophagus cell was the stale (7,1), so this assertion failed."""
+    grid = _grid()
+    imp = impassable_cells(grid, sg.GRID_W, sg.GRID_H)
+    assert sg.SARCOPHAGUS_CELLS == [[3, 8], [4, 8]]
+    for cell in sg.SARCOPHAGUS_CELLS:
+        assert cell in imp, f"sarcophagus cell {cell} must be impassable (paint/grid registration gap, #1396)"
+
+
+def test_pillars_match_painted_cells():
+    """Both pillar footprints must sit on their re-calibrated painted cells, not the stale
+    crypt_firelit_v2 positions (2,3)/(11,3)."""
+    grid = _grid()
+    imp = impassable_cells(grid, sg.GRID_W, sg.GRID_H)
+    assert sg.PILLAR_L_CELLS == [[2, 4]]
+    assert sg.PILLAR_R_CELLS == [[9, 9]]
+    assert [2, 4] in imp
+    assert [9, 9] in imp
+    # the STALE pre-#1396 prop cells must no longer be authored as prop footprints.
+    prop_cells = {(c0, r0) for prop in grid.props for (c0, r0) in prop.cells}
+    assert (2, 3) not in prop_cells
+    assert (11, 3) not in prop_cells
+    assert (7, 1) not in prop_cells
+
+
+def test_hero_and_goblin_spawn_cells_stay_walkable():
+    """The fixed hero(6,6)/goblin(9,5) spawn cells must never collide with the corrected prop
+    footprints — a content fix here must not accidentally trap the demo's own combatants."""
+    grid = _grid()
+    imp = impassable_cells(grid, sg.GRID_W, sg.GRID_H)
+    assert sg.HERO_CELL not in imp
+    assert sg.GOBLIN_CELL not in imp
+
+
+def test_obstacles_list_matches_authored_props():
+    """OBSTACLES (used for the printed seed summary + kept in lock-step with set_grid) must be
+    exactly the flattened pillar/sarcophagus footprints — no silent drift between the two."""
+    assert sg.OBSTACLES == sg.PILLAR_L_CELLS + sg.PILLAR_R_CELLS + sg.SARCOPHAGUS_CELLS


### PR DESCRIPTION
## Summary
- `qa/seed_gfx_combat.py`'s scene_grid still carried the OLDER `crypt_firelit_v2` greybox-conditioned prop cells — pillarL(2,3) / pillarR(11,3) / sarcophagus(7,1) — but the currently-deployed `crypt_dense_v1.png` plate went through a later Gemini polish+populate repaint (CANONICAL.md) that recomposed the room without re-deriving prop cells from the greybox, so the engine's impassable set drifted from the paint: an actor could be placed standing on the painted sarcophagus with no pathing obstacle underneath it (#1396).
- Re-derived the true painted-prop cells by replaying the `qa/export_scene_grid.py` contract camera (orthographic size=13, `Euler(30,45,0)`, `cellToWorld`) against real `crypt_dense_v1.png` captures in `qa/evidence/1392/*.jpg`, calibrated against the `logical_cell -> screen_bbox/floor_y_px` manifests in `qa/evidence/1397` + `qa/evidence/1408` (which reproduce pixel-exact under that camera model — strong confirmation the model is correct before trusting it on the crypt captures).
- Content-only fix — engine untouched, additive (`servers/engine/scene_grid.py` and its API are unchanged).

### Prop → cell map (old → corrected)
| prop | old (crypt_firelit_v2) | corrected (crypt_dense_v1) |
|---|---|---|
| pillar_l | (2,3) | (2,4) |
| pillar_r | (11,3) | (9,9) |
| sarcophagus | (7,1) — 1 cell | (3,8) + (4,8) — 2-cell footprint |

## Changes
- `qa/seed_gfx_combat.py` — extracted a pure `_build_crypt_grid()` builder (no server dependency, directly unit-testable) from `_author_crypt_grid()`; replaced the stale `OBSTACLES` triple with `PILLAR_L_CELLS` / `PILLAR_R_CELLS` / `SARCOPHAGUS_CELLS` at the re-calibrated cells; `_prop()` now takes a footprint (list of cells) instead of a single cell, so the sarcophagus can carry its 2-cell footprint.
- `qa/test_seed_gfx_combat.py` (new) — `validate_scene_grid` == 0 violations; a **red-first regression** pinning the sarcophagus footprint as impassable (verified to fail under the pre-fix cells: the old authoring left (3,8)/(4,8) walkable); pillar cells match the paint; the stale (2,3)/(11,3)/(7,1) cells are gone from the authored props; hero(6,6)/goblin(9,5) spawn cells stay walkable (no self-trap regression).

## Test plan
- [x] `uv run --directory servers/engine python -m pytest ../../qa/test_seed_gfx_combat.py -p no:cacheprovider -v` — 5 passed
- [x] Confirmed red-first: re-running the new assertions against the OLD cell values shows `(3,8)`/`(4,8)` were walkable pre-fix (the exact "actor on the sarcophagus" bug)
- [x] `uv run --directory servers/engine python "$PWD/qa/seed_gfx_combat.py" <tmpdir>` — seed runs clean, `impassable_total: 50`
- [x] `bash qa/fast_gate.sh` — 257 passed
- [ ] Live render validation (crypt_dense_v1.png on the GEX44 box, visual-critic pass confirming the actor no longer stands on the painted sarcophagus) queues behind the next box session — this PR is the content/pathing fix only, admin-merge per #1389.