### PR TITLE
#1436 W5c U2: native-window T3 playtester palette + runner

### DIFF
--- a/qa/UI_PLAYTEST.md
+++ b/qa/UI_PLAYTEST.md
@@ -95,6 +95,34 @@ opening turn seats a living canon PC + companion and opens a scene) so the launc
 through the *real* launcher start-flow — which is exactly the flow that exercises #305 (a dead
 character must not be offered/seated as a PC; if it is, the newbie reports it).
 
+## The T3 native-window variant (issue #1436 U2 / #1322)
+
+The T3 gate exits on the RENDERED surface, not the browser: a blind AI playtester completes a quest
+loop in the standalone Unity **WorldOSPlayer.app** window. `qa/ui_playtest_player.sh` is the browser
+harness's native twin — it exposes the **same 9-tool contract** to the player agent but backs it with
+macOS primitives instead of Playwright, and scores with the **same** `qa/ui_playtest_score.py`.
+
+```sh
+qa/ui_playtest_player.sh --preflight            # check app + deps + swift helper + PERMISSIONS, no run
+qa/ui_playtest_player.sh <runid> <beats> <budget>   # seed → viewer → player app → DM loop → play → score
+```
+
+- Boot recipe: `qa/seed_gfx_combat.py` mints `camp_gfxdemo01` → `viewer/server.py` serves
+  `/combat-surface` (move sink + chat wired) → `WorldOSPlayer.app` is launched with the env
+  launch-contract `WORLDOS_ENGINE_BASE_URL` / `WORLDOS_CAMPAIGN_ID` → the **unchanged** `run_duo` DM
+  loop resolves the player's moves → the native palette drives the window → teardown → score.
+- Palette backing (`qa/native_palette/native_palette_server.js`): `screenshot` = `screencapture -l
+  <windowid>` (window found via `CGWindowList`); `click(x,y)` = a `CGEvent` click at window-relative
+  pixels mapped to global points (via `qa/native_palette/native_input.swift`, or `cliclick` if
+  installed); `type`/`key` = synthetic keystrokes; `a11y_tree` = a **pixels-only stub** (the T3
+  persona plays from screenshots); `wait`/`report_bug`/`give_up`/`finish` identical to the browser
+  palette. Persona brief: `qa/native_palette/play_player_native_t3.txt`.
+- **macOS permissions (owner action, FAIL-LOUD):** the palette needs **Screen Recording** (System
+  Settings ▸ Privacy & Security ▸ Screen Recording — for the capture AND for `CGWindowList` to see the
+  window) and **Accessibility** (▸ Accessibility — for synthetic input). A missing grant aborts the
+  run with the exact pane to open; it is never silently skipped. Run `--preflight` to check both.
+- One live GUI harness at a time; the palette never touches Eva; the engine stays the sole writer.
+
 ## The Player palette (the constrained tool surface)
 
 `qa/playwright/palette_server.js` is an **MCP server** that is the Player's *entire* tool surface

--- a/qa/native_palette/native_input.swift
+++ b/qa/native_palette/native_input.swift
@@ -1,0 +1,188 @@
+// native_input.swift — the macOS PRIMITIVES behind the T3 native-window palette (issue #1436/#1322).
+//
+// The browser palette (qa/playwright/palette_server.js) drives a Playwright page. The T3 gate needs
+// the SAME blind-player tool surface pointed at the NATIVE WorldOSPlayer.app window instead. This
+// helper is the thin CoreGraphics/Quartz layer that the native palette server shells out to for the
+// three things a browser gives you for free: FIND the player's window, CLICK/press inside it, and
+// PREFLIGHT the macOS TCC permissions those need. Screenshots are taken by /usr/sbin/screencapture
+// (see the server) — this helper never captures pixels, so it needs no Screen-Recording grant itself.
+//
+// It is deliberately a SINGLE self-contained file with no third-party deps so it both:
+//   - runs interpreted:  `swift native_input.swift <subcommand> …`   (no build step; what the server uses)
+//   - compiles:          `swiftc native_input.swift -o native_input`  (the harness self-check asserts this)
+//
+// Subcommands (each prints ONE line of JSON to stdout; exit 0 on success, 2 on a usage/lookup miss):
+//   checkperms                      -> {"screen_recording":bool,"accessibility":bool}
+//   winfind  <ownerName>            -> {"found":bool,"window_id":int,"x":n,"y":n,"w":n,"h":n,"owner":s,"title":s}
+//   click    <globalX> <globalY> [double]   -> {"ok":true}   (left click at GLOBAL screen points, top-left origin)
+//   key      <name>                 -> {"ok":true}   (Return/Escape/Tab/Space/Arrow*/Delete or a single char)
+//   type     <text…>                -> {"ok":true}   (synthesize a unicode string into the focused field)
+//
+// Coordinate contract: Quartz CGWindow bounds AND CGEvent cursor positions are BOTH global screen
+// POINTS with a top-left origin, so they compose directly. The server maps window-relative screenshot
+// PIXELS to global points via the window origin + the backing scale (pixel_w / point_w) before calling
+// `click` — this helper only ever sees final global points and never guesses scale.
+
+import Foundation
+import CoreGraphics
+#if canImport(ApplicationServices)
+import ApplicationServices
+#endif
+
+// ---- tiny JSON emit (no Codable ceremony for one-line results) --------------
+func emit(_ obj: [String: Any]) {
+    if let data = try? JSONSerialization.data(withJSONObject: obj, options: [.sortedKeys]),
+       let s = String(data: data, encoding: .utf8) {
+        print(s)
+    } else {
+        print("{\"ok\":false,\"error\":\"json-encode-failed\"}")
+    }
+}
+
+// ---- permission preflight ---------------------------------------------------
+// The native palette needs TWO TCC grants at RUNTIME, attached to the responsible app (the terminal /
+// process that launched the harness): Screen Recording (screencapture of the window) + Accessibility
+// (synthetic CGEvent input). We report both so the server can FAIL LOUD with the exact Settings pane.
+// Owners that are always present in the on-screen list REGARDLESS of a Screen-Recording grant (system
+// overlays live on high layers and leak their owner even when normal windows are redacted). If, after
+// excluding these, ZERO normal (layer-0) windows are visible, the process is redacted == no effective
+// grant. This EMPIRICAL signal is authoritative: on macOS 14+/15+ CGPreflightScreenCaptureAccess can
+// return true while the actual window list (and screencapture) is still redacted (observed on this box).
+let SYSTEM_OWNERS: Set<String> = ["Window Server", "Dock", "Control Center", "Spotlight", "Notification Center"]
+
+func normalWindowCount() -> Int {
+    let opts: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+    guard let list = CGWindowListCopyWindowInfo(opts, kCGNullWindowID) as? [[String: Any]] else { return 0 }
+    var n = 0
+    for w in list {
+        let layer = w[kCGWindowLayer as String] as? Int ?? -1
+        let owner = w[kCGWindowOwnerName as String] as? String ?? ""
+        if layer == 0 && !owner.isEmpty && !SYSTEM_OWNERS.contains(owner) { n += 1 }
+    }
+    return n
+}
+
+func checkPerms() {
+    var preflight = true
+    // CGPreflightScreenCaptureAccess is macOS 10.15+; treat older OSes as "assume granted" (true).
+    if #available(macOS 10.15, *) {
+        preflight = CGPreflightScreenCaptureAccess()
+    }
+    let normals = normalWindowCount()
+    // Trust the EMPIRICAL probe: a grant means normal windows are enumerable. `preflight` is reported
+    // too for diagnostics, but `screen_recording` is the ground truth the server gates on.
+    let screen = preflight && normals > 0
+    let ax = AXIsProcessTrusted()
+    emit(["screen_recording": screen, "accessibility": ax,
+          "preflight": preflight, "normal_windows": normals])
+}
+
+// ---- window lookup ----------------------------------------------------------
+// Owner name (kCGWindowOwnerName) is available WITHOUT Screen Recording; only window TITLES and
+// captured PIXELS require the grant — so a missing grant still lets us find + click the window, and
+// the screenshot (not this helper) is where the loud failure surfaces. We pick the largest on-screen,
+// non-zero-layer window owned by the target app (the game view, not a tiny helper/status window).
+func winFind(_ owner: String) {
+    let opts: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+    guard let infoList = CGWindowListCopyWindowInfo(opts, kCGNullWindowID) as? [[String: Any]] else {
+        emit(["found": false, "error": "window-list-unavailable"]); exit(2)
+    }
+    var best: [String: Any]? = nil
+    var bestArea: CGFloat = -1
+    for win in infoList {
+        guard let o = win[kCGWindowOwnerName as String] as? String, o == owner else { continue }
+        // layer 0 == normal app windows; skip menubar/overlay layers.
+        if let layer = win[kCGWindowLayer as String] as? Int, layer != 0 { continue }
+        guard let b = win[kCGWindowBounds as String] as? [String: Any],
+              let w = b["Width"] as? CGFloat, let h = b["Height"] as? CGFloat else { continue }
+        let area = w * h
+        if area > bestArea { bestArea = area; best = win }
+    }
+    guard let win = best,
+          let b = win[kCGWindowBounds as String] as? [String: Any],
+          let x = b["X"] as? CGFloat, let y = b["Y"] as? CGFloat,
+          let w = b["Width"] as? CGFloat, let h = b["Height"] as? CGFloat,
+          let wid = win[kCGWindowNumber as String] as? Int else {
+        emit(["found": false, "owner": owner]); exit(2)
+    }
+    emit([
+        "found": true, "window_id": wid,
+        "x": Int(x), "y": Int(y), "w": Int(w), "h": Int(h),
+        "owner": owner, "title": (win[kCGWindowName as String] as? String) ?? "",
+    ])
+}
+
+// ---- synthetic input --------------------------------------------------------
+func postClick(_ gx: Double, _ gy: Double, doubleClick: Bool) {
+    let pt = CGPoint(x: gx, y: gy)
+    let src = CGEventSource(stateID: .hidSystemState)
+    // move first so hover/enter handlers see the cursor, then down/up.
+    CGEvent(mouseEventSource: src, mouseType: .mouseMoved, mouseCursorPosition: pt, mouseButton: .left)?.post(tap: .cghidEventTap)
+    func clickOnce(_ count: Int64) {
+        let down = CGEvent(mouseEventSource: src, mouseType: .leftMouseDown, mouseCursorPosition: pt, mouseButton: .left)
+        let up = CGEvent(mouseEventSource: src, mouseType: .leftMouseUp, mouseCursorPosition: pt, mouseButton: .left)
+        if count > 1 { down?.setIntegerValueField(.mouseEventClickState, value: count); up?.setIntegerValueField(.mouseEventClickState, value: count) }
+        down?.post(tap: .cghidEventTap)
+        up?.post(tap: .cghidEventTap)
+    }
+    clickOnce(1)
+    if doubleClick { clickOnce(2) }
+    emit(["ok": true])
+}
+
+// Named virtual keycodes (US layout) for the keys the palette contract uses. Anything not here that is
+// a single character is typed via the unicode path.
+let NAMED_KEYS: [String: CGKeyCode] = [
+    "return": 36, "enter": 36, "tab": 48, "space": 49, "delete": 51, "backspace": 51,
+    "escape": 53, "esc": 53, "left": 123, "arrowleft": 123, "right": 124, "arrowright": 124,
+    "down": 125, "arrowdown": 125, "up": 126, "arrowup": 126,
+]
+
+func postKey(_ name: String) {
+    let src = CGEventSource(stateID: .hidSystemState)
+    let key = name.lowercased()
+    if let code = NAMED_KEYS[key] {
+        CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: true)?.post(tap: .cghidEventTap)
+        CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: false)?.post(tap: .cghidEventTap)
+        emit(["ok": true]); return
+    }
+    // single unnamed char -> unicode keystroke
+    postType(name)
+}
+
+func postType(_ text: String) {
+    let src = CGEventSource(stateID: .hidSystemState)
+    let down = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: true)
+    let up = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: false)
+    var chars = Array(text.utf16)
+    down?.keyboardSetUnicodeString(stringLength: chars.count, unicodeString: &chars)
+    up?.keyboardSetUnicodeString(stringLength: chars.count, unicodeString: &chars)
+    down?.post(tap: .cghidEventTap)
+    up?.post(tap: .cghidEventTap)
+    emit(["ok": true])
+}
+
+// ---- dispatch ---------------------------------------------------------------
+let args = Array(CommandLine.arguments.dropFirst())
+guard let cmd = args.first else {
+    emit(["ok": false, "error": "usage: native_input <checkperms|winfind|click|key|type> …"]); exit(2)
+}
+switch cmd {
+case "checkperms":
+    checkPerms()
+case "winfind":
+    guard args.count >= 2 else { emit(["found": false, "error": "usage: winfind <ownerName>"]); exit(2) }
+    winFind(args[1])
+case "click":
+    guard args.count >= 3, let gx = Double(args[1]), let gy = Double(args[2]) else {
+        emit(["ok": false, "error": "usage: click <globalX> <globalY> [double]"]); exit(2)
+    }
+    postClick(gx, gy, doubleClick: args.count >= 4 && args[3] == "double")
+case "key":
+    guard args.count >= 2 else { emit(["ok": false, "error": "usage: key <name>"]); exit(2) }
+    postKey(args[1])
+case "type":
+    postType(args.dropFirst().joined(separator: " "))
+default:
+    emit(["ok": false, "error": "unknown subcommand: \(cmd)"]); exit(2)
+}

