### PR TITLE
#1441 P2: scene<->grid coherence — camp fixture + SCENE/FIXTURE pairing

### DIFF
--- a/qa/UI_PLAYTEST.md
+++ b/qa/UI_PLAYTEST.md
@@ -104,13 +104,28 @@ macOS primitives instead of Playwright, and scores with the **same** `qa/ui_play
 
 ```sh
 qa/ui_playtest_player.sh --preflight            # check app + deps + swift helper + PERMISSIONS, no run
-qa/ui_playtest_player.sh <runid> <beats> <budget>   # seed → viewer → player app → DM loop → play → score
+qa/ui_playtest_player.sh <runid> <beats> <budget> [--force]   # seed → viewer → player app → DM loop → play → score
 ```
 
-- Boot recipe: `qa/seed_gfx_combat.py` mints `camp_gfxdemo01` → `viewer/server.py` serves
-  `/combat-surface` (move sink + chat wired) → `WorldOSPlayer.app` is launched with the env
-  launch-contract `WORLDOS_ENGINE_BASE_URL` / `WORLDOS_CAMPAIGN_ID` → the **unchanged** `run_duo` DM
-  loop resolves the player's moves → the native palette drives the window → teardown → score.
+- Boot recipe: the **scene-paired seed** (default `qa/seed_gfx_camp.py`, see the pairing table just
+  below) mints `camp_gfxdemo01` → `viewer/server.py` serves `/combat-surface` (move sink + chat
+  wired) → `WorldOSPlayer.app` is launched with the env launch-contract `WORLDOS_ENGINE_BASE_URL` /
+  `WORLDOS_CAMPAIGN_ID` → the **unchanged** `run_duo` DM loop resolves the player's moves → the
+  native palette drives the window → teardown → score.
+
+**SCENE ↔ FIXTURE pairing (#1441 Phase 2 — read this before changing the seed or the baked scene):**
+the Unity player build bakes exactly one scene's painted props into its plate, and the seed script's
+`scene_grid` impassable set must match that same scene or the painted props render walkable — this is
+precisely how the felt bug shipped: the player build baked the `camp_clearing_night` plate (fire pit,
+log seat, bedrolls, supply crates, boulders, tree line) while the harness kept seeding the older
+crypt-shaped grid (pillars + a sarcophagus) under the same `camp_gfxdemo01` campaign id, so none of the
+camp's painted scenery was pathing-solid and actors could stand *in* the campfire or *on* the log seat
+(the owner's "stacking on everything" report). `qa/ui_playtest_player.sh` now resolves the seed script
+from a `WORLDOS_PLAYER_SCENE` env var (`camp` default, or `crypt`) via a fixed pairing table —
+`camp` → `qa/seed_gfx_camp.py`, `crypt` → `qa/seed_gfx_combat.py` — and refuses to run with an explicit
+`WORLDOS_PLAYER_SEED_SCRIPT` override that doesn't match the requested scene unless you pass `--force`;
+when the player app's baked scene changes again, update the pairing table (or set
+`WORLDOS_PLAYER_SCENE=crypt`) rather than swapping the seed's grid contents in place.
 - Palette backing (`qa/native_palette/native_palette_server.js`): `screenshot` = `screencapture -l
   <windowid>` (window found via `CGWindowList`); `click(x,y)` = a `CGEvent` click at window-relative
   pixels mapped to global points (via `qa/native_palette/native_input.swift`, or `cliclick` if

--- a/qa/seed_gfx_camp.py
+++ b/qa/seed_gfx_camp.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""seed_gfx_camp.py — deterministic hero-vs-goblin GRID combat on camp_gfxdemo01, COHERENT with the
+camp_clearing_night plate (#1441 Phase 2: scene<->grid coherence).
+
+Sibling of qa/seed_gfx_combat.py (same shape: pinned campaign id, hero + goblin combat, surprise
+seeding) but the scene_grid is the camp_clearing_night AUTHORED grid, not the crypt's. The felt bug
+this fixes: the player's WorldOSPlayer.app build BAKES the camp_clearing_night plate (fire pit, log
+seat, bedrolls, supply crates, boulders, tree line — extensions/renderers/shared/room_recipes.json's
+"camp_clearing_night" entry, adopted tier=stable 2026-07-08), but the T3 harness (qa/ui_playtest_
+player.sh) seeded camp_gfxdemo01 with seed_gfx_combat.py's CRYPT grid (14x11, pillars + sarcophagus).
+Those painted camp props were never in the engine's impassable set, so actors could walk onto/through
+the fire pit and log seat — the owner's "stacking on everything" report. This seed re-authors
+camp_gfxdemo01 on the SAME campfire-clearing scene_grid room_recipes.json cites as the plate's
+source of truth (qa/seed_gfx_camp_clearing.py::_author_camp_grid, verbatim prop layout — one source
+between the painted plate and the combat obstacles), so the painted logs/fire/crates/bedrolls/rocks/
+trees are pathing-solid and the T3 harness renders a coherent scene.
+
+  # NOTE: uv --directory cd's into servers/engine first, so pass the script by ABSOLUTE path:
+  WORLDOS_STATE_DIR=<dir> uv run --directory servers/engine python "$PWD/qa/seed_gfx_camp.py" <state_dir>
+
+Engine = SOLE WRITER: writes only via server.* engine calls + save_campaign. Additive (a new seed;
+touches no existing seed/contract — seed_gfx_combat.py is untouched and stays available for when the
+player build reverts to the crypt plate).
+"""
+import json
+import os
+import sys
+
+
+CID = "camp_gfxdemo01"  # the id seed_gfx_combat.py + the box renderer pin (unchanged; grid swaps)
+GRID_W, GRID_H = 16, 12
+# Prop footprints — VERBATIM from qa/seed_gfx_camp_clearing.py::_author_camp_grid, the authored grid
+# extensions/renderers/shared/room_recipes.json's "camp_clearing_night" entry cites as its source of
+# truth. Keeping this list in lock-step (rather than importing the function) keeps this seed's own
+# OBSTACLES summary self-contained and directly diffable against the recipe's `_doc` field.
+TREE_CELLS = [[2, 0], [2, 1], [6, 0], [6, 1], [9, 0], [9, 1], [13, 0], [13, 1]]
+ROCK_L_CELLS = [[1, 6]]
+ROCK_R_CELLS = [[14, 6]]
+CAMPFIRE_CELLS = [[8, 6]]
+BEDROLL_CELLS = [[7, 7], [9, 7], [8, 8]]
+LOG_SEAT_CELLS = [[6, 6], [6, 7]]
+SUPPLY_CRATE_CELLS = [[10, 6]]
+OBSTACLES = (TREE_CELLS + ROCK_L_CELLS + ROCK_R_CELLS + CAMPFIRE_CELLS + BEDROLL_CELLS
+             + LOG_SEAT_CELLS + SUPPLY_CRATE_CELLS)
+# Combat spawns — the recipe's own party/npc zone anchors (clear of every prop footprint above).
+HERO_CELL = [7, 9]
+GOBLIN_CELL = [10, 8]
+
+
+def _build_camp_grid(cid: str, location_id: str = ""):
+    """Pure grid builder (no server dependency) — a 16x12 open-air campfire-clearing scene_grid, NO
+    perimeter walls (outdoor clearing; matches scene_grid.py::_gen_forest's convention and the
+    camp_clearing_night recipe), whose prop footprints are the painted fire pit / log seat / bedrolls
+    / supply crates / boulders / tree line. Kept separate from `_author_camp_grid` so it's directly
+    unit-testable (validate_scene_grid + impassable_cells) without spinning up a full campaign/server."""
+    from scene_grid import (  # noqa: PLC0415
+        SceneGrid, SceneGridSpec, SceneCell, SceneCellDefault, SceneProp, SceneLighting, _layout_hash,
+    )
+
+    cells: list = []
+    props: list = []
+
+    def _prop(pid: str, kind: str, footprint: list, band: str, sil: str) -> None:
+        anchor = footprint[0]
+        props.append(SceneProp(id=pid, kind=kind, cells=[(c0, r0) for (c0, r0) in footprint],
+                               anchor_cell=(anchor[0], anchor[1]), occluder=True,
+                               height_band=band, silhouette=sil))
+        for (c0, r0) in footprint:
+            cells.append(SceneCell(c=c0, r=r0, type="prop", walkable=False, prop_ref=pid))
+
+    for i, pair in enumerate((TREE_CELLS[0:2], TREE_CELLS[2:4], TREE_CELLS[4:6], TREE_CELLS[6:8])):
+        _prop(f"tree_{i}", "large_tree", pair, "tall", "gnarled night forest tree, dense dark canopy")
+    _prop("rock_l", "boulder", ROCK_L_CELLS, "mid", "mossy boulder catching firelight on one face")
+    _prop("rock_r", "boulder_r", ROCK_R_CELLS, "mid", "lichen-covered boulder in cool moon-shadow")
+    _prop("campfire", "campfire_pit", CAMPFIRE_CELLS, "low",
+          "a glowing campfire pit ringed with fire-stones, embers drifting up")
+    _prop("bedroll_1", "bedroll", [BEDROLL_CELLS[0]], "low", "a rolled sleeping bedroll and blanket")
+    _prop("bedroll_2", "bedroll_2", [BEDROLL_CELLS[1]], "low", "a rolled sleeping bedroll near the embers")
+    _prop("bedroll_3", "bedroll_3", [BEDROLL_CELLS[2]], "low", "a bedroll with a pack for a pillow")
+    _prop("log_seat", "fallen_log", LOG_SEAT_CELLS, "low", "a fallen log dragged up as fireside seating")
+    _prop("supply_crates", "supply_crates", SUPPLY_CRATE_CELLS, "low",
+          "stacked travel packs and a supply crate, waterskins hanging off the straps")
+
+    grid = SceneGrid(
+        scene_id=f"{cid}:camp_clearing", location_id=location_id, kind="forest",
+        biome="open forest clearing at night, campfire lit, moonlit tree line",
+        grid=SceneGridSpec(cols=GRID_W, rows=GRID_H, cell_size_ft=5, projection="dimetric-2to1"),
+        cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
+        cells=cells, props=props,
+        lighting=SceneLighting(key_dir_deg=200, key_color="#ff8a3d", ambient_color="#26305a",
+                               mood="night campfire clearing, warm ember glow from the central fire "
+                                    "vs deep blue-violet moonlit shadow under the trees"),
+    )
+    grid.art.layout_hash = _layout_hash(grid)
+    return grid
+
+
+def _author_camp_grid(server, cid: str):
+    """Attach a 16x12 camp_clearing_night-coherent scene_grid (see `_build_camp_grid`) to the
+    campaign's current location. Replaces the crypt grid seed_gfx_combat.py authored for this same
+    CID — the #1441 P2 fix — so the impassable set matches the CAMP plate the player build renders."""
+    c = server._require(cid)
+    loc = c.locations.get(c.current_location_id)
+    grid = _build_camp_grid(cid, loc.id)
+    loc.scene_grid = grid
+    server.save_campaign(c)
+    return grid
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: seed_gfx_camp.py <state_dir>", file=sys.stderr)
+        sys.exit(2)
+    state_dir = sys.argv[1]
+    os.environ["WORLDOS_STATE_DIR"] = state_dir
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "servers", "engine"))
+    import server  # noqa: PLC0415
+    from models import Campaign  # noqa: PLC0415
+
+    # Pin the well-known id the box renderer hardcodes (create_campaign auto-ids, so build directly).
+    server.save_campaign(Campaign(id=CID, title="GFX Camp Demo",
+                                  summary="Playable PoE2 3D-on-2D combat demo on camp_clearing_night."))
+    server.add_location(campaign_id=CID, name="Campfire Clearing", make_current=True,
+                        description="A moonlit forest clearing: a low campfire, bedrolls, a fallen-log "
+                                    "seat, supply crates, boulders, and a loose tree-line boundary.")
+
+    # Author a CONTRACT-MATCHING 16x12 scene_grid whose PROP cells == the painted camp_clearing_night
+    # plate's fire pit / log seat / bedrolls / crates / boulders / trees. One source: this scene_grid
+    # is the SAME layout room_recipes.json's "camp_clearing_night" entry cites (qa/seed_gfx_camp_
+    # clearing.py), so the combat obstacles below match exactly what the player renders.
+    grid = _author_camp_grid(server, CID)
+
+    server.start_session(CID, title="GFX Camp Demo")
+
+    hero = server.create_character(
+        campaign_id=CID, name="Aldric", kind="player",
+        race="human", class_name="fighter", level=4,
+        abilities={"strength": 18, "dexterity": 14, "constitution": 16,
+                   "intelligence": 10, "wisdom": 12, "charisma": 10},
+        apply_srd_defaults=True, add_to_party=True,
+    )
+    hero_id = hero["id"]
+
+    gob = server.spawn_monster(CID, name="Goblin", count=1)
+    goblin_id = gob["spawned"][0]["id"]
+
+    # Hero surprises the goblin so the PLAYER acts first (a surprised NPC skips its first turn);
+    # leading NPC turns don't auto-resolve headless (no DM), so the demo drive loop needs a PC current.
+    import scene_grid as sg  # noqa: PLC0415
+    # ONE source: combat obstacles = the FULL scene-grid impassable set (perimeter WALLS [none, this
+    # is an open-air clearing] + props), not a props-only subset — else a token could end on a cell
+    # the room art paints as prop.
+    impassable = sg.impassable_cells(grid, GRID_W, GRID_H)
+    server.start_combat(CID, [hero_id, goblin_id], surpriser_ids=[hero_id])
+    server.set_grid(CID, width=GRID_W, height=GRID_H, obstacles=impassable)
+    server.place_combatant_at_coords(CID, hero_id, HERO_CELL[0], HERO_CELL[1])
+    server.place_combatant_at_coords(CID, goblin_id, GOBLIN_CELL[0], GOBLIN_CELL[1])
+
+    print(json.dumps({
+        "campaign_id": CID, "hero_id": hero_id, "goblin_id": goblin_id,
+        "grid": f"{GRID_W}x{GRID_H}", "prop_obstacles": OBSTACLES, "impassable_total": len(impassable),
+        "hero_cell": HERO_CELL, "goblin_cell": GOBLIN_CELL,
+    }))
+
+
+if __name__ == "__main__":
+    main()

--- a/qa/test_seed_gfx_camp.py
+++ b/qa/test_seed_gfx_camp.py
@@ -1,0 +1,106 @@
+"""Self-tests for qa/seed_gfx_camp.py's authored camp_clearing_night-coherent scene_grid (#1441 P2).
+
+RED-FIRST regression for the scene<->grid coherence bug: the player's WorldOSPlayer.app build bakes
+the camp_clearing_night plate (painted fire pit, log seat, bedrolls, supply crates, boulders, tree
+line), but campaign camp_gfxdemo01's combat grid was seed_gfx_combat.py's CRYPT layout (14x11,
+pillars + a sarcophagus) — none of the camp's painted props were in the engine's impassable set, so
+actors could walk onto/through the fire pit and log seat (the owner's "stacking on everything"
+report). Before this fix existed, importing seed_gfx_camp and checking the camp prop cells against
+seed_gfx_combat's crypt-shaped impassable set would fail every assertion below (wrong grid dims,
+none of the camp prop cells impassable) — this file pins the FIXED grid so that regression can't
+silently return.
+
+Run with the engine venv (pydantic + pytest live there):
+    uv run --directory servers/engine python -m pytest ../../qa/test_seed_gfx_camp.py -p no:cacheprovider
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "qa"))
+sys.path.insert(0, str(_ROOT / "servers" / "engine"))
+
+import server  # noqa: E402,F401  imported FIRST: resolves the models<->scene_grid import cycle
+import seed_gfx_camp as sg  # noqa: E402
+from scene_grid import validate_scene_grid, impassable_cells  # noqa: E402
+
+
+def _grid():
+    return sg._build_camp_grid(sg.CID, "loc-test")
+
+
+def test_scene_grid_has_zero_validate_violations():
+    """The pre-greybox gate (door zones / protected lanes / connectivity) must stay clean."""
+    grid = _grid()
+    assert validate_scene_grid(grid, sg.GRID_W, sg.GRID_H) == []
+
+
+def test_grid_dims_match_camp_clearing_night_recipe():
+    """16x12 — the dims qa/seed_gfx_camp_clearing.py authored and room_recipes.json's
+    "camp_clearing_night" entry cites as its source of truth. Deliberately NOT 14x11 (the crypt's
+    dims) — a coherent fixture is allowed to differ in size from the fixture it replaces; the client
+    reads dims from the surface, not a hardcoded constant."""
+    assert (sg.GRID_W, sg.GRID_H) == (16, 12)
+
+
+def test_painted_camp_props_are_all_impassable():
+    """#1441 P2 RED-FIRST: every painted prop on the camp_clearing_night plate — fire pit, log seat,
+    bedrolls, supply crates, both boulders, all four trees — must be an engine pathing obstacle. This
+    is the exact "stacking on everything" felt-bug: under the pre-fix crypt grid, NONE of these cells
+    were impassable (the crypt grid doesn't know about camp props at all), so an actor could be
+    placed standing in the campfire or on the log seat."""
+    grid = _grid()
+    imp = impassable_cells(grid, sg.GRID_W, sg.GRID_H)
+    for cell in sg.OBSTACLES:
+        assert cell in imp, f"camp prop cell {cell} must be impassable (#1441 scene<->grid coherence)"
+
+
+def test_obstacle_prop_cell_count_matches_recipe():
+    """17 prop cells total (4 trees x2 + 2 boulders + 1 campfire + 3 bedrolls + log seat x2 + 1 supply
+    crate) — pinned so a future edit can't silently drop a prop from the impassable set without a
+    test failing."""
+    assert len(sg.OBSTACLES) == 17
+    assert len(sg.TREE_CELLS) == 8
+    assert len(sg.BEDROLL_CELLS) == 3
+    assert len(sg.LOG_SEAT_CELLS) == 2
+
+
+def test_no_perimeter_walls_open_air_clearing():
+    """Coherence with scene_grid.py::_gen_forest's convention: an outdoor clearing has NO hard
+    perimeter walls (unlike the crypt's solid perimeter) — only named props are impassable. Corner
+    and edge-midpoint cells that aren't part of a prop footprint must stay walkable."""
+    grid = _grid()
+    imp = {tuple(c) for c in impassable_cells(grid, sg.GRID_W, sg.GRID_H)}
+    obstacle_set = {tuple(c) for c in sg.OBSTACLES}
+    for cell in [(0, 0), (15, 0), (0, 11), (15, 11), (0, 6), (15, 5)]:
+        assert cell not in obstacle_set and cell not in imp, \
+            f"open-air clearing cell {cell} must not be a perimeter wall"
+
+
+def test_hero_and_goblin_spawn_cells_stay_walkable():
+    """The fixed hero(7,9)/goblin(10,8) spawn cells must never collide with the painted prop
+    footprints — a coherence fix here must not accidentally trap the demo's own combatants."""
+    grid = _grid()
+    imp = impassable_cells(grid, sg.GRID_W, sg.GRID_H)
+    assert sg.HERO_CELL not in imp
+    assert sg.GOBLIN_CELL not in imp
+
+
+def test_obstacles_list_matches_authored_props():
+    """OBSTACLES (used for the printed seed summary + kept in lock-step with set_grid) must be
+    exactly the flattened tree/rock/campfire/bedroll/log-seat/crate footprints — no silent drift
+    between the two."""
+    assert sg.OBSTACLES == (
+        sg.TREE_CELLS + sg.ROCK_L_CELLS + sg.ROCK_R_CELLS + sg.CAMPFIRE_CELLS
+        + sg.BEDROLL_CELLS + sg.LOG_SEAT_CELLS + sg.SUPPLY_CRATE_CELLS
+    )
+
+
+def test_same_campaign_id_as_crypt_seed():
+    """seed_gfx_camp.py must mint the SAME campaign id seed_gfx_combat.py does (camp_gfxdemo01) — the
+    id the box renderer + qa/ui_playtest_player.sh hardcode. This is a swap of the GRID under a
+    stable id, not a new fixture id."""
+    import seed_gfx_combat as combat_sg  # noqa: PLC0415
+    assert sg.CID == combat_sg.CID == "camp_gfxdemo01"

--- a/qa/ui_playtest_player.sh
+++ b/qa/ui_playtest_player.sh
@@ -34,21 +34,50 @@
 # Preflight both without launching a run:   qa/ui_playtest_player.sh --preflight
 # ────────────────────────────────────────────────────────────────────────────────────────────────
 #
-# Usage:   qa/ui_playtest_player.sh <runid> <beats> <budget>
+# Usage:   qa/ui_playtest_player.sh <runid> <beats> <budget> [--force]
 #   <runid>  = names qa/ui_playtest_runs/<runid>/ (wiped + recreated).
 #   <beats>  = soft cap on player palette actions.  <budget> = USD cap for the PLAYER agent.
+#   --force  = proceed even if WORLDOS_PLAYER_SEED_SCRIPT doesn't match WORLDOS_PLAYER_SCENE's
+#              paired fixture (see the SCENE<->FIXTURE table below). Without it, a mismatched
+#              override is a hard error — the #1441 P2 scene<->grid coherence gate.
 # Env knobs:
 #   WORLDOS_PLAYER_APP        — path to WorldOSPlayer.app (default: ~/Applications, /Applications,
 #                               then ~/worldos-session-notes/w5a-build/WorldOSPlayer.app).
 #   WORLDOS_NPT_WINDOW_OWNER  — CGWindowList owner name (default "WorldOSPlayer").
 #   WORLDOS_DM_MODEL / WORLDOS_UIPT_PLAYER_MODEL — per-agent models (DM opus; player sonnet).
+#   WORLDOS_PLAYER_SCENE      — which BAKED scene the player app renders: "camp" (default — the
+#                               scene the WorldOSPlayer.app build currently bakes) or "crypt" (for
+#                               when the baked scene reverts). Picks the paired seed script below.
+#   WORLDOS_PLAYER_SEED_SCRIPT — explicit override of the seed script path; must match the scene's
+#                               paired fixture unless --force is passed (see SCENE<->FIXTURE below).
+#
+# ────────────────────────────────────────────────────────────────────────────────────────────────
+# SCENE <-> FIXTURE pairing (#1441 Phase 2 — kills stacking-on-scenery / float-on-props): the Unity
+# player build BAKES ONE scene's painted props into its plate. The seed script's scene_grid
+# impassable set must match THAT scene, or the painted props render walkable and actors visibly
+# stand "on" the fire pit / logs / sarcophagus (the owner's "stacking on everything" report). camp
+# is the DEFAULT pairing (the player's CURRENTLY baked scene); crypt is kept for when the build
+# reverts to it. A mismatched explicit override requires --force — never silently run incoherent.
+#   scene "camp"  -> qa/seed_gfx_camp.py    (camp_clearing_night-coherent: fire pit/logs/crates/
+#                                            bedrolls/rocks/trees all impassable)
+#   scene "crypt" -> qa/seed_gfx_combat.py  (crypt_dense_v1-coherent: pillars/sarcophagus impassable)
+# ────────────────────────────────────────────────────────────────────────────────────────────────
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 1
 
 NPT_DIR="$ROOT/qa/native_palette"
 PW_DIR="$ROOT/qa/playwright"                     # the palette shares the MCP SDK installed here
 OWNER="${WORLDOS_NPT_WINDOW_OWNER:-WorldOSPlayer}"
-CID="camp_gfxdemo01"                             # the id seed_gfx_combat.py + the box renderer pin
+CID="camp_gfxdemo01"        # the id EVERY seed_gfx_camp*/seed_gfx_combat.py + the box renderer pin
+
+# --- SCENE <-> FIXTURE pairing table (#1441 Phase 2; see the header comment) -------------------
+fixture_for_scene() {
+  case "$1" in
+    camp)  echo "$ROOT/qa/seed_gfx_camp.py" ;;
+    crypt) echo "$ROOT/qa/seed_gfx_combat.py" ;;
+    *) return 1 ;;
+  esac
+}
 
 # --- locate the installed MCP SDK (worktrees have no node_modules — accept an explicit override or
 # the canonical checkout's qa/playwright install, matching native_palette_server.js's resolution). --
@@ -93,6 +122,31 @@ if [ "${1:-}" = "--preflight" ]; then
 fi
 
 . "$ROOT/qa/lib_beat_driver.sh"  # worldos_env + shared DM helpers (dm_timeout/resolve/chatlog)
+
+# --- strip a --force flag from anywhere in argv (positional runid/beats/budget stay in order) ---
+FORCE_MISMATCH=0
+POSITIONAL=()
+for _a in "$@"; do
+  case "$_a" in
+    --force) FORCE_MISMATCH=1 ;;
+    *) POSITIONAL+=("$_a") ;;
+  esac
+done
+set -- "${POSITIONAL[@]+"${POSITIONAL[@]}"}"
+
+# --- resolve the SCENE <-> FIXTURE pairing (#1441 Phase 2 — see header comment) -----------------
+SCENE="${WORLDOS_PLAYER_SCENE:-camp}"
+PAIRED_SEED="$(fixture_for_scene "$SCENE")" || {
+  echo "[t3] unknown WORLDOS_PLAYER_SCENE='$SCENE' (known: camp, crypt)" >&2; exit 2; }
+SEED_SCRIPT="${WORLDOS_PLAYER_SEED_SCRIPT:-$PAIRED_SEED}"
+if [ "$SEED_SCRIPT" != "$PAIRED_SEED" ] && [ "$FORCE_MISMATCH" != "1" ]; then
+  echo "[t3] FATAL: WORLDOS_PLAYER_SEED_SCRIPT=$SEED_SCRIPT does not match scene '$SCENE' (paired: $PAIRED_SEED)." >&2
+  echo "       This is the #1441 scene<->grid coherence gate — an incoherent pairing re-introduces the" >&2
+  echo "       stacking-on-scenery bug (painted props walkable). Pass --force to override deliberately." >&2
+  exit 6
+fi
+[ "$SEED_SCRIPT" != "$PAIRED_SEED" ] && echo "[t3] WARN: --force override — seeding '$SEED_SCRIPT' under scene '$SCENE' (paired seed would be '$PAIRED_SEED')." >&2
+echo "[t3] scene=$SCENE seed=$SEED_SCRIPT"
 
 RUN="${1:-t3-$(date +%H%M%S)}"
 BEATS="${2:-40}"
@@ -144,8 +198,9 @@ BASE_URL="http://127.0.0.1:$PORT"
 
 # --- seed the pre-minted combat campaign (engine = sole writer) --------------
 # uv --directory cd's into servers/engine, so pass the seed by ABSOLUTE path (per its docstring).
-echo "[t3] seeding $CID (hero-vs-goblin grid combat)…"
-SEED_JSON="$(WORLDOS_STATE_DIR="$STATE_DIR" uv run --directory servers/engine python "$ROOT/qa/seed_gfx_combat.py" "$STATE_DIR" 2>"$RUNDIR/seed.err")" \
+# SEED_SCRIPT is the scene<->fixture-paired seed resolved above (default: qa/seed_gfx_camp.py).
+echo "[t3] seeding $CID via $SEED_SCRIPT (hero-vs-goblin grid combat, scene=$SCENE)…"
+SEED_JSON="$(WORLDOS_STATE_DIR="$STATE_DIR" uv run --directory servers/engine python "$SEED_SCRIPT" "$STATE_DIR" 2>"$RUNDIR/seed.err")" \
   || { echo "[t3] seed failed (see $RUNDIR/seed.err)" >&2; cat "$RUNDIR/seed.err" >&2; exit 4; }
 echo "[t3] seeded: $SEED_JSON"
 
@@ -248,10 +303,14 @@ dm_turn() {
 
 # The campaign is PRE-SEEDED (camp_gfxdemo01), so — unlike ui_playtest.sh's cold-open — the DM GROUNDS
 # on the existing state and opens the scene; it does NOT start_world/re-seat (mirrors mechanism_probe.sh).
+case "$SCENE" in
+  crypt) SCENE_BRIEF="a firelit crypt (pillars + a sarcophagus) on a combat grid" ;;
+  *)     SCENE_BRIEF="a moonlit campfire clearing (fire pit, log seat, bedrolls, supply crates) on a combat grid" ;;
+esac
 echo "[t3] DM opening the scene on the pre-seeded campaign…"
 DMSG="$(dm_turn 1 "$DM_BRIEF
 
-You are resuming an IN-PROGRESS session (campaign_id=\"$CID\") — the party + a live combat encounter are ALREADY seeded (a level-4 fighter PC vs a goblin in a firelit crypt on a combat grid). Do NOT start_world or re-seat anyone. FIRST call scene_context(campaign_id=\"$CID\") (or get_state) to re-ground on the party, the combat, and the grid. Then open the scene with real quoted narration and hand the player an open moment + a clear choice. Their actions arrive next as tagged moves; resolve them THROUGH the engine and narrate.")"
+You are resuming an IN-PROGRESS session (campaign_id=\"$CID\") — the party + a live combat encounter are ALREADY seeded (a level-4 fighter PC vs a goblin in $SCENE_BRIEF). Do NOT start_world or re-seat anyone. FIRST call scene_context(campaign_id=\"$CID\") (or get_state) to re-ground on the party, the combat, and the grid. Then open the scene with real quoted narration and hand the player an open moment + a clear choice. Their actions arrive next as tagged moves; resolve them THROUGH the engine and narrate.")"
 worldos_resolve_dm_reply "$DMSG" "$STATE_DIR"; DMSG="$WORLDOS_DM_REPLY"
 if [ -z "$DMSG" ]; then
   echo "[t3] WARN: DM produced no opening (see $RUNDIR/dm/dm.err) — recording a visible failure beat." >&2


### PR DESCRIPTION
## Summary
- Root cause (#1441 item 4): the WorldOSPlayer.app build bakes the `camp_clearing_night` plate (fire pit, log seat, bedrolls, supply crates, boulders, tree line), but `campaign_gfxdemo01`'s combat grid was `seed_gfx_combat.py`'s CRYPT layout (14x11, pillars + sarcophagus) — none of the camp's painted props were in the engine's impassable set, so actors could stand in the fire pit or on the log seat (the owner's "stacking on everything" report).
- New `qa/seed_gfx_camp.py`: same CID/shape as `seed_gfx_combat.py` (pinned campaign, hero+goblin surprise combat) but authors the `camp_clearing_night` 16x12 open-air grid — the exact prop layout `room_recipes.json`'s `camp_clearing_night` entry cites (`qa/seed_gfx_camp_clearing.py::_author_camp_grid`) — so every painted prop (4 trees, 2 boulders, campfire, 3 bedrolls, log seat, supply crates = 17 cells) is pathing-solid. `validate_scene_grid` → 0 violations.
- `qa/ui_playtest_player.sh` now resolves the seed via a SCENE↔FIXTURE pairing table (`camp` default → `seed_gfx_camp.py`, `crypt` → `seed_gfx_combat.py`, selectable via `WORLDOS_PLAYER_SCENE`) and refuses an explicit `WORLDOS_PLAYER_SEED_SCRIPT` override that doesn't match the requested scene unless `--force` is passed.
- `qa/UI_PLAYTEST.md` documents the pairing rule + the coherence lesson.
- Filed #1444 (architecture-only, not built): the real multi-room fix is the player selecting its backdrop by the engine's location plate SLOT instead of one baked scene.

## Test plan
- [x] `qa/test_seed_gfx_camp.py` (8 new tests, red-first: confirmed the fire-pit cell was walkable under the old crypt grid before this fix)
- [x] `qa/test_seed_gfx_combat.py` unchanged/still green (5 tests)
- [x] `qa/test_native_palette.py` still green (11 tests — runner still references `seed_gfx_combat.py` in the pairing table)
- [x] `qa/fast_gate.sh` — 257 passed
- [x] Verified the SCENE/FIXTURE mismatch gate: rejects a mismatched `WORLDOS_PLAYER_SEED_SCRIPT` without `--force` (exit 6), accepts it with `--force`

Admin-merge note (#1389 — auto-merge hangs repo-wide): merge with `gh pr merge --admin --squash` once green + resolved.