### PR TITLE
feat(macos): W5 player-build launch handoff (#1322)

### DIFF
--- a/macos/WorldOSApp/Sources/WorldOSApp/Services/AppProcessService.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Services/AppProcessService.swift
@@ -15,6 +15,7 @@ final class AppProcessService: ObservableObject {
     private var providerProcess: ManagedProcess?
     private var intentionallyStoppingProviderPIDs: Set<Int32> = []
     private let registry = ProviderRegistry()
+    private let playerLauncher = PlayerLauncher()
     private let maxLogCharacters = 120_000
 
     var activeProviderOpenWorldsURL: URL? {
@@ -283,6 +284,34 @@ final class AppProcessService: ObservableObject {
         guard var endpoint = viewerEndpoint, endpoint.name == "Provider viewer" else { return }
         endpoint.status = .running
         viewerEndpoint = endpoint
+    }
+
+    /// Hand the active campaign off to the standalone Unity **player build** (issue #1322 / W5).
+    /// Additive + defaulted: when no `WorldOSPlayer.app` is installed (configured path or default)
+    /// this is a no-op returning `.notConfigured`, and the app behaves exactly as before. The player
+    /// is launched BESIDE the app as an INDEPENDENT process — its exit never affects the running
+    /// viewer/provider (engine), and a repeat call is idempotent (an already-running player is
+    /// activated, not duplicated). The base URL handed over is the ORIGIN the player consumes
+    /// (`/combat-surface`, `/events`, `POST /move`) — not the `/openworlds/` UI path.
+    @discardableResult
+    func launchPlayer(playerAppPath: String) -> PlayerLaunchOutcome {
+        guard let endpoint = viewerEndpoint, endpoint.status != .stopped else {
+            append("Player launch skipped: no running engine/viewer to hand off.", stream: .supervisor)
+            return .notConfigured
+        }
+        let outcome = playerLauncher.launch(
+            configuredPath: playerAppPath,
+            baseURL: endpoint.url,
+            campaignID: activeCampaignID
+        )
+        switch outcome {
+        case .notConfigured:
+            append("Player launch: no \(PlayerLaunchContract.defaultAppName) found (configured or default) — player tier absent.", stream: .supervisor)
+        case let .launch(invocation):
+            let base = invocation.environment[PlayerLaunchContract.baseURLKey] ?? endpoint.url.absoluteString
+            append("Launched WorldOS player at \(invocation.appURL.path) → \(base)", stream: .supervisor)
+        }
+        return outcome
     }
 
     func stopProvider() {

--- a/macos/WorldOSApp/Sources/WorldOSApp/Services/PlayerLauncher.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Services/PlayerLauncher.swift
@@ -1,0 +1,158 @@
+import Foundation
+#if canImport(AppKit)
+import AppKit
+#endif
+
+/// THE launch contract between the macOS app and the standalone Unity **player build** (issue
+/// #1322 / W5; formalizes docs/roadmap/RENDER-DELIVERY-DECISION.md — Unity launched BESIDE the app,
+/// renderer = PURE CONSUMER, input = the existing `POST /move` kinds only).
+///
+/// The app hands the campaign off through **environment variables set on the launched player
+/// process** — the SAME mechanism `AppProcessService` already uses to hand the campaign id + roots
+/// to the viewer/provider children (`launchManagedProcess`'s env overlay). We deliberately pick env
+/// vars over a plist/config-file beside the `.app`:
+///   - it mirrors the existing bridge idiom exactly (one env dict, applied at launch);
+///   - nothing is written to disk, so there is no stale-config hazard, no cleanup, and nothing to
+///     reconcile on an idempotent relaunch (keeps the pure-consumer invariant crisp — the player
+///     is not even a *disk* writer);
+///   - each handoff carries a fresh base URL + campaign id atomically with the launch.
+///
+/// The player reads these two vars at startup (`System.Environment.GetEnvironmentVariable(...)`) and
+/// renders the engine surfaces (`/combat-surface`, `/events`) at `BASE_URL` for `CAMPAIGN_ID`,
+/// posting move-intents through the existing `/move` kinds. Absent → the player shows its own idle
+/// / no-campaign state. It NEVER writes engine state and defines NO new endpoint.
+enum PlayerLaunchContract {
+    /// Engine/viewer base origin the player consumes (e.g. `http://127.0.0.1:8765`).
+    static let baseURLKey = "WORLDOS_ENGINE_BASE_URL"
+    /// Active campaign id to render (omitted when there is no active campaign).
+    static let campaignIDKey = "WORLDOS_CAMPAIGN_ID"
+    /// Default player bundle name, looked up under `~/Applications` then `/Applications`.
+    static let defaultAppName = "WorldOSPlayer.app"
+}
+
+/// A fully-resolved, side-effect-free description of ONE player launch: which bundle to open, the
+/// env payload to hand it, and whether to spawn a fresh instance. Pure value type so tests can
+/// assert the exact invocation without touching LaunchServices.
+struct PlayerLaunchInvocation: Equatable {
+    let appURL: URL
+    let environment: [String: String]
+    /// Always `false`: an already-running player is ACTIVATED (brought forward), never duplicated —
+    /// this is what makes a repeat launch idempotent at the LaunchServices layer.
+    let createsNewInstance: Bool
+}
+
+/// Outcome of a launch request. `.notConfigured` is the additive-by-default identity: when no
+/// player `.app` is installed, NOTHING is launched and the app behaves exactly as it does on `main`
+/// today (the rendered tier is simply absent).
+enum PlayerLaunchOutcome: Equatable {
+    case notConfigured
+    case launch(PlayerLaunchInvocation)
+}
+
+/// Launches the standalone Unity player BESIDE the app and hands off the campaign. The player is an
+/// INDEPENDENT LaunchServices process: the app holds no handle to it and wires no termination
+/// callback, so the player's exit can never touch the engine (viewer/provider) processes, and the
+/// engine's lifecycle never depends on the player.
+@MainActor
+final class PlayerLauncher: ObservableObject {
+    /// The bundle URL of the most recently launched player (nil until a successful launch), for
+    /// diagnostics / UI affordances.
+    @Published private(set) var launchedPlayerURL: URL?
+
+    private let fileExists: (String) -> Bool
+    private let openInvocation: (PlayerLaunchInvocation) -> Void
+
+    /// - Parameters:
+    ///   - fileExists: probes whether a candidate `.app` bundle is present (injectable for tests).
+    ///   - open: performs the real LaunchServices launch (injectable seam; defaults to NSWorkspace).
+    init(
+        fileExists: @escaping (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
+        open: @escaping (PlayerLaunchInvocation) -> Void = PlayerLauncher.openWithWorkspace
+    ) {
+        self.fileExists = fileExists
+        self.openInvocation = open
+    }
+
+    /// Resolve + launch. Returns the outcome so the caller can surface it (e.g. log a no-op when the
+    /// player tier is absent). A `.notConfigured` result performs no side effects at all.
+    @discardableResult
+    func launch(configuredPath: String, baseURL: URL, campaignID: String?) -> PlayerLaunchOutcome {
+        let outcome = PlayerLauncher.resolveOutcome(
+            configuredPath: configuredPath,
+            baseURL: baseURL,
+            campaignID: campaignID,
+            homeDirectory: FileManager.default.homeDirectoryForCurrentUser,
+            fileExists: fileExists
+        )
+        if case let .launch(invocation) = outcome {
+            openInvocation(invocation)
+            launchedPlayerURL = invocation.appURL
+        }
+        return outcome
+    }
+
+    // MARK: - Pure resolution (hermetic; no filesystem/LaunchServices side effects)
+
+    /// Build the launch outcome from inputs. Pure aside from the injected `fileExists` probe.
+    static func resolveOutcome(
+        configuredPath: String,
+        baseURL: URL,
+        campaignID: String?,
+        homeDirectory: URL,
+        fileExists: (String) -> Bool
+    ) -> PlayerLaunchOutcome {
+        guard let appURL = locatePlayerApp(
+            configuredPath: configuredPath,
+            homeDirectory: homeDirectory,
+            fileExists: fileExists
+        ) else {
+            return .notConfigured
+        }
+        var environment = [PlayerLaunchContract.baseURLKey: baseURL.absoluteString]
+        let campaign = campaignID?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !campaign.isEmpty {
+            environment[PlayerLaunchContract.campaignIDKey] = campaign
+        }
+        return .launch(
+            PlayerLaunchInvocation(appURL: appURL, environment: environment, createsNewInstance: false)
+        )
+    }
+
+    /// First existing candidate wins: an explicit configured path (tilde-expanded), then
+    /// `~/Applications/WorldOSPlayer.app`, then `/Applications/WorldOSPlayer.app`. Returns nil when
+    /// none exist → `.notConfigured` (today's behavior, byte-identical).
+    static func locatePlayerApp(
+        configuredPath: String,
+        homeDirectory: URL,
+        fileExists: (String) -> Bool
+    ) -> URL? {
+        var candidates: [URL] = []
+        let trimmed = configuredPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            candidates.append(URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath))
+        }
+        candidates.append(homeDirectory.appendingPathComponent("Applications/\(PlayerLaunchContract.defaultAppName)"))
+        candidates.append(URL(fileURLWithPath: "/Applications/\(PlayerLaunchContract.defaultAppName)"))
+        return candidates.first { fileExists($0.path) }
+    }
+
+    // MARK: - Real launch seam
+
+    /// Launch via `NSWorkspace.openApplication(at:configuration:)`, carrying the campaign handoff in
+    /// `configuration.environment`. `createsNewApplicationInstance = false` makes a repeat launch
+    /// idempotent (an already-running player is activated, not duplicated). The completion handler
+    /// intentionally holds NO reference to any engine process — player launch is fire-and-forget and
+    /// fully decoupled from the viewer/provider lifecycle.
+    nonisolated private static func openWithWorkspace(_ invocation: PlayerLaunchInvocation) {
+        #if canImport(AppKit)
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.environment = invocation.environment
+        configuration.createsNewApplicationInstance = invocation.createsNewInstance
+        configuration.activates = true
+        NSWorkspace.shared.openApplication(at: invocation.appURL, configuration: configuration) { _, _ in
+            // No-op: independent process; a launch error surfaces only via the returned outcome path,
+            // and player exit never affects the engine.
+        }
+        #endif
+    }
+}

--- a/macos/WorldOSApp/Sources/WorldOSApp/Views/PlayView.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Views/PlayView.swift
@@ -26,6 +26,11 @@ struct PlayView: View {
     @Binding var maxTurns: String
     @Binding var webURL: URL?
 
+    // Additive (issue #1322 / W5): path to the standalone Unity player `.app`. Empty → the default
+    // ~/Applications/WorldOSPlayer.app is used; if neither exists the launch is a defaulted no-op.
+    // Read directly from UserDefaults so no binding has to be threaded through RootView.
+    @AppStorage("playerAppPath") private var playerAppPath: String = ""
+
     @State private var runID: String = PlayView.newRunID()
     @State private var companions: String = ""
     @State private var alertMessage: String?
@@ -83,6 +88,11 @@ struct PlayView: View {
                     Label("Start Game", systemImage: "play.fill")
                 }
                 .buttonStyle(.borderedProminent)
+                Button {
+                    openInPlayer()
+                } label: {
+                    Label("Open in Player", systemImage: "cube.transparent")
+                }
                 Button {
                     processService.stopProvider()
                     processService.stopViewer()
@@ -172,6 +182,15 @@ struct PlayView: View {
             )
         } catch {
             alertMessage = error.localizedDescription
+        }
+    }
+
+    /// Hand the running engine's campaign off to the standalone Unity player (issue #1322 / W5).
+    /// A defaulted no-op when no player `.app` is installed; surfaces a hint if there is no engine.
+    private func openInPlayer() {
+        let outcome = processService.launchPlayer(playerAppPath: playerAppPath)
+        if case .notConfigured = outcome, processService.viewerEndpoint?.status == nil {
+            alertMessage = "Start a viewer or game session before opening the player."
         }
     }
 

--- a/macos/WorldOSApp/Sources/WorldOSApp/Views/SettingsView.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Views/SettingsView.swift
@@ -26,12 +26,17 @@ struct SettingsView: View {
 
     @State private var preferredPortText = ""
 
+    // Additive (issue #1322 / W5): standalone Unity player `.app` path. Empty → the default
+    // ~/Applications/WorldOSPlayer.app. Read directly from UserDefaults (no RootView binding).
+    @AppStorage("playerAppPath") private var playerAppPath: String = ""
+
     var body: some View {
         Form {
             Section("Workspace") {
                 ValidatedTextField("Repo path", text: $repoPath, error: repoPathError)
                 ValidatedTextField("Private art repo path", text: $artRepoPath, error: artRepoPathError)
                 TextField("State directory", text: $stateDir)
+                TextField("Player app path (blank = ~/Applications/WorldOSPlayer.app)", text: $playerAppPath)
                 VStack(alignment: .leading, spacing: 6) {
                     HStack {
                         ValidatedTextField("Preferred port", text: $preferredPortText, error: preferredPortError)

--- a/macos/WorldOSApp/Tests/WorldOSAppTests/PlayerLauncherTests.swift
+++ b/macos/WorldOSApp/Tests/WorldOSAppTests/PlayerLauncherTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+
+@testable import WorldOSApp
+
+/// Unit tests for the standalone Unity **player** launch handoff (issue #1322 / W5). These exercise
+/// the pure resolution logic (`resolveOutcome` / `locatePlayerApp`) and the injectable launch seam,
+/// and are deliberately hermetic: they mock the `.app` presence via an injected `fileExists` probe
+/// and capture the launch invocation via an injected `open` closure — never touching the real
+/// filesystem, LaunchServices, or an actual app launch.
+@MainActor
+final class PlayerLauncherTests: XCTestCase {
+
+    private let home = URL(fileURLWithPath: "/Users/tester")
+    private let baseURL = URL(string: "http://127.0.0.1:8765")!
+
+    // MARK: - resolveOutcome (pure)
+
+    /// Configured player present → launch with the exact env payload (base URL + campaign id) and
+    /// the configured bundle path. This is the primary contract assertion.
+    func testResolveLaunchesConfiguredPlayerWithContractEnvironment() {
+        let configured = "/Users/tester/Games/WorldOSPlayer.app"
+        let outcome = PlayerLauncher.resolveOutcome(
+            configuredPath: configured,
+            baseURL: baseURL,
+            campaignID: "camp-42",
+            homeDirectory: home,
+            fileExists: { $0 == configured }
+        )
+        guard case let .launch(invocation) = outcome else {
+            return XCTFail("expected .launch, got \(outcome)")
+        }
+        XCTAssertEqual(invocation.appURL, URL(fileURLWithPath: configured))
+        XCTAssertEqual(invocation.environment[PlayerLaunchContract.baseURLKey], "http://127.0.0.1:8765")
+        XCTAssertEqual(invocation.environment[PlayerLaunchContract.campaignIDKey], "camp-42")
+        // Idempotent-relaunch guarantee: never spawn a duplicate instance.
+        XCTAssertFalse(invocation.createsNewInstance)
+    }
+
+    /// No configured path → fall back to the default `~/Applications/WorldOSPlayer.app`.
+    func testResolveFallsBackToDefaultHomeApplications() {
+        let expected = home.appendingPathComponent("Applications/WorldOSPlayer.app").path
+        let outcome = PlayerLauncher.resolveOutcome(
+            configuredPath: "",
+            baseURL: baseURL,
+            campaignID: "camp-1",
+            homeDirectory: home,
+            fileExists: { $0 == expected }
+        )
+        guard case let .launch(invocation) = outcome else {
+            return XCTFail("expected .launch, got \(outcome)")
+        }
+        XCTAssertEqual(invocation.appURL.path, expected)
+    }
+
+    /// An explicit configured path is preferred over the default when both exist.
+    func testResolvePrefersConfiguredOverDefault() {
+        let configured = "/opt/WorldOSPlayer.app"
+        let outcome = PlayerLauncher.resolveOutcome(
+            configuredPath: configured,
+            baseURL: baseURL,
+            campaignID: nil,
+            homeDirectory: home,
+            fileExists: { _ in true } // everything "exists" → configured must still win
+        )
+        guard case let .launch(invocation) = outcome else {
+            return XCTFail("expected .launch, got \(outcome)")
+        }
+        XCTAssertEqual(invocation.appURL, URL(fileURLWithPath: configured))
+    }
+
+    /// No campaign id → the campaign var is OMITTED (never emitted empty); base URL still handed over.
+    func testResolveOmitsCampaignWhenAbsent() {
+        let configured = "/opt/WorldOSPlayer.app"
+        for campaign in [nil, "", "   "] as [String?] {
+            let outcome = PlayerLauncher.resolveOutcome(
+                configuredPath: configured,
+                baseURL: baseURL,
+                campaignID: campaign,
+                homeDirectory: home,
+                fileExists: { _ in true }
+            )
+            guard case let .launch(invocation) = outcome else {
+                return XCTFail("expected .launch for campaign=\(String(describing: campaign))")
+            }
+            XCTAssertNil(invocation.environment[PlayerLaunchContract.campaignIDKey],
+                         "campaign var must be omitted for \(String(describing: campaign))")
+            XCTAssertEqual(invocation.environment[PlayerLaunchContract.baseURLKey], "http://127.0.0.1:8765")
+        }
+    }
+
+    /// BYTE-IDENTITY / today's-behavior path: no player `.app` anywhere → `.notConfigured`, i.e.
+    /// nothing is launched and the app behaves exactly as it does without the player tier.
+    func testResolveNoPlayerInstalledIsNotConfigured() {
+        let outcome = PlayerLauncher.resolveOutcome(
+            configuredPath: "",
+            baseURL: baseURL,
+            campaignID: "camp-1",
+            homeDirectory: home,
+            fileExists: { _ in false } // nothing exists
+        )
+        XCTAssertEqual(outcome, .notConfigured)
+    }
+
+    // MARK: - launch() side-effect seam
+
+    /// A resolvable launch invokes the injected open seam EXACTLY once with the resolved invocation.
+    func testLaunchInvokesOpenSeamOnceWithInvocation() {
+        var captured: [PlayerLaunchInvocation] = []
+        let configured = "/opt/WorldOSPlayer.app"
+        let launcher = PlayerLauncher(
+            fileExists: { $0 == configured },
+            open: { captured.append($0) }
+        )
+        let outcome = launcher.launch(configuredPath: configured, baseURL: baseURL, campaignID: "camp-9")
+
+        XCTAssertEqual(captured.count, 1)
+        XCTAssertEqual(captured.first?.appURL, URL(fileURLWithPath: configured))
+        XCTAssertEqual(captured.first?.environment[PlayerLaunchContract.campaignIDKey], "camp-9")
+        XCTAssertEqual(launcher.launchedPlayerURL, URL(fileURLWithPath: configured))
+        if case .notConfigured = outcome { XCTFail("expected .launch") }
+    }
+
+    /// When there is no player, launch() performs ZERO side effects: the open seam is never called
+    /// and no launched URL is recorded (defaulted no-op == today's behavior).
+    func testLaunchNoPlayerIsPureNoOp() {
+        var openCalls = 0
+        let launcher = PlayerLauncher(
+            fileExists: { _ in false },
+            open: { _ in openCalls += 1 }
+        )
+        let outcome = launcher.launch(configuredPath: "", baseURL: baseURL, campaignID: "camp-1")
+
+        XCTAssertEqual(outcome, .notConfigured)
+        XCTAssertEqual(openCalls, 0)
+        XCTAssertNil(launcher.launchedPlayerURL)
+    }
+
+    /// Idempotent relaunch: repeated launches always resolve `createsNewInstance == false`, so
+    /// LaunchServices activates the existing player instead of duplicating it.
+    func testRepeatedLaunchIsIdempotentSingleInstance() {
+        var captured: [PlayerLaunchInvocation] = []
+        let configured = "/opt/WorldOSPlayer.app"
+        let launcher = PlayerLauncher(
+            fileExists: { $0 == configured },
+            open: { captured.append($0) }
+        )
+        launcher.launch(configuredPath: configured, baseURL: baseURL, campaignID: "camp-1")
+        launcher.launch(configuredPath: configured, baseURL: baseURL, campaignID: "camp-1")
+
+        XCTAssertEqual(captured.count, 2)
+        XCTAssertTrue(captured.allSatisfy { !$0.createsNewInstance },
+                      "every relaunch must reuse the running instance (idempotent)")
+    }
+}


### PR DESCRIPTION
## What
Additive Mac-side launch path that hands the active campaign off to the standalone Unity **player build**, mirroring `AppProcessService`'s existing env-dict handoff idiom. Formalizes `docs/roadmap/RENDER-DELIVERY-DECISION.md`: the player is launched **beside** the app; renderer = **pure consumer**; input = the **existing `POST /move` kinds only**. Part 2 of W5a (issue #1322).

The GEX44 box build lane delivers `WorldOSPlayer.app` in parallel — this PR is built against the documented contract below and a faked `.app` (injected `fileExists`) so it lands independent of that artifact.

## THE CONTRACT (so the build lane aligns)
The app hands the campaign off via **environment variables set on the launched player process** (the same mechanism `AppProcessService.launchManagedProcess` already uses to hand campaign id + roots to the viewer/provider). The player reads these at startup (`System.Environment.GetEnvironmentVariable(...)`):

| Env var | Meaning |
|---|---|
| `WORLDOS_ENGINE_BASE_URL` | engine/viewer **origin** the player consumes — `/combat-surface`, `/events`, `POST /move` (e.g. `http://127.0.0.1:8765`) |
| `WORLDOS_CAMPAIGN_ID` | active campaign to render; **omitted** when there is no active campaign |

Absent → the player shows its own idle / no-campaign state. It NEVER writes engine state and defines NO new endpoint.

**Player `.app` location:** new additive `playerAppPath` preference. Blank → default `~/Applications/WorldOSPlayer.app`, then `/Applications/WorldOSPlayer.app`. None present → `.notConfigured` no-op (today's behavior byte-identical).

**Launch mechanism:** `NSWorkspace.openApplication(at:configuration:)` with `configuration.environment` carrying the contract and `createsNewApplicationInstance = false` → **idempotent relaunch** (an already-running player is activated, not duplicated). The player is an **independent** LaunchServices process; no termination handler is wired to the viewer/provider, so **player exit never touches the engine**.

Chose env vars over a plist/config-file beside the `.app`: mirrors the existing bridge idiom, writes nothing to disk (no stale-config hazard / no cleanup / no reconcile-on-relaunch), and keeps the pure-consumer invariant crisp.

## Invariants
- Zero new engine endpoints; zero new writers (renderer stays a pure consumer).
- Additive + defaulted: no player installed ⇒ identical to `main` today.

## Tests
- `PlayerLauncherTests` (XCTest, hermetic — mocks `.app` presence + captures the launch invocation/env payload): contract env payload, default-path fallback, configured-over-default, campaign omission, **byte-identity `.notConfigured` no-op**, single-invocation seam, idempotent relaunch.
- `swift build` warning-clean; `qa/fast_gate.sh` = **257 passed** (engine byte-identical — zero Python touched).
- XCTest executes in the `macOS Swift` CI job (this dev host is CommandLineTools-only, no XCTest — documented in the workflow).

## Merge
Auto-merge armed; **not** merging here. Admin-merge per #1389 once `macOS Swift` CI (build + XCTest) is green.

Closes part 2 of #1322.