--- a/qa/native_palette/native_palette_server.js
+++ b/qa/native_palette/native_palette_server.js
@@ -1,0 +1,494 @@
+#!/usr/bin/env node
+/*
+ * WorldOS AI playtester — the NATIVE-WINDOW PLAYER PALETTE (issue #1436 / #1322, the T3 gate).
+ *
+ * This is the SAME blind-player tool surface as qa/playwright/palette_server.js, but pointed at the
+ * standalone Unity **WorldOSPlayer.app** window instead of a browser. The T3 gate asks a blind AI
+ * playtester to complete a QUEST LOOP entirely in the RENDERED surface; that surface is a native
+ * macOS window, so the palette is backed by macOS primitives rather than Playwright:
+ *
+ *   screenshot()   -> screencapture -l <windowid>  (the player window, found via CGWindowList)
+ *   a11y_tree()    -> STUB. The native window is pixels-only (no DOM/AX tree exposed); the T3 player
+ *                     persona works from screenshots. Returned so the 9-tool contract is identical.
+ *   click(x,y)     -> a CGEvent left-click at window-relative PIXELS (mapped to global points), via the
+ *                     committed Swift helper native_input.swift (or `cliclick` if installed).
+ *   type(text)     -> synthetic unicode keystrokes into the focused field (optional Enter to submit).
+ *   key(name)      -> a single key press (Return/Escape/Tab/Arrow*).
+ *   wait(ms)       -> sleep (a native window has no selector to wait on; selector is a no-op note).
+ *   report_bug/give_up/finish  -> IDENTICAL to the browser palette: same bugs.ndjson / status.json /
+ *                     actions.ndjson shape, so qa/ui_playtest_score.py scores a native run UNCHANGED.
+ *
+ * Artifact layout (identical to the browser palette, so the scorer + summary read it verbatim):
+ *   <RUNDIR>/bugs.ndjson                         (top-level deliverable)
+ *   <RUNDIR>/player/screenshots/step-NNN-*.png
+ *   <RUNDIR>/player/actions.ndjson               ({seq, action, target/x/y, ok, dead, screen, ...})
+ *   <RUNDIR>/player/console.ndjson               (empty — a native window has no browser console)
+ *   <RUNDIR>/player/network.ndjson               (empty — the palette does not observe the app's HTTP)
+ *   <RUNDIR>/player/status.json                  (give_up / finish end signal + satisfaction)
+ *
+ * Env (set by qa/ui_playtest_player.sh):
+ *   WORLDOS_NPT_RUNDIR       — the RUN ROOT (bugs.ndjson + status.json land here; player/ under it)
+ *   WORLDOS_NPT_PERSONA      — persona slug stamped on each bug
+ *   WORLDOS_NPT_WINDOW_OWNER — CGWindowList owner name of the player app (default "WorldOSPlayer")
+ *   WORLDOS_NPT_HELPER       — path to a prebuilt native_input binary (else the .swift is compiled/run)
+ *   WORLDOS_NPT_CLICK_TOOL   — "auto" (default) | "cliclick" | "helper"
+ *   WORLDOS_NPT_SCREEN       — coarse screen label stamped on actions (default "player"; honest — the
+ *                              native game view is NOT the browser SPA's "table" screen)
+ *   WORLDOS_NPT_FULLSCREEN_FALLBACK — "1" to fall back to a full-screen grab when the window isn't found
+ *
+ * MACOS PERMISSIONS (checked at startup — the run FAILS LOUD, never silently skips, if either is
+ * missing, because a missing grant is an OWNER action, not a test result):
+ *   - Screen Recording  (System Settings > Privacy & Security > Screen Recording) — for screencapture
+ *     AND for CGWindowList to enumerate the player's window at all (redacted without it).
+ *   - Accessibility     (System Settings > Privacy & Security > Accessibility) — for synthetic input.
+ *
+ * Pure player-side surface: NEVER imports the engine, NEVER reads campaign state, NEVER writes
+ * anything but the run-dir artifacts. The engine stays the sole writer.
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync, spawnSync } = require("child_process");
+
+// The MCP SDK + zod live in the sibling qa/playwright workspace (the harness already installs them
+// there). Resolve normally first (in case this dir grows its own node_modules), then fall back to the
+// playwright workspace — no second npm install required.
+function requireShared(mod) {
+  const parts = mod.split("/");
+  // Candidate node_modules roots, in order: an explicit override, this dir's own, the sibling
+  // qa/playwright workspace (where the harness installs the SDK), and the canonical repo checkout
+  // (worktrees don't get node_modules — gitignored — so fall back to the main checkout's install).
+  const roots = [
+    process.env.WORLDOS_NPT_NODE_MODULES,
+    path.join(__dirname, "node_modules"),
+    path.join(__dirname, "..", "playwright", "node_modules"),
+    "/Users/lume/WorldOS/qa/playwright/node_modules",
+  ].filter(Boolean);
+  try {
+    return require(mod);
+  } catch (_e) {
+    // require.resolve({paths}) honors the package's "exports" map (the SDK maps
+    // "server/mcp.js" -> dist/cjs/...), which a raw path.join would bypass.
+    for (const root of roots) {
+      try { return require(require.resolve(mod, { paths: [root] })); } catch (_e2) {}
+    }
+    throw new Error(
+      "cannot resolve '" + mod + "' — install the palette deps (cd qa/playwright && npm install) or " +
+      "set WORLDOS_NPT_NODE_MODULES to a node_modules dir that has @modelcontextprotocol/sdk + zod. " +
+      "searched: " + roots.join(", ")
+    );
+  }
+}
+const { McpServer } = requireShared("@modelcontextprotocol/sdk/server/mcp.js");
+const { StdioServerTransport } = requireShared("@modelcontextprotocol/sdk/server/stdio.js");
+const { z } = requireShared("zod");
+
+// The harness always sets WORLDOS_NPT_RUNDIR; the default lands under the OS temp dir (never the
+// repo) so an ad-hoc/selfcheck run can't leave a stray npt-run/ in the working tree.
+const RUNDIR = process.env.WORLDOS_NPT_RUNDIR || path.join(require("os").tmpdir(), "worldos-npt-run");
+const PLAYERDIR = path.join(RUNDIR, "player");
+const PERSONA = (process.env.WORLDOS_NPT_PERSONA || "t3-native").trim();
+const OWNER = (process.env.WORLDOS_NPT_WINDOW_OWNER || "WorldOSPlayer").trim();
+const CLICK_TOOL = (process.env.WORLDOS_NPT_CLICK_TOOL || "auto").trim();
+const SCREEN_LABEL = (process.env.WORLDOS_NPT_SCREEN || "player").trim();
+const FULLSCREEN_FALLBACK = process.env.WORLDOS_NPT_FULLSCREEN_FALLBACK === "1";
+const SELFCHECK = process.argv.includes("--selfcheck");
+const MAX_WAIT_MS = 8000;
+
+const SHOTS = path.join(PLAYERDIR, "screenshots");
+const A11Y = path.join(PLAYERDIR, "a11y");
+for (const d of [RUNDIR, PLAYERDIR, SHOTS, A11Y]) fs.mkdirSync(d, { recursive: true });
+
+const BUGS = path.join(RUNDIR, "bugs.ndjson");
+const ACTIONS = path.join(PLAYERDIR, "actions.ndjson");
+const CONSOLE = path.join(PLAYERDIR, "console.ndjson"); // stays empty (native has no browser console)
+const NETWORK = path.join(PLAYERDIR, "network.ndjson"); // stays empty (palette does not observe HTTP)
+const STATUS = path.join(PLAYERDIR, "status.json");
+// Touch the empty logs so the scorer's readers find them (it tolerates absent, but parity is cleaner).
+for (const f of [CONSOLE, NETWORK]) { try { if (!fs.existsSync(f)) fs.writeFileSync(f, ""); } catch (_e) {} }
+
+let seq = 0;
+let winCache = null; // {x,y,w,h, id, scale} — refreshed on each screenshot
+
+const A11Y_STUB =
+  "(pixels-only surface) The native WorldOSPlayer window exposes NO accessibility tree — it is a " +
+  "rendered game view. Use screenshot() to SEE, then click(x,y) at the pixel you want. Coordinates " +
+  "are relative to the screenshot's top-left. The T3 player persona plays entirely from screenshots.";
+
+function appendLine(file, obj) {
+  try { fs.appendFileSync(file, JSON.stringify(obj) + "\n"); } catch (_e) {}
+}
+function nowIso() { return new Date().toISOString().replace(/\.\d+Z$/, "Z"); }
+
+// ---- the Swift primitives helper -------------------------------------------
+// Prefer a prebuilt binary (WORLDOS_NPT_HELPER); else compile native_input.swift once to a temp
+// binary (fast per-call); else fall back to the `swift` interpreter (slower, ~1-2s/call but portable).
+const SWIFT_SRC = path.join(__dirname, "native_input.swift");
+let helperCmd = null; // {file, argv0extra:[]}
+function resolveHelper() {
+  if (helperCmd) return helperCmd;
+  const explicit = (process.env.WORLDOS_NPT_HELPER || "").trim();
+  if (explicit && fs.existsSync(explicit)) { helperCmd = { bin: explicit, pre: [] }; return helperCmd; }
+  // try to compile once
+  const out = path.join(PLAYERDIR, "native_input");
+  try {
+    if (!fs.existsSync(out)) execFileSync("swiftc", [SWIFT_SRC, "-o", out], { stdio: "pipe" });
+    helperCmd = { bin: out, pre: [] };
+    return helperCmd;
+  } catch (_e) {
+    // fall back to interpreting the source
+    helperCmd = { bin: "swift", pre: [SWIFT_SRC] };
+    return helperCmd;
+  }
+}
+function runHelper(args) {
+  const h = resolveHelper();
+  const r = spawnSync(h.bin, [...h.pre, ...args], { encoding: "utf8", timeout: 20000 });
+  if (r.status !== 0 && !r.stdout) {
+    return { _error: (r.stderr || r.error || "helper failed").toString().slice(0, 300) };
+  }
+  try { return JSON.parse((r.stdout || "").trim().split("\n").pop()); }
+  catch (_e) { return { _error: "unparseable helper output: " + (r.stdout || "").slice(0, 200) }; }
+}
+function haveCliclick() {
+  try { execFileSync("which", ["cliclick"], { stdio: "pipe" }); return true; } catch (_e) { return false; }
+}
+
+// ---- permission gate (FAIL LOUD) -------------------------------------------
+function assertPermissions() {
+  const p = runHelper(["checkperms"]);
+  const missing = [];
+  if (!p || p.screen_recording !== true) {
+    missing.push(
+      "SCREEN RECORDING — open: System Settings > Privacy & Security > Screen Recording, enable the " +
+      "app running this harness (Terminal/iTerm/your shell), then RESTART it. Without it the player " +
+      "window cannot be enumerated or captured. (probe: " + JSON.stringify(p) + ")"
+    );
+  }
+  if (!p || p.accessibility !== true) {
+    missing.push(
+      "ACCESSIBILITY — open: System Settings > Privacy & Security > Accessibility, enable the app " +
+      "running this harness, then RESTART it. Without it synthetic clicks/keys are silently dropped."
+    );
+  }
+  if (missing.length) {
+    process.stderr.write(
+      "\n[native-palette] FATAL: missing macOS permission(s) — this is an OWNER action, not a skip:\n" +
+      missing.map((m) => "  * " + m).join("\n") + "\n\n"
+    );
+    process.exit(3);
+  }
+}
+
+// ---- window + screenshot ----------------------------------------------------
+function findWindow() {
+  const w = runHelper(["winfind", OWNER]);
+  if (w && w.found === true) return w;
+  return null;
+}
+function pixelSize(file) {
+  // sips is always present on macOS; parse pixelWidth/pixelHeight.
+  try {
+    const r = spawnSync("sips", ["-g", "pixelWidth", "-g", "pixelHeight", file], { encoding: "utf8" });
+    const w = /pixelWidth:\s*(\d+)/.exec(r.stdout || "");
+    const h = /pixelHeight:\s*(\d+)/.exec(r.stdout || "");
+    if (w && h) return { pw: Number(w[1]), ph: Number(h[1]) };
+  } catch (_e) {}
+  return null;
+}
+function screencaptureWindow(label) {
+  const name = "step-" + String(seq).padStart(3, "0") + (label ? "-" + label : "") + ".png";
+  const file = path.join(SHOTS, name);
+  const rel = path.join("player", "screenshots", name);
+  const win = findWindow();
+  let mode = "window";
+  if (win) {
+    spawnSync("screencapture", ["-l", String(win.id), "-o", "-x", file], { encoding: "utf8" });
+  } else if (FULLSCREEN_FALLBACK) {
+    mode = "fullscreen";
+    spawnSync("screencapture", ["-x", file], { encoding: "utf8" });
+  } else {
+    return { ok: false, screenshot: "", reason: "player window '" + OWNER + "' not found (is WorldOSPlayer.app launched? set WORLDOS_NPT_FULLSCREEN_FALLBACK=1 to grab the whole screen)" };
+  }
+  const px = fs.existsSync(file) ? pixelSize(file) : null;
+  // scale = capture pixels / window points (Retina = 2). Used to map click pixels -> global points.
+  let scale = 1;
+  if (win && px && win.w > 0) scale = px.pw / win.w;
+  winCache = win ? { x: win.x, y: win.y, w: win.w, h: win.h, id: win.id, scale } : null;
+  return { ok: fs.existsSync(file), screenshot: rel, mode, window: win || null, pixels: px, scale };
+}
+
+// ---- bug + action logging (identical shape to the browser palette) ----------
+function writeBug(rec) {
+  const out = {
+    ts: rec.ts || nowIso(), action_seq: seq, persona: PERSONA,
+    screen: rec.screen || SCREEN_LABEL, category: rec.category || "ux",
+    severity: rec.severity || "minor", title: rec.title || "(untitled)",
+    expected: rec.expected || "", actual: rec.actual || "", screenshot: rec.screenshot || "",
+    evidence: rec.evidence || {}, tried_alternatives: rec.tried_alternatives || [],
+    blocks_progress: rec.blocks_progress === true, source: rec.source || "player",
+  };
+  appendLine(BUGS, out);
+  return out;
+}
+function logAction(action, detail) {
+  seq += 1;
+  appendLine(ACTIONS, { ts: nowIso(), seq, action, ...detail, screen: SCREEN_LABEL });
+  return seq;
+}
+function fileHash(file) {
+  try { return String(fs.statSync(file).size) + ":" + require("crypto").createHash("sha1").update(fs.readFileSync(file)).digest("hex"); }
+  catch (_e) { return ""; }
+}
+
+// ---- MCP server -------------------------------------------------------------
+const server = new McpServer({ name: "worldos-nativeplayer", version: "1.0.0" });
+function textResult(obj) {
+  return { content: [{ type: "text", text: typeof obj === "string" ? obj : JSON.stringify(obj) }] };
+}
+
+server.registerTool(
+  "screenshot",
+  {
+    description:
+      "Take a screenshot of the WorldOS player window RIGHT NOW. Returns the saved PNG path plus the " +
+      "window's pixel size — click by pixel coordinates relative to this image's top-left. This is a " +
+      "pixels-only surface: there is no accessibility tree, so LOOK at the image before you act.",
+    inputSchema: {},
+  },
+  async () => {
+    const shot = screencaptureWindow("look");
+    const s = logAction("screenshot", { screenshot: shot.screenshot, ok: shot.ok });
+    return textResult({
+      screen: SCREEN_LABEL, seq: s, screenshot: shot.screenshot, ok: shot.ok,
+      window_pixels: shot.pixels ? { width: shot.pixels.pw, height: shot.pixels.ph } : null,
+      note: shot.ok ? "click(x,y) uses pixels from this image (top-left origin)." : shot.reason,
+    });
+  }
+);
+
+server.registerTool(
+  "a11y_tree",
+  {
+    description:
+      "Read the accessibility tree of the current screen. NOTE: the native player window is pixels-only " +
+      "and exposes no accessibility tree — this returns an explanation. Use screenshot() + click(x,y).",
+    inputSchema: {},
+  },
+  async () => {
+    logAction("a11y_tree", { stub: true });
+    return textResult({ screen: SCREEN_LABEL, a11y: A11Y_STUB, pixels_only: true });
+  }
+);
+
+server.registerTool(
+  "click",
+  {
+    description:
+      "Click inside the player window at PIXEL coordinates (x,y) from the last screenshot (top-left " +
+      "origin). This is how you move your token / press an on-screen control in the rendered game. " +
+      "Returns whether the click landed and whether the view changed.",
+    inputSchema: {
+      x: z.number().describe("X pixel from the screenshot's left edge."),
+      y: z.number().describe("Y pixel from the screenshot's top edge."),
+      double: z.boolean().optional().describe("Double-click (default false)."),
+    },
+  },
+  async ({ x, y, double }) => {
+    if (!winCache) screencaptureWindow("preclick"); // ensure we know the window bounds + scale
+    if (!winCache) {
+      const s = logAction("click", { x, y, ok: false, reason: "no window" });
+      return textResult({ ok: false, seq: s, reason: "player window not located — take a screenshot first." });
+    }
+    // window-relative pixels -> global screen points
+    const gx = winCache.x + x / winCache.scale;
+    const gy = winCache.y + y / winCache.scale;
+    const before = (function () { const f = screencaptureWindow("clickbefore"); return f.ok ? fileHash(path.join(RUNDIR, f.screenshot)) : ""; })();
+    let ok = true, reason = "";
+    const args = ["click", String(gx), String(gy)];
+    if (double) args.push("double");
+    const useCli = CLICK_TOOL === "cliclick" || (CLICK_TOOL === "auto" && haveCliclick());
+    if (useCli) {
+      const r = spawnSync("cliclick", [(double ? "dc:" : "c:") + Math.round(gx) + "," + Math.round(gy)], { encoding: "utf8" });
+      if (r.status !== 0) { ok = false; reason = (r.stderr || "cliclick failed").slice(0, 200); }
+    } else {
+      const r = runHelper(args);
+      if (!r || r.ok !== true) { ok = false; reason = (r && r._error) || "click helper failed"; }
+    }
+    spawnSync("sleep", ["0.7"]);
+    const after = screencaptureWindow("click");
+    const afterHash = after.ok ? fileHash(path.join(RUNDIR, after.screenshot)) : "";
+    const changed = before !== "" && afterHash !== "" ? before !== afterHash : true;
+    const s = logAction("click", { x, y, gx: Math.round(gx), gy: Math.round(gy), ok, changed, dead: ok && !changed, reason });
+    return textResult({
+      ok, seq: s, screen: SCREEN_LABEL, screen_changed: changed, screenshot: after.screenshot,
+      reason: ok ? (changed ? "" : "WARNING: click landed but the view did not change — possible dead control; consider report_bug.") : reason,
+    });
+  }
+);
+
+server.registerTool(
+  "type",
+  {
+    description:
+      "Type text via synthetic keystrokes into whatever field the player window currently has focused. " +
+      "Set submit=true to press Enter afterward (e.g. to send a chat/command line).",
+    inputSchema: {
+      text: z.string().describe("What to type, in plain English."),
+      submit: z.boolean().optional().describe("Press Enter after typing (default false)."),
+    },
+  },
+  async ({ text, submit }) => {
+    let ok = true, reason = "";
+    const r = runHelper(["type", String(text)]);
+    if (!r || r.ok !== true) { ok = false; reason = (r && r._error) || "type helper failed"; }
+    if (ok && submit) { runHelper(["key", "return"]); spawnSync("sleep", ["0.9"]); }
+    const after = screencaptureWindow("type");
+    const s = logAction("type", { text: String(text).slice(0, 200), submit: !!submit, ok, reason });
+    return textResult({ ok, seq: s, screen: SCREEN_LABEL, screenshot: after.screenshot, submitted: !!submit, reason });
+  }
+);
+
+server.registerTool(
+  "key",
+  {
+    description:
+      'Press a single key on the player window (e.g. "Enter", "Escape", "Tab", "ArrowDown"). Use Enter ' +
+      "to confirm, Escape to close a popup.",
+    inputSchema: { name: z.string().describe("Key name, e.g. Enter / Escape / Tab / ArrowDown.") },
+  },
+  async ({ name }) => {
+    let ok = true, reason = "";
+    const r = runHelper(["key", String(name)]);
+    if (!r || r.ok !== true) { ok = false; reason = (r && r._error) || "key helper failed"; }
+    spawnSync("sleep", ["0.4"]);
+    const after = screencaptureWindow("key");
+    const s = logAction("key", { name, ok, reason });
+    return textResult({ ok, seq: s, screen: SCREEN_LABEL, screenshot: after.screenshot, reason });
+  }
+);
+
+server.registerTool(
+  "wait",
+  {
+    description:
+      "Wait for the game to settle. Pass a number of milliseconds (capped at " + MAX_WAIT_MS + "ms). " +
+      "(A selector wait has no meaning on a pixels-only native window; it is treated as a short wait.)",
+    inputSchema: {
+      ms: z.number().optional().describe("Milliseconds to wait (capped)."),
+      selector: z.string().optional().describe("Ignored on native — no DOM. Present for contract parity."),
+    },
+  },
+  async ({ ms, selector }) => {
+    const dur = Math.max(0, Math.min(Number(ms || 1000), MAX_WAIT_MS));
+    spawnSync("sleep", [String(dur / 1000)]);
+    const s = logAction("wait", { ms: ms || null, selector: selector || null, ok: true });
+    return textResult({ ok: true, seq: s, screen: SCREEN_LABEL, note: selector ? "selector ignored (native window has no DOM)" : "" });
+  }
+);
+
+server.registerTool(
+  "report_bug",
+  {
+    description:
+      "Record ONE bug or UX problem you just hit. This is the POINT of the test — be specific. " +
+      "Give the severity (critical = blocks all play / major = blocks this task / minor = annoying / " +
+      "trivial = cosmetic), what you EXPECTED, and what ACTUALLY happened.",
+    inputSchema: {
+      severity: z.enum(["critical", "major", "minor", "trivial"]).describe("How bad is it."),
+      screen: z.string().optional().describe("Which part of the game you are on."),
+      expected: z.string().describe("What you expected to happen."),
+      actual: z.string().describe("What actually happened."),
+      title: z.string().optional().describe("One-line summary."),
+      category: z.enum(["ux", "bug", "content", "accessibility", "performance"]).optional(),
+      blocks_progress: z.boolean().optional().describe("Did this stop you from continuing?"),
+      tried_alternatives: z.array(z.string()).optional().describe("Other things you tried first."),
+    },
+  },
+  async (rec) => {
+    const shot = screencaptureWindow("bug");
+    const out = writeBug({
+      category: rec.category || "ux", severity: rec.severity, screen: rec.screen || SCREEN_LABEL,
+      title: rec.title || rec.expected.slice(0, 80), expected: rec.expected, actual: rec.actual,
+      screenshot: shot.screenshot, tried_alternatives: rec.tried_alternatives || [],
+      blocks_progress: rec.blocks_progress === true, source: "player",
+    });
+    logAction("report_bug", { severity: out.severity, title: out.title });
+    return textResult({ ok: true, recorded: out.title, severity: out.severity, screenshot: shot.screenshot });
+  }
+);
+
+server.registerTool(
+  "give_up",
+  {
+    description:
+      "End the playtest because you are stuck and cannot find a way to continue. Explain WHY in plain " +
+      "words. Only use this when you have genuinely exhausted the obvious options.",
+    inputSchema: { reason: z.string().describe("Why you are giving up.") },
+  },
+  async ({ reason }) => {
+    const shot = screencaptureWindow("giveup");
+    logAction("give_up", { reason });
+    writeBug({
+      category: "ux", severity: "major", screen: SCREEN_LABEL,
+      title: "Player gave up: " + String(reason).slice(0, 80),
+      expected: "A player can complete the quest loop in the rendered surface without getting stuck.",
+      actual: String(reason).slice(0, 500), screenshot: shot.screenshot,
+      blocks_progress: true, source: "give_up",
+    });
+    try { fs.writeFileSync(STATUS, JSON.stringify({ ended: true, reason: "give_up", detail: String(reason).slice(0, 500), at: nowIso() })); } catch (_e) {}
+    return textResult({ ok: true, ended: true, note: "Run ended. Thanks for playing." });
+  }
+);
+
+server.registerTool(
+  "finish",
+  {
+    description:
+      "End the playtest because you have PLAYED ENOUGH to fairly judge the experience and you are NOT " +
+      "blocked (use give_up ONLY when genuinely stuck). Give your honest overall satisfaction (1-10) " +
+      "and a 1-2 sentence closing verdict. This is the normal, satisfied way to end.",
+    inputSchema: {
+      satisfaction: z.number().int().min(1).max(10).describe("Your honest overall satisfaction, 1-10."),
+      verdict: z.string().describe("A 1-2 sentence closing verdict."),
+    },
+  },
+  async ({ satisfaction, verdict }) => {
+    const shot = screencaptureWindow("finish");
+    logAction("finish", { satisfaction, verdict: String(verdict).slice(0, 200), screenshot: shot.screenshot });
+    try { fs.writeFileSync(STATUS, JSON.stringify({ ended: true, reason: "finish", satisfaction, detail: String(verdict).slice(0, 500), at: nowIso() })); } catch (_e) {}
+    return textResult({ ok: true, ended: true, note: "Run ended — thanks for playing." });
+  }
+);
+
+const TOOL_NAMES = ["screenshot", "a11y_tree", "click", "type", "key", "wait", "report_bug", "give_up", "finish"];
+
+// ---- selfcheck (no GUI, no permission gate): assert the contract + helper ----
+// Used by qa/test_native_palette.py to prove the server boots and registers the 9-tool contract
+// without a live player window or a TCC grant.
+if (SELFCHECK) {
+  const registered = Object.keys((server && server._registeredTools) || {});
+  const have = TOOL_NAMES.every((t) => registered.includes(t));
+  const helperOk = fs.existsSync(SWIFT_SRC);
+  const result = {
+    ok: have && helperOk,
+    tools: registered.sort(),
+    expected: TOOL_NAMES.slice().sort(),
+    tool_contract_match: have,
+    helper_present: helperOk,
+    helper_src: SWIFT_SRC,
+  };
+  process.stdout.write(JSON.stringify(result) + "\n");
+  process.exit(result.ok ? 0 : 1);
+}
+
+// ---- live boot --------------------------------------------------------------
+assertPermissions();
+(async () => {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+})().catch((e) => {
+  process.stderr.write("native_palette fatal: " + (e && e.stack ? e.stack : e) + "\n");
+  process.exit(1);
+});

--- a/qa/native_palette/play_player_native_t3.txt
+++ b/qa/native_palette/play_player_native_t3.txt
@@ -1,0 +1,66 @@
+You are "THE T3 PLAYTESTER" — a player testing WorldOS through its real RENDERED GAME WINDOW: the
+standalone WorldOSPlayer app, a 3D-on-2D tactical scene shown on your screen. You are BLIND to
+everything except what the window draws. You canNOT read the code, the rules, the dice math, the
+engine, or the DM's notes — ONLY the pixels in the window. This is the T3 gate: prove a real player
+can complete a QUEST LOOP entirely in the rendered surface.
+
+HOW YOU SEE AND ACT — a small set of tools and NOTHING else. This is a PIXELS-ONLY window: there is
+no menu of labels, no accessibility list. You look at the picture and click WHERE things are.
+
+  - screenshot()  — take a picture of the game window RIGHT NOW. It tells you the window's pixel
+                    size. USE THIS FIRST and again whenever the scene might have changed. Everything
+                    you do is decided from this picture.
+  - a11y_tree()   — (not available here) returns only a note reminding you this is a pixels-only
+                    surface. Do not rely on it; work from screenshot().
+  - click(x, y)   — click INSIDE the window at pixel coordinates measured from the picture's
+                    TOP-LEFT corner. This is how you move your character and use on-screen controls:
+                    look at the screenshot, decide the pixel you want (e.g. the tile to walk to, the
+                    enemy to attack, a button), and click it. Set double=true for a double-click.
+  - type(text, submit) — type text into whatever field the window has focused; set submit=true to
+                    press Enter after (e.g. to send a command or chat line, if the game shows one).
+  - key(name)     — press one key, e.g. key("Enter"), key("Escape"), key("Tab"), key("ArrowUp").
+  - wait(ms)      — wait a moment if the scene is still loading or an animation is playing
+                    (e.g. wait(2000)). The DM's reply to a move can take several seconds.
+  - report_bug(...) — write down a problem (see below). THIS IS THE WHOLE POINT.
+  - give_up(reason) — only if you are truly stuck and have run out of obvious things to try.
+  - finish(satisfaction, verdict) — the NORMAL way to end: once you have played the loop and seen
+                    enough to judge it, give your honest satisfaction 1-10 and a 1-2 sentence verdict.
+
+THE QUEST LOOP you are trying to complete (in the rendered window, start to finish):
+  walk to an NPC → take a quest / accept the encounter → cross the room toward the foe →
+  FIGHT (move into position, attack) → resolve the fight → judge the experience and finish().
+The opening scene is a firelit crypt with your hero and at least one enemy on a tactical grid. Your
+job is to DRIVE it: read the scene, move your hero, engage, and see it resolve on screen.
+
+HOW YOU BEHAVE (stay in character — this is the test):
+- ALWAYS screenshot() before you act, so you click the RIGHT pixel. Reason out loud: "my hero is
+  the figure near the center; the goblin is up and to the right; I'll click the tile next to it to
+  move there." Then click that pixel.
+- Move deliberately: click a floor tile toward your goal, wait for the move + the DM's narration,
+  screenshot to see the result, and go again. To attack, click the enemy (or the tile beside it,
+  then the enemy) as the game affords.
+- Judge READABILITY as you go — a rendered surface's whole job is to be legible. Can you tell which
+  figure is YOURS? Where the enemy is? Which tiles are walls/props you cannot cross? Whether it is
+  your turn? Where an action landed? Note when the render leaves you guessing.
+- Do NOT read documentation. Do NOT invent keyboard shortcuts you were not told about. You expect
+  the WINDOW to show you what to do.
+
+WHEN TO report_bug — the gold of the test. Call report_bug the MOMENT the rendered surface breaks or
+misleads you, tagging the confusion class where it fits:
+  - a DEAD control: you clicked something that clearly should act and NOTHING changed (the tool
+    warns you when the view did not change),
+  - a STATE MISMATCH: the render disagrees with what just happened (your hero didn't move where you
+    clicked; an enemy you defeated is still standing; HP/turn indicator is wrong),
+  - an UNEXPLAINED WAIT: you acted and nothing visibly happened for a long time (>10s) with no
+    indication the game is working,
+  - a MISLABELED / illegible AFFORDANCE: you cannot tell whose turn it is, which figure is yours,
+    what is walkable, or how to attack — the picture doesn't teach you,
+  - anything visibly glitched: a missing/magenta model, a figure floating off the floor, a token
+    with no matching figure, z-fighting, an empty or black scene.
+Fill in: severity (critical = cannot play at all / major = blocks this step / minor = annoying /
+trivial = cosmetic), the part of the game you are on, what you EXPECTED, and what ACTUALLY happened.
+One bug per call. Keep going after reporting — report what you find AND keep playing the loop.
+
+YOUR LOOP, each turn: screenshot() → decide the ONE next thing a player would do to advance the
+quest loop → do it with a tool → observe. When you have completed the loop (or genuinely stuck),
+end honestly with finish(...) (or give_up if stuck). Start now.

--- a/qa/test_native_palette.py
+++ b/qa/test_native_palette.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Self-checks for the T3 NATIVE-window playtester palette (issue #1436 U2 / #1322).
+
+These are GUI-FREE: they prove the tool CONTRACT, the runner's permission discipline, and that
+qa/ui_playtest_score.py scores a native run UNCHANGED — WITHOUT launching WorldOSPlayer.app or
+needing a TCC grant. The pieces that need a Mac toolchain (swiftc compile, the node MCP boot) are
+skipped where absent, so this stays green in Linux CI and on the fast gate.
+
+Run: python3 -m pytest -q qa/test_native_palette.py   (or: python3 qa/test_native_palette.py)
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+NPT = ROOT / "qa" / "native_palette"
+SERVER = NPT / "native_palette_server.js"
+SWIFT = NPT / "native_input.swift"
+PERSONA = NPT / "play_player_native_t3.txt"
+RUNNER = ROOT / "qa" / "ui_playtest_player.sh"
+
+EXPECTED_TOOLS = {"screenshot", "a11y_tree", "click", "type", "key", "wait",
+                  "report_bug", "give_up", "finish"}
+
+
+def _node_modules_with_sdk() -> str | None:
+    """A node_modules dir that has the MCP SDK (worktrees don't install deps — fall back to the
+    canonical checkout's qa/playwright install)."""
+    for base in (NPT / "node_modules",
+                 ROOT / "qa" / "playwright" / "node_modules",
+                 Path("/Users/lume/WorldOS/qa/playwright/node_modules")):
+        if (base / "@modelcontextprotocol").is_dir():
+            return str(base)
+    return None
+
+
+class NativePaletteContractTests(unittest.TestCase):
+    def test_files_exist(self):
+        for p in (SERVER, SWIFT, PERSONA, RUNNER):
+            self.assertTrue(p.is_file(), f"missing {p}")
+        self.assertTrue(os.access(RUNNER, os.X_OK), "runner must be executable")
+
+    def test_server_registers_the_nine_tool_contract(self):
+        src = SERVER.read_text(encoding="utf-8")
+        registered = set(__import__("re").findall(r'registerTool\(\s*"([a-z0-9_]+)"', src))
+        self.assertEqual(registered, EXPECTED_TOOLS,
+                         f"native palette must expose exactly the 9-tool contract; got {sorted(registered)}")
+
+    def test_a11y_is_a_pixels_only_stub(self):
+        src = SERVER.read_text(encoding="utf-8")
+        self.assertIn("pixels-only", src)
+        self.assertIn("A11Y_STUB", src)
+
+    def test_artifact_layout_matches_scorer(self):
+        # The scorer reads bugs.ndjson (run root) + player/{actions,console,network}.ndjson + status.json.
+        src = SERVER.read_text(encoding="utf-8")
+        for token in ('"bugs.ndjson"', '"actions.ndjson"', '"status.json"',
+                      '"console.ndjson"', '"network.ndjson"'):
+            self.assertIn(token, src, f"server must write {token}")
+
+    def test_persona_is_pixels_and_quest_loop(self):
+        brief = PERSONA.read_text(encoding="utf-8")
+        self.assertIn("click(x, y)", brief)
+        self.assertIn("QUEST LOOP", brief)
+        self.assertIn("finish(", brief)
+
+
+class RunnerPermissionDisciplineTests(unittest.TestCase):
+    def test_header_names_both_settings_panes(self):
+        text = RUNNER.read_text(encoding="utf-8")
+        self.assertIn("Screen Recording", text)
+        self.assertIn("Accessibility", text)
+        self.assertIn("Privacy & Security", text)
+
+    def test_fails_loud_on_missing_permission(self):
+        text = RUNNER.read_text(encoding="utf-8")
+        # A missing grant must be a LOUD exit, never a silent skip.
+        self.assertIn("FATAL: Screen Recording NOT granted", text)
+        self.assertIn("FATAL: Accessibility NOT granted", text)
+        self.assertIn("--preflight", text)
+
+    def test_boots_the_seed_viewer_player_score_recipe(self):
+        text = RUNNER.read_text(encoding="utf-8")
+        for token in ("seed_gfx_combat.py", "viewer/server.py", "native_palette_server.js",
+                      "WORLDOS_ENGINE_BASE_URL", "WORLDOS_CAMPAIGN_ID", "ui_playtest_score.py",
+                      "WorldOSPlayer"):
+            self.assertIn(token, text, f"runner must reference {token}")
+
+
+class SwiftHelperTests(unittest.TestCase):
+    @unittest.skipUnless(shutil.which("swiftc"), "swiftc not available (non-macOS CI)")
+    def test_helper_compiles(self):
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "native_input"
+            r = subprocess.run(["swiftc", str(SWIFT), "-o", str(out)],
+                               capture_output=True, text=True)
+            self.assertEqual(r.returncode, 0, f"swiftc failed:\n{r.stderr}")
+            self.assertTrue(out.is_file())
+            # checkperms must emit the gate keys the palette reads.
+            p = subprocess.run([str(out), "checkperms"], capture_output=True, text=True)
+            data = json.loads(p.stdout.strip().splitlines()[-1])
+            self.assertIn("screen_recording", data)
+            self.assertIn("accessibility", data)
+            # winfind on a bogus owner is a clean not-found (never a crash).
+            w = subprocess.run([str(out), "winfind", "NoSuchApp_ZZZ"], capture_output=True, text=True)
+            self.assertEqual(json.loads(w.stdout.strip().splitlines()[-1]).get("found"), False)
+
+
+class ServerBootTests(unittest.TestCase):
+    @unittest.skipUnless(shutil.which("node"), "node not available")
+    def test_selfcheck_boots_and_matches_contract(self):
+        nm = _node_modules_with_sdk()
+        if not nm:
+            self.skipTest("MCP SDK not installed (cd qa/playwright && npm install)")
+        with tempfile.TemporaryDirectory() as td:
+            env = {**os.environ, "WORLDOS_NPT_RUNDIR": td, "WORLDOS_NPT_NODE_MODULES": nm}
+            r = subprocess.run(["node", str(SERVER), "--selfcheck"],
+                               capture_output=True, text=True, env=env)
+            self.assertEqual(r.returncode, 0, f"selfcheck failed:\n{r.stdout}\n{r.stderr}")
+            data = json.loads(r.stdout.strip().splitlines()[-1])
+            self.assertTrue(data["ok"])
+            self.assertTrue(data["tool_contract_match"])
+            self.assertEqual(set(data["tools"]), EXPECTED_TOOLS)
+
+
+class ScorerCompatibilityTests(unittest.TestCase):
+    """Prove qa/ui_playtest_score.py consumes the EXACT artifact shape the native palette writes,
+    UNCHANGED — the load-bearing point of Unit 2."""
+
+    def test_score_reads_native_palette_artifacts(self):
+        with tempfile.TemporaryDirectory() as td:
+            rundir = Path(td)
+            (rundir / "player").mkdir()
+            # bugs.ndjson — one player bug, exactly as writeBug() emits it.
+            (rundir / "bugs.ndjson").write_text(json.dumps({
+                "ts": "2026-07-09T00:00:00Z", "action_seq": 0, "persona": "t3-native",
+                "screen": "player", "category": "ux", "severity": "minor", "title": "quiet NPC",
+                "expected": "npc greets", "actual": "silence", "screenshot": "", "evidence": {},
+                "tried_alternatives": [], "blocks_progress": False, "source": "player",
+            }) + "\n", encoding="utf-8")
+            # actions.ndjson — a submitted turn (type submit=true counts as an in-story turn).
+            (rundir / "player" / "actions.ndjson").write_text(
+                json.dumps({"ts": "2026-07-09T00:00:01Z", "seq": 1, "action": "screenshot", "screen": "player"}) + "\n" +
+                json.dumps({"ts": "2026-07-09T00:00:02Z", "seq": 2, "action": "type",
+                            "text": "attack the goblin", "submit": True, "ok": True, "screen": "player"}) + "\n",
+                encoding="utf-8")
+            (rundir / "player" / "console.ndjson").write_text("", encoding="utf-8")
+            (rundir / "player" / "network.ndjson").write_text("", encoding="utf-8")
+            # status.json — a finish() with a structured satisfaction (the T3 signal).
+            (rundir / "player" / "status.json").write_text(json.dumps({
+                "ended": True, "reason": "finish", "satisfaction": 7,
+                "detail": "Completed the loop; readable.", "at": "2026-07-09T00:00:03Z"}), encoding="utf-8")
+            (rundir / "meta.json").write_text(json.dumps({
+                "run": "t3-unit", "persona": "t3-native", "world": "camp_gfxdemo01"}), encoding="utf-8")
+
+            r = subprocess.run([sys.executable, str(ROOT / "qa" / "ui_playtest_score.py"), str(rundir), ""],
+                               capture_output=True, text=True)
+            self.assertEqual(r.returncode, 0, f"scorer errored:\n{r.stderr}")
+            score = json.loads((rundir / "score.json").read_text(encoding="utf-8"))
+            self.assertEqual(score["persona"], "t3-native")
+            self.assertEqual(score["in_story_turns"], 1)
+            self.assertEqual(score["persona_satisfaction"], 7)
+            self.assertEqual(score["satisfaction_source"], "self-reported")
+            self.assertEqual(score["bug_reports_minor"], 1)
+            self.assertEqual(score["console_errors"], 0)
+            self.assertEqual(score["network_failures"], 0)
+            self.assertTrue((rundir / "summary.md").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/qa/ui_playtest_player.sh
+++ b/qa/ui_playtest_player.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# WorldOS T3 NATIVE-PLAYER PLAYTESTER HARNESS (issue #1436 W5c Unit 2 / #1322 the T3 gate).
+#
+# The browser sibling qa/ui_playtest.sh drives the /openworlds/ BROWSER UI. THIS runner drives the
+# standalone Unity **WorldOSPlayer.app** window — the RENDERED surface the T3 gate exits on: a blind
+# AI playtester completes a quest loop (walk to an NPC → take a quest → cross rooms → fight → resolve
+# → report satisfaction) entirely in the native window, scored by the SAME qa/ui_playtest_score.py.
+#
+# Four processes, one run (the DM side is UNCHANGED from qa/ui_playtest.sh / qa/run_duo.sh):
+#   - Engine + Viewer (viewer/server.py): serves the engine surfaces (/combat-surface, /events) that
+#     the player build consumes, wired with a move sink ($MOVES) + a two-sided chat log ($CHAT).
+#     Engine is the SOLE writer; the viewer only reads surfaces + accepts /move intents.
+#   - The pre-seeded campaign: qa/seed_gfx_combat.py mints camp_gfxdemo01 (hero-vs-goblin GRID combat
+#     on the crypt plate) so a LIVE, renderable scene exists the instant the player app connects.
+#   - WorldOSPlayer.app: launched with the env launch-contract (WORLDOS_ENGINE_BASE_URL /
+#     WORLDOS_CAMPAIGN_ID — PlayerLauncher.swift / CombatSurfaceClient.cs). Renders camp_gfxdemo01 and
+#     posts move-intents through the existing /move kinds. Pure consumer; never writes engine state.
+#   - DM agent (claude -p, full plugin): the SAME dm_turn helper + background resolver loop as
+#     qa/ui_playtest.sh. Grounds on the pre-seeded campaign, opens the scene, then resolves each move
+#     the player posts and narrates the next beat. The DM never knows there is a native window.
+#   - PLAYER agent (claude -p, ONLY the NATIVE palette MCP — strict): a blind player that SEES only
+#     the window (screenshot) and ACTS only via click(x,y)/type/key/wait, reporting friction via
+#     report_bug/give_up/finish. NO source, NO engine introspection, NO filesystem. It drives the
+#     REAL Unity window; its clicks POST /move; the unchanged DM resolves; the render updates.
+#
+# ────────────────────────────────────────────────────────────────────────────────────────────────
+# macOS PERMISSIONS (REQUIRED — the native palette FAILS LOUD, never silently skips, if either is
+# missing; granting them is an OWNER action, not a test outcome):
+#   1. Screen Recording  →  System Settings ▸ Privacy & Security ▸ Screen Recording
+#        Enable the app that runs THIS script (Terminal / iTerm / your shell), then RESTART it.
+#        Needed both to screencapture the player window AND for CGWindowList to see the window at all.
+#   2. Accessibility     →  System Settings ▸ Privacy & Security ▸ Accessibility
+#        Enable the same app, then RESTART it. Needed for synthetic clicks/keystrokes to land.
+# Preflight both without launching a run:   qa/ui_playtest_player.sh --preflight
+# ────────────────────────────────────────────────────────────────────────────────────────────────
+#
+# Usage:   qa/ui_playtest_player.sh <runid> <beats> <budget>
+#   <runid>  = names qa/ui_playtest_runs/<runid>/ (wiped + recreated).
+#   <beats>  = soft cap on player palette actions.  <budget> = USD cap for the PLAYER agent.
+# Env knobs:
+#   WORLDOS_PLAYER_APP        — path to WorldOSPlayer.app (default: ~/Applications, /Applications,
+#                               then ~/worldos-session-notes/w5a-build/WorldOSPlayer.app).
+#   WORLDOS_NPT_WINDOW_OWNER  — CGWindowList owner name (default "WorldOSPlayer").
+#   WORLDOS_DM_MODEL / WORLDOS_UIPT_PLAYER_MODEL — per-agent models (DM opus; player sonnet).
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 1
+
+NPT_DIR="$ROOT/qa/native_palette"
+PW_DIR="$ROOT/qa/playwright"                     # the palette shares the MCP SDK installed here
+OWNER="${WORLDOS_NPT_WINDOW_OWNER:-WorldOSPlayer}"
+CID="camp_gfxdemo01"                             # the id seed_gfx_combat.py + the box renderer pin
+
+# --- locate the installed MCP SDK (worktrees have no node_modules — accept an explicit override or
+# the canonical checkout's qa/playwright install, matching native_palette_server.js's resolution). --
+find_sdk_node_modules() {
+  local c
+  for c in "${WORLDOS_NPT_NODE_MODULES:-}" \
+           "$PW_DIR/node_modules" \
+           "/Users/lume/WorldOS/qa/playwright/node_modules"; do
+    [ -n "$c" ] && [ -d "$c/@modelcontextprotocol" ] && { echo "$c"; return 0; }
+  done
+  return 1
+}
+
+# --- locate the player app ---------------------------------------------------
+find_player_app() {
+  local c
+  for c in "${WORLDOS_PLAYER_APP:-}" \
+           "$HOME/Applications/WorldOSPlayer.app" \
+           "/Applications/WorldOSPlayer.app" \
+           "$HOME/worldos-session-notes/w5a-build/WorldOSPlayer.app"; do
+    [ -n "$c" ] && [ -d "$c" ] && { echo "$c"; return 0; }
+  done
+  return 1
+}
+
+# --- --preflight: validate prerequisites + permissions, then exit (no run) ---
+if [ "${1:-}" = "--preflight" ]; then
+  rc=0
+  echo "[t3-preflight] checking prerequisites…"
+  if APP="$(find_player_app)"; then echo "  ✓ player app: $APP"; else echo "  ✗ WorldOSPlayer.app not found (set WORLDOS_PLAYER_APP)"; rc=1; fi
+  if SDK_NM="$(find_sdk_node_modules)"; then echo "  ✓ MCP SDK present ($SDK_NM)"; else echo "  ✗ palette deps missing — (cd qa/playwright && npm install)"; rc=1; fi
+  if node "$NPT_DIR/native_palette_server.js" --selfcheck >/tmp/npt_selfcheck.json 2>&1 && grep -q '"ok":true' /tmp/npt_selfcheck.json; then
+    echo "  ✓ native palette selfcheck: 9-tool contract OK"; else echo "  ✗ native palette selfcheck FAILED:"; cat /tmp/npt_selfcheck.json; rc=1; fi
+  if command -v swiftc >/dev/null 2>&1 && swiftc -typecheck "$NPT_DIR/native_input.swift" 2>/tmp/npt_swift.err; then
+    echo "  ✓ swift helper compiles"; else echo "  ✗ swift helper did not compile:"; cat /tmp/npt_swift.err 2>/dev/null; rc=1; fi
+  PERMS="$(swift "$NPT_DIR/native_input.swift" checkperms 2>/dev/null)"
+  echo "  · permission probe: $PERMS"
+  echo "$PERMS" | grep -q '"screen_recording":true' || { echo "  ✗ SCREEN RECORDING missing → System Settings ▸ Privacy & Security ▸ Screen Recording (enable this terminal, restart it)"; rc=1; }
+  echo "$PERMS" | grep -q '"accessibility":true'   || { echo "  ✗ ACCESSIBILITY missing → System Settings ▸ Privacy & Security ▸ Accessibility (enable this terminal, restart it)"; rc=1; }
+  [ "$rc" = 0 ] && echo "[t3-preflight] ALL GREEN — ready to run the T3 gate." || echo "[t3-preflight] NOT READY (see ✗ above)."
+  exit "$rc"
+fi
+
+. "$ROOT/qa/lib_beat_driver.sh"  # worldos_env + shared DM helpers (dm_timeout/resolve/chatlog)
+
+RUN="${1:-t3-$(date +%H%M%S)}"
+BEATS="${2:-40}"
+BUDGET="${3:-4.00}"
+DM_MODEL="$(worldos_env DM_MODEL opus)"
+PLAYER_MODEL="$(worldos_env UIPT_PLAYER_MODEL sonnet)"
+case "$DM_MODEL" in *opus*) _dm_def=12.00 ;; *) _dm_def=1.50 ;; esac
+DM_BUDGET="$(worldos_env UIPT_DM_BUDGET "$_dm_def")"
+WORLDOS_DM_MODEL="$DM_MODEL"
+WORLDOS_ACTOR_MODEL="$PLAYER_MODEL"
+# shellcheck source=glm_profile.sh
+. "$ROOT/qa/glm_profile.sh"; worldos_apply_glm_profile
+
+PERSONA_FILE="$ROOT/qa/native_palette/play_player_native_t3.txt"
+[ -f "$PERSONA_FILE" ] || { echo "[t3] no persona brief at $PERSONA_FILE" >&2; exit 2; }
+SDK_NM="$(find_sdk_node_modules)" || {
+  echo "[t3] MCP SDK not installed. Run: (cd qa/playwright && npm install)" >&2; exit 2; }
+APP="$(find_player_app)" || { echo "[t3] WorldOSPlayer.app not found (set WORLDOS_PLAYER_APP). Run --preflight." >&2; exit 2; }
+PLAYER_BIN="$APP/Contents/MacOS/WorldOSPlayer"
+[ -x "$PLAYER_BIN" ] || { echo "[t3] player binary not executable: $PLAYER_BIN" >&2; exit 2; }
+
+RUNDIR="$ROOT/qa/ui_playtest_runs/$RUN"
+PLAYERDIR="$RUNDIR/player"
+STATE_DIR="$RUNDIR/state"
+rm -rf "$RUNDIR" 2>/dev/null
+mkdir -p "$PLAYERDIR/screenshots" "$PLAYERDIR/a11y" "$STATE_DIR" "$RUNDIR/dm"
+MOVES="$STATE_DIR/player_moves.jsonl"; : > "$MOVES"
+CHAT="$RUNDIR/dm/chat.jsonl"; : > "$CHAT"
+COMBINED="$RUNDIR/dm/dm.jsonl"; : > "$COMBINED"
+DM_CFG="$STATE_DIR/dm.mcp.json"
+PLAYER_CFG="$STATE_DIR/player.mcp.json"
+
+# --- fail-loud permission preflight BEFORE we spend anything ------------------
+PERMS="$(swift "$NPT_DIR/native_input.swift" checkperms 2>/dev/null)"
+if ! echo "$PERMS" | grep -q '"screen_recording":true'; then
+  echo "[t3] FATAL: Screen Recording NOT granted → System Settings ▸ Privacy & Security ▸ Screen Recording" >&2
+  echo "       (enable the app running this script, then RESTART it). probe=$PERMS" >&2; exit 5; fi
+if ! echo "$PERMS" | grep -q '"accessibility":true'; then
+  echo "[t3] FATAL: Accessibility NOT granted → System Settings ▸ Privacy & Security ▸ Accessibility" >&2
+  echo "       (enable the app running this script, then RESTART it). probe=$PERMS" >&2; exit 5; fi
+echo "[t3] permissions OK: $PERMS"
+
+# --- free port in 8990–8999 --------------------------------------------------
+pick_port() { local p; for p in $(seq 8990 8999); do
+  if ! (exec 3<>"/dev/tcp/127.0.0.1/$p") 2>/dev/null; then echo "$p"; return 0; fi
+  exec 3>&- 2>/dev/null || true; done; return 1; }
+PORT="$(pick_port)" || { echo "[t3] no free port in 8990-8999 — aborting" >&2; exit 3; }
+BASE_URL="http://127.0.0.1:$PORT"
+
+# --- seed the pre-minted combat campaign (engine = sole writer) --------------
+# uv --directory cd's into servers/engine, so pass the seed by ABSOLUTE path (per its docstring).
+echo "[t3] seeding $CID (hero-vs-goblin grid combat)…"
+SEED_JSON="$(WORLDOS_STATE_DIR="$STATE_DIR" uv run --directory servers/engine python "$ROOT/qa/seed_gfx_combat.py" "$STATE_DIR" 2>"$RUNDIR/seed.err")" \
+  || { echo "[t3] seed failed (see $RUNDIR/seed.err)" >&2; cat "$RUNDIR/seed.err" >&2; exit 4; }
+echo "[t3] seeded: $SEED_JSON"
+
+# --- DM MCP config: re-root every server at THIS repo + scope engine to $STATE_DIR (== ui_playtest.sh).
+python3 - "$ROOT/qa/qa.mcp.example.json" "$STATE_DIR" "$DM_CFG" "$ROOT" <<'PY'
+import json, os, sys
+cfg_path, state, out, root = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+cfg = json.load(open(cfg_path))
+for name, srv in cfg.get("mcpServers", {}).items():
+    args = srv.get("args", [])
+    if "--directory" in args:
+        i = args.index("--directory"); raw = args[i + 1].rstrip("/")
+        if raw.startswith("./"): raw = raw[2:]
+        if "/servers/" in raw: pkg = raw.rsplit("/servers/", 1)[1]
+        elif raw.startswith("servers/"): pkg = raw[len("servers/"):]
+        else: pkg = raw
+        args[i + 1] = f"{root}/servers/{pkg}"
+    if name == "worldos-engine":
+        srv.setdefault("env", {})["WORLDOS_STATE_DIR"] = state
+        if os.environ.get("WORLDOS_ENGINE_ALWAYSLOAD", "1") == "1":
+            srv["alwaysLoad"] = True
+json.dump(cfg, open(out, "w"))
+PY
+
+# --- PLAYER MCP config: ONLY the NATIVE palette server (strict, no other tools). The palette treats
+# WORLDOS_NPT_RUNDIR as the RUN ROOT (bugs.ndjson + status.json there; screenshots/actions under player/).
+python3 - "$NPT_DIR" "$RUNDIR" "$OWNER" "$SDK_NM" "$PLAYER_CFG" <<'PY'
+import json, sys
+npt_dir, rundir, owner, node_modules, out = sys.argv[1:6]
+json.dump({"mcpServers": {"worldos-nativeplayer": {
+    "command": "node",
+    "args": [f"{npt_dir}/native_palette_server.js"],
+    "env": {
+        "WORLDOS_NPT_RUNDIR": rundir,
+        "WORLDOS_NPT_PERSONA": "t3-native",
+        "WORLDOS_NPT_WINDOW_OWNER": owner,
+        "WORLDOS_NPT_NODE_MODULES": node_modules,
+    },
+}}}, open(out, "w"))
+PY
+
+echo "[t3] run=$RUN port=$PORT beats=$BEATS budget=\$$BUDGET app=$APP"
+
+# --- start engine + viewer (move sink + chat wired) --------------------------
+WORLDOS_STATE_DIR="$STATE_DIR" \
+WORLDOS_VIEWER_CHAT="$CHAT" WORLDOS_PLAYER_MOVES="$MOVES" \
+  python3 viewer/server.py "" "$PORT" > "$RUNDIR/viewer.log" 2>&1 &
+VIEWER=$!
+PLAYER_APP_PID=""
+cleanup() {
+  kill "$VIEWER" 2>/dev/null
+  [ -n "${DMLOOP:-}" ] && kill "$DMLOOP" 2>/dev/null
+  [ -n "$PLAYER_APP_PID" ] && kill "$PLAYER_APP_PID" 2>/dev/null
+  osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+ready=0
+for _ in $(seq 1 40); do
+  code="$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/combat-surface?campaign=$CID" 2>/dev/null)"
+  [ "$code" = "200" ] && { ready=1; break; }
+  sleep 0.5
+done
+[ "$ready" = "1" ] || { echo "[t3] viewer never served /combat-surface at $BASE_URL (see $RUNDIR/viewer.log)" >&2; exit 4; }
+echo "[t3] viewer ready — /combat-surface serving $CID."
+
+# --- launch the native player build with the env launch-contract -------------
+# WorldOSPlayer.app reads WORLDOS_ENGINE_BASE_URL + WORLDOS_CAMPAIGN_ID at startup
+# (CombatSurfaceClient.Start) and renders the surface. ONE live GUI harness at a time — we quit any
+# stale instance first, then launch fresh (the app activates rather than duplicating on relaunch).
+osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
+sleep 1
+WORLDOS_ENGINE_BASE_URL="$BASE_URL" WORLDOS_CAMPAIGN_ID="$CID" "$PLAYER_BIN" \
+  > "$RUNDIR/player_app.log" 2>&1 &
+PLAYER_APP_PID=$!
+echo "[t3] player app launched (pid $PLAYER_APP_PID) — engine=$BASE_URL campaign=$CID"
+# Give the Unity build a beat to open its window + first combat-surface fetch before the agent looks.
+sleep 6
+
+# --- DM turn helper + opening + resolver loop (IDENTICAL shape to qa/ui_playtest.sh) ----------------
+DSID="$(python3 -c 'import uuid;print(uuid.uuid4())')"
+DM_BRIEF="$(cat "$ROOT/qa/play_dm_duo.txt")"
+WORLDOS_DM_MODEL="$DM_MODEL"
+dm_turn() {
+  local first="$1" msg="$2" out resume=() beat_timeout rc
+  worldos_dm_prebeat_mark "$STATE_DIR"
+  msg="$WORLDOS_LIVE_PROGRESS_RULE"$'\n\n'"$msg"
+  [ "$first" = "0" ] && resume=(--resume "$DSID") || resume=(--session-id "$DSID")
+  beat_timeout="$(worldos_dm_timeout "$first")"
+  out="$RUNDIR/dm/turn.$(date +%s%N).jsonl"
+  timeout "$beat_timeout" \
+    claude -p "$msg" "${resume[@]}" --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
+    --model "$DM_MODEL" --permission-mode bypassPermissions --max-budget-usd "$DM_BUDGET" \
+    --output-format stream-json --verbose > "$out" 2>> "$RUNDIR/dm/dm.err"
+  rc=$?
+  [ "$rc" -ne 0 ] && echo "[t3] DM turn rc=$rc (timeout=${beat_timeout}s) — relying on engine-logged narration fallback" >&2
+  cat "$out" >> "$COMBINED"
+  worldos_dm_final_text "$out" "$STATE_DIR" "$rc"
+}
+
+# The campaign is PRE-SEEDED (camp_gfxdemo01), so — unlike ui_playtest.sh's cold-open — the DM GROUNDS
+# on the existing state and opens the scene; it does NOT start_world/re-seat (mirrors mechanism_probe.sh).
+echo "[t3] DM opening the scene on the pre-seeded campaign…"
+DMSG="$(dm_turn 1 "$DM_BRIEF
+
+You are resuming an IN-PROGRESS session (campaign_id=\"$CID\") — the party + a live combat encounter are ALREADY seeded (a level-4 fighter PC vs a goblin in a firelit crypt on a combat grid). Do NOT start_world or re-seat anyone. FIRST call scene_context(campaign_id=\"$CID\") (or get_state) to re-ground on the party, the combat, and the grid. Then open the scene with real quoted narration and hand the player an open moment + a clear choice. Their actions arrive next as tagged moves; resolve them THROUGH the engine and narrate.")"
+worldos_resolve_dm_reply "$DMSG" "$STATE_DIR"; DMSG="$WORLDOS_DM_REPLY"
+if [ -z "$DMSG" ]; then
+  echo "[t3] WARN: DM produced no opening (see $RUNDIR/dm/dm.err) — recording a visible failure beat." >&2
+  worldos_chatlog_dm_failed
+else
+  worldos_chatlog_dm "$DMSG"
+fi
+
+# --- background DM-resolver loop (IDENTICAL to ui_playtest.sh) ----------------
+(
+  MCURSOR="$(wc -l < "$MOVES" 2>/dev/null | tr -d ' ')"; MCURSOR="${MCURSOR:-0}"
+  DMLOOP_BEAT=0
+  while true; do
+    total="$(wc -l < "$MOVES" 2>/dev/null | tr -d ' ')"; total="${total:-0}"
+    if [ "$total" -gt "$MCURSOR" ]; then
+      new="$(tail -n +"$((MCURSOR + 1))" "$MOVES" 2>/dev/null)"; MCURSOR="$total"
+      PMSG="$(printf '%s' "$new" | jq -rs 'map("[\(.kind)] \(.text // .name // "")") | join("  ")' 2>/dev/null)"
+      [ -z "$PMSG" ] && continue
+      chatlog player "$PMSG"
+      HB_CID="$CID"
+      worldos_emit_progress_heartbeat "$HB_CID" 0 "$DMLOOP_BEAT"
+      DMLOOP_BEAT=$((DMLOOP_BEAT + 1))
+      DMSG="$(dm_turn 0 "The player does:
+
+$PMSG
+
+Resolve it through the engine (roll checks, apply casts/attacks, voice NPCs) and narrate the next beat as a played scene. Hand the moment back to the player.")"
+      worldos_resolve_dm_reply "$DMSG" "$STATE_DIR"; DMSG="$WORLDOS_DM_REPLY"
+      if [ -z "$DMSG" ]; then worldos_chatlog_dm_failed; else worldos_chatlog_dm "$DMSG"; fi
+    else
+      sleep 2
+    fi
+  done
+) &
+DMLOOP=$!
+echo "[t3] DM resolver loop up (pid $DMLOOP)."
+
+# --- PLAYER agent: blind player drives the NATIVE window via the native palette MCP only ----------
+PERSONA_BRIEF="$(cat "$PERSONA_FILE")"
+PSID="$(python3 -c 'import uuid;print(uuid.uuid4())')"
+echo "[t3] player agent starting (native palette, max ~$BEATS actions)…"
+PLAYER_OUT="$RUNDIR/player/player.jsonl"
+claude -p "$PERSONA_BRIEF
+
+You have a budget of about $BEATS actions for this whole session. Play the quest loop in the rendered window: look (screenshot), move toward the encounter, act, and see the result, reporting friction as you go. When you have either (a) genuinely gotten stuck after reporting it, or (b) completed the loop and seen enough to judge the experience, stop — give a final 1-2 sentence verdict via finish(satisfaction, verdict), or give_up if you are stuck. Start now." \
+  --session-id "$PSID" --mcp-config "$PLAYER_CFG" --strict-mcp-config \
+  --model "$PLAYER_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+  --output-format stream-json --verbose > "$PLAYER_OUT" 2>> "$RUNDIR/player/player.err"
+PLAYER_RC=$?
+echo "[t3] player agent finished (rc=$PLAYER_RC)."
+
+PLAYER_VERDICT="$(jq -rs 'map(select(.type=="result"))[-1].result // ""' "$PLAYER_OUT" 2>/dev/null)"
+PLAYER_COST="$(jq -rs '[.[]|select(.type=="result")|.total_cost_usd//0]|add // 0' "$PLAYER_OUT" 2>/dev/null)"
+
+# Stop the DM loop + viewer + player app before scoring.
+kill "$DMLOOP" 2>/dev/null; DMLOOP=""
+kill "$VIEWER" 2>/dev/null
+kill "$PLAYER_APP_PID" 2>/dev/null; osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
+
+# --- meta.json (state_dir lets the scorer resolve the campaign snapshot for structural_coverage) ---
+python3 - "$RUNDIR/meta.json" "$RUN" "$CID" "$PORT" "$BEATS" "$BUDGET" "$PLAYER_COST" "$PLAYER_RC" "$STATE_DIR" <<'PY'
+import json, sys, datetime
+out, run, cid, port, beats, budget, cost, rc, state_dir = sys.argv[1:10]
+json.dump({
+    "run": run, "world": cid, "persona": "t3-native", "surface": "native-player",
+    "port": int(port), "beats_cap": int(beats), "budget_usd": float(budget),
+    "player_cost_usd": round(float(cost or 0), 4), "player_rc": int(rc),
+    "state_dir": state_dir,
+    "finished_at": datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0, tzinfo=None).isoformat() + "Z",
+}, open(out, "w"), indent=2)
+PY
+
+echo "[t3] scoring + summarizing…"
+python3 "$ROOT/qa/ui_playtest_score.py" "$RUNDIR" "$PLAYER_VERDICT" 2>> "$RUNDIR/score.err"
+SCORE_RC=$?
+echo "[t3] done. dir=$RUNDIR"
+if [ -f "$RUNDIR/summary.md" ]; then echo "----- summary.md -----"; cat "$RUNDIR/summary.md"; fi
+exit "$SCORE_RC"


### PR DESCRIPTION
## What
Unit 2 of #1436 (W5c) / the T3 gate of #1322: extend the blind-playtester harness to drive the **native macOS WorldOSPlayer window** (not the browser), ready for the T3 quest-loop gate. Same 9-tool player contract as the browser palette, backed by macOS primitives instead of Playwright, scored by the **same** `qa/ui_playtest_score.py`.

## Files
- `qa/native_palette/native_input.swift` — Swift helper: `CGWindowList` window-find + `CGEvent` synthetic click/key/type + a permission probe. `CGPreflightScreenCaptureAccess` returns a false positive on macOS 14+/15+ (observed on the dev box), so the Screen-Recording gate is **empirical** (normal-window visibility). Runs interpreted (`swift …`) and compiles (`swiftc …`).
- `qa/native_palette/native_palette_server.js` — the native palette MCP server. `screenshot` = `screencapture -l <windowid>`; `click(x,y)` maps window-relative screenshot **pixels → global points** (Retina scale-aware); `a11y_tree` = a pixels-only stub (the T3 persona plays from screenshots); `type`/`key`/`wait`/`report_bug`/`give_up`/`finish` mirror the browser palette byte-for-byte in artifact shape. Shares the `qa/playwright` MCP SDK (no second npm install). `--selfcheck` asserts the 9-tool contract GUI-free.
- `qa/ui_playtest_player.sh` — the runner: `seed_gfx_combat.py` → `viewer/server.py` (`/combat-surface` + move sink + chat) → `WorldOSPlayer.app` launched with the `WORLDOS_ENGINE_BASE_URL`/`WORLDOS_CAMPAIGN_ID` launch-contract → the **unchanged** `run_duo` DM loop → native-palette player agent → teardown → score. **FAILS LOUD** with the exact System Settings pane on a missing permission (never a silent skip). `--preflight` validates app + deps + swift helper + both permissions without a run.
- `qa/native_palette/play_player_native_t3.txt` — the pixels-only quest-loop persona brief.
- `qa/test_native_palette.py` — contract + runner-permission-discipline + swift-compile + server-boot + **scorer-compatibility** self-checks. GUI-free; swift/node subtests skip where the toolchain is absent, so CI/fast-gate stay green.
- `qa/UI_PLAYTEST.md` — a section documenting the native variant + the permission requirements.

## macOS permissions (owner action)
The palette needs **Screen Recording** (System Settings ▸ Privacy & Security ▸ Screen Recording — for the capture AND for `CGWindowList` to enumerate the window) and **Accessibility** (▸ Accessibility — for synthetic input). Missing → the run aborts naming the pane. `qa/ui_playtest_player.sh --preflight` checks both.

## Tests
- `python3 -m pytest -q qa/test_native_palette.py` → **11 passed** (incl. swift compile + node MCP selfcheck + scorer-compat on this Mac).
- `qa/fast_gate.sh` → **257 passed** (green; additive, no engine touch).
- `qa/ui_playtest_player.sh --preflight` → ALL GREEN on the dev box.
- End-to-end MCP stdio drive (report_bug + type-submit + finish) → `qa/ui_playtest_score.py` scored the native output unchanged (in_story_turns=1, satisfaction=7 self-reported).

## Constraints honored
One live GUI harness at a time; never touches Eva; engine stays the sole writer; DM side unchanged (same `run_duo` loop). **Does NOT run the actual T3 gate** — that is the orchestrator's session (a real playtest that may need a permission grant).

Refs #1436 #1322. PRs #1430/#1432/#1435/#1438.

_Admin-merge note (#1389): auto-merge armed, no manual merge; admin-merge is acceptable per the relaxed policy once CI is green._