### PR TITLE
qa: restamp stale EXPECTED_SC ruler pin (#1427)

### DIFF
--- a/qa/test_artifact_evals.py
+++ b/qa/test_artifact_evals.py
@@ -34,11 +34,16 @@ import artifact_calibration_panel as panel  # noqa: E402
 # would silently re-version every historical engine-duo score. These pin the exact current hashes
 # (origin/main @ the HV1 branch point). If a future edit changes them, this test goes RED and forces a
 # conscious re-baseline (the same discipline test_scores_db_comparability enforces for content edits).
-EXPECTED_SC = "sc_5c35d1ec2d86"  # re-baselined #1360: assert_behavioral.py parenthesization fix —
-EXPECTED_LC = "lc_b031bd9f47e1"  # the ruler hashes FILE BYTES (scoring_config_version._content_hash
-# reads p.read_bytes()), so this edit re-versions it even though re.compile(...).pattern is
-# unchanged (verified via git-stash before/after diff, not by this hash) — the file's bytes
-# are what changed, not the runtime regex behavior.
+EXPECTED_SC = "sc_38b768e2fd1b"  # re-baselined #1427: release_readiness.py touched by #1417/#1414
+EXPECTED_LC = "lc_b031bd9f47e1"  # ("qa: auto-persist scores rows for the manual-append bucket",
+# commit 9f244613) — that PR only ADDS a new --scores-db CLI arg and an auto-persist call for the
+# RRI row AFTER `result` is computed and written to --out; it does not touch any of the 11 RRI
+# gates, thresholds, or scoring logic. Verdict: NON-SEMANTIC to scoring — zero effect on what an
+# RRI/lens number MEANS — so only sc_ (which includes release_readiness.py) moves; lc_ (the 8
+# lens-only files) is confirmed BYTE-IDENTICAL (unchanged from the #1360 re-baseline), matching
+# scoring_config_version()'s file-byte hashing (it reads p.read_bytes(), so any edit to a listed
+# file re-versions sc_ regardless of semantic effect — this is a deliberate restamp of a
+# no-semantic-change edit, not a ruler recalibration).
 
 
 def test_engine_duo_rulers_are_byte_unchanged():


### PR DESCRIPTION
## Summary
Fixes repo-wide RED on `qa-release-gate-tests` (issue #1427) caused by a stale `EXPECTED_SC` pin in `qa/test_artifact_evals.py::test_engine_duo_rulers_are_byte_unchanged`.

## Root cause
- `qa/scoring_config_version.py`'s `SCORING_CONFIG_FILES` includes `qa/release_readiness.py`.
- That file was last touched by #1417/#1414 ("qa: auto-persist scores rows for the manual-append bucket", commit `9f244613`) — verified via `git log --oneline <pin-commit>..HEAD -- qa/<each SCORING_CONFIG_FILES member>`: it is the **only** ruler file that changed since the `#1360` pin (`43a91f73`).
- The hardcoded `EXPECTED_SC`/`EXPECTED_LC` constants were never re-baselined after that merge, so the test has been RED on main ever since, forcing admin-merges on every PR (per #1389's convention).

## Semantic verdict: non-semantic (option b)
Read the #1417 diff (`git show 9f244613 -- qa/release_readiness.py`): it only adds a new `--scores-db` CLI arg (test-only override, defaults to `""`) and an auto-persist call for the RRI ledger row **after** `result` is computed and written to `--out`. It does not touch any of the 11 RRI gates, thresholds, or scoring logic.

Confirms as non-semantic: `lc_` (the LENS ruler — `SCORING_CONFIG_FILES` minus `release_readiness.py`) is **unchanged** at `lc_b031bd9f47e1`, identical to the #1360 baseline. Only `sc_` moved (`sc_5c35d1ec2d86` → `sc_38b768e2fd1b`), which is exactly what a byte-only edit to the one full-ruler-only file (`release_readiness.py`, outside the lens set) produces. `scoring_config_version()` hashes raw file bytes (`p.read_bytes()`), so any edit re-versions `sc_` regardless of semantic effect — this restamp records that verdict rather than recalibrating anything.

## Fix
Restamp `EXPECTED_SC` to the current `sc_38b768e2fd1b` (`EXPECTED_LC` unchanged) with an inline comment documenting the no-semantic-change verdict and diff summary, so future readers don't have to re-derive this.

## Test plan
- [x] `python3 -m pytest qa/test_artifact_evals.py -q` → 39 passed, 1 skipped (was RED before this change, reproduced the exact #1427 failure on a clean checkout of main)
- [x] `bash qa/fast_gate.sh` → Tier-0 deterministic engine tier: **257 passed**

Auto-merge armed; will merge on green per the admin-merge convention (#1389) since this specific check has been red repo-wide (not introduced by this PR).

Closes #1427.