### PR TITLE
ci: sync qa-release-gate test lists (GHA ↔ Woodpecker) + static parity guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
             ../../qa/test_release_readiness_scope.py \
             ../../qa/test_scores_db_comparability.py \
             ../../qa/test_scores_db.py \
+            ../../qa/test_artifact_evals.py \
             ../../qa/test_closeout.py \
             ../../qa/test_duo_resume.py \
             ../../qa/test_release_gate_static.py \
@@ -123,6 +124,7 @@ jobs:
             ../../qa/test_deterministic_rri_gate.py \
             ../../qa/test_orchestrate_split_rri.py \
             ../../qa/test_visual_regression_check.py \
+            ../../qa/test_visual_critic.py \
             ../../qa/test_structural_coverage.py \
             ../../qa/test_story_readout_approval.py \
             ../../qa/test_feature_engagement.py \

--- a/.woodpecker/qa-release-gate-tests.yml
+++ b/.woodpecker/qa-release-gate-tests.yml
@@ -28,6 +28,7 @@ steps:
         ../../qa/test_scores_db.py
         ../../qa/test_artifact_evals.py
         ../../qa/test_closeout.py
+        ../../qa/test_duo_resume.py
         ../../qa/test_release_gate_static.py
         ../../qa/test_ui_playtest_score_image_outcomes.py
         ../../qa/test_claude_auth_isolation.py

--- a/.woodpecker/qa-release-gate-tests.yml
+++ b/.woodpecker/qa-release-gate-tests.yml
@@ -6,6 +6,10 @@ steps:
     image: ghcr.io/astral-sh/uv:python3.12-bookworm
     environment:
       WORLDOS_RULES_OFFLINE: "1"
+      # The container runs as root; run_duo.sh's root guard exits 2 without this (the same
+      # IS_SANDBOX=1 contract the root VM sweep lane uses). test_duo_resume.py stubs claude,
+      # so no real bypassPermissions call happens here.
+      IS_SANDBOX: "1"
     commands:
       - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends git jq; rm -rf /var/lib/apt/lists/*'
       - >-

--- a/qa/test_release_gate_static.py
+++ b/qa/test_release_gate_static.py
@@ -312,6 +312,26 @@ class QuotaCircuitBreakerStaticContractTests(unittest.TestCase):
             source.index('python3 "$ASSERT_BEHAVIORAL_SCRIPT"'),
         )
 
+    def test_qa_release_gate_ci_lists_are_in_parity(self):
+        # The GHA qa-release-gate-tests job and its Woodpecker mirror each grew test files the other
+        # lacked (test_artifact_evals.py was Woodpecker-only, so the #1427 stale-ruler-pin failure was
+        # invisible in GHA and read as "the Woodpecker mirror is broken"; test_duo_resume.py was
+        # GHA-only). Both gates must run the SAME qa/ test set — additions go to both files.
+        gha = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        job = re.search(r"^  qa-release-gate-tests:\n(.*?)(?=^  \S)", gha, re.M | re.S)
+        self.assertIsNotNone(job, "qa-release-gate-tests job not found in ci.yml")
+        gha_tests = set(re.findall(r"qa/(test_\w+\.py)", job.group(1)))
+        woodpecker = (ROOT / ".woodpecker" / "qa-release-gate-tests.yml").read_text(encoding="utf-8")
+        woodpecker_tests = set(re.findall(r"qa/(test_\w+\.py)", woodpecker))
+        # guard the extraction itself — an empty set would vacuously "match" a broken regex.
+        self.assertGreater(len(gha_tests), 40, "ci.yml extraction came back implausibly small")
+        self.assertEqual(
+            gha_tests,
+            woodpecker_tests,
+            "qa-release-gate test lists drifted between .github/workflows/ci.yml and "
+            ".woodpecker/qa-release-gate-tests.yml — add the test file to BOTH gates",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

Post-mortem of the repo-wide `ci/woodpecker/*/qa-release-gate-tests` failure (#1427, fixed by the #1431 restamp): the failure was only visible on Woodpecker because the two gate definitions had **drifted in both directions**:

| test file | GHA `ci.yml` | Woodpecker mirror |
|---|---|---|
| `qa/test_artifact_evals.py` (#1331) | ❌ missing | ✅ |
| `qa/test_visual_critic.py` | ❌ missing | ✅ |
| `qa/test_duo_resume.py` (#1374) | ✅ | ❌ missing |

So when #1417/#1414 touched `release_readiness.py` without restamping the `EXPECTED_SC` ruler pin, only the Woodpecker mirror went red — GHA stayed green on the same commits, which read as "the Woodpecker runner is broken" and cost a full investigation. The invariant test was doing its job; the parity gap hid that.

## What

- **`.github/workflows/ci.yml`**: add `test_artifact_evals.py` + `test_visual_critic.py` to the `qa-release-gate-tests` job (same order as the Woodpecker list).
- **`.woodpecker/qa-release-gate-tests.yml`**: add `test_duo_resume.py`.
- **`qa/test_release_gate_static.py`**: new `test_qa_release_gate_ci_lists_are_in_parity` — parses both CI files and asserts the `qa/test_*.py` sets are identical, so a future addition to only one gate fails statically in BOTH CIs with an actionable message. Includes an extraction-sanity floor (>40 files) so a broken regex can't vacuously pass.

## Additivity / invariants

Pure CI-config + additive static test; no engine/schema/snapshot surface touched. All three swapped-in test files verified locally at this SHA:

```
qa/test_release_gate_static.py  → 23 passed, 2 subtests
test_artifact_evals + test_duo_resume + test_visual_critic → 89 passed
```

Both YAMLs parse clean. The Woodpecker PR pipeline runs the updated config from this branch, so the `test_duo_resume.py`-in-container path is validated by this PR's own checks before merge.

Also a live probe for #1389: auto-merge is enabled on this PR — if it lands without `--admin`, the repo-wide hang was the (now-fixed) Woodpecker red, and #1389 can likely be closed.