### PR TITLE
docs: relax merge guidance back to --auto (auto-merge hang resolved)

### DIFF
--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -213,10 +213,10 @@ change must respect them.
    git worktree prune
    ```
 
-**Merging (auto-merge hangs — read before relying on `--auto`):** repo-wide GitHub auto-merge hangs
-on ~every PR; once checks are green and review threads are resolved, merge directly with
-`gh pr merge <n> --admin --squash` rather than waiting on `--auto`. Never push-and-abandon — shepherd
-to merged. Full detail: `docs/OPERATIONS.md` "Merging" section.
+**Merging:** once checks are green and review threads are resolved: `gh pr merge <n> --squash --auto`.
+Auto-merge works — the earlier repo-wide hang was a red required Woodpecker check, not a GitHub bug
+(resolved #1431/#1434, see closed #1389); `--admin` is emergency-only (it bypasses branch protection).
+Never push-and-abandon — shepherd to merged. Full detail: `docs/OPERATIONS.md` "Merging" section.
 
 **The whole shape:** worktree off main → implement additive → focused single-process test →
 push → `gh pr create` (no `tail` in an `&&` chain) → merge after checks pass →

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -24,12 +24,16 @@
    `docs/roadmap/NOW.md` is the you-are-here surface — read both alongside this page (both land in
    PR #1385; reference by path regardless of merge status).
 
-## Merging (read this — auto-merge hangs)
+## Merging
 
-Repo-wide GitHub auto-merge HANGS on ~every PR (root cause open — see #1389; symptom: auto-merge
-armed + checks green but the merge never fires). **Procedure:** once checks are green and review threads are resolved, merge directly
-— `gh pr merge <n> --admin --squash`. Never rely on `--auto` alone. Never push-and-abandon a PR:
-shepherd every PR you open to merged (or explicitly parked/blocked) before ending your turn.
+Once checks are green and review threads are resolved: `gh pr merge <n> --squash --auto`. Auto-merge
+fires normally — the earlier repo-wide "hang" (#1389, closed) was a **red required Woodpecker
+`qa-release-gate-tests` context**, not a GitHub bug: a stale `EXPECTED_SC` ruler pin made the required
+check red on every PR while GitHub Actions stayed green, so auto-merge correctly refused to merge.
+Resolved by #1431 (restamp) + #1434 (GHA↔Woodpecker list parity + static guard). `--admin` is
+**emergency-only** (declare why in a PR comment + file a follow-up) — it bypasses branch protection.
+Never push-and-abandon a PR: shepherd every PR you open to merged (or explicitly parked/blocked) before
+ending your turn.
 
 ## The loop (per issue)
 


### PR DESCRIPTION
Follow-up to #1434 / closed #1389.

The `docs/OPERATIONS.md` and `WorldOS-RUNBOOK.md` "Merging" sections told every agent to use `gh pr merge --admin --squash` because "auto-merge hangs repo-wide." That hang was **not** a GitHub bug — it was the required Woodpecker `qa-release-gate-tests` context being **red** on every PR (stale `EXPECTED_SC` ruler pin from #1414/#1417), which correctly blocks auto-merge. Because the failing test (`test_artifact_evals.py`) ran only in the Woodpecker gate and not in GitHub Actions, the Actions checks looked green and it read as a mysterious hang.

Resolved by #1431 (restamp) + #1434 (GHA↔Woodpecker list parity + static guard). PR #1434 itself auto-merged with plain `--auto`, no `--admin` — proof the path is healthy.

This reverts the default guidance to `--squash --auto` and marks `--admin` emergency-only (it bypasses branch protection, which is exactly what we don't want as a default). Docs-only.