### PR TITLE
Propagate move advisory notes into combat_loop result (#1447 gap)

### DIFF
--- a/servers/engine/combat_loop.py
+++ b/servers/engine/combat_loop.py
@@ -622,11 +622,22 @@ def _apply_intent(server, campaign_id: str, actor_id: str, intent: Intent) -> di
                             "save_made": save_made,
                         }
         elif intent.kind == "move":
+            move_view: dict | None = None
             if intent.to_cell is not None:
-                server.move_to_coords(campaign_id, actor_id, intent.to_cell[0], intent.to_cell[1])
+                move_view = server.move_to_coords(campaign_id, actor_id, intent.to_cell[0], intent.to_cell[1])
             elif intent.to_zone:
-                server.move_to_zone(campaign_id, combatant_id=actor_id, zone=intent.to_zone)
+                move_view = server.move_to_zone(campaign_id, combatant_id=actor_id, zone=intent.to_zone)
             entry["result"] = {"to_cell": intent.to_cell, "to_zone": intent.to_zone}
+            # #1447 gap: move_to_coords/move_to_zone's advisory notes (movement_illegal /
+            # move_blocked) were rolled but never surfaced here, so the player's advisory UI
+            # went dormant. ADDITIVE: only set when the verb actually returned one — a legal
+            # in-budget move's result dict stays byte-identical to today. Advisory text only;
+            # never gates (the verbs themselves never block on this).
+            if isinstance(move_view, dict):
+                if move_view.get("movement_illegal") is not None:
+                    entry["result"]["movement_illegal"] = move_view["movement_illegal"]
+                if move_view.get("move_blocked") is not None:
+                    entry["result"]["move_blocked"] = move_view["move_blocked"]
         elif intent.kind == "disengage":
             server.use_action(campaign_id, actor_id, kind="disengage")
             if intent.to_cell is not None:

--- a/servers/engine/tests/test_player_turn_arbiter.py
+++ b/servers/engine/tests/test_player_turn_arbiter.py
@@ -105,6 +105,47 @@ def test_move_to_cell_charges_movement_budget(grid_fight):
     assert cb.moved_cells_this_turn == 4  # Chebyshev 0,0 -> 4,0 == 4 cells charged
 
 
+# ── #1447 GAP: move's own advisory notes (movement_illegal / move_blocked) reach the
+# ── digest entry's `result`, so the player advisory UI (dormant since #1447) can render them.
+
+
+def test_legal_move_result_is_byte_identical(grid_fight):
+    """A legal, in-budget move's `result` dict is UNCHANGED — no advisory keys appear when the
+    verb didn't return one. Exact-dict assertion so any future stray key trips this test."""
+    cid, hero, gob = grid_fight
+    out = combat_loop.resolve_player_turn(cid, hero, Intent(kind="move", to_cell=(3, 0)))
+    assert out["ok"] is True, out
+    assert out["resolved"]["result"] == {"to_cell": (3, 0), "to_zone": ""}
+
+
+def test_over_budget_move_surfaces_movement_illegal(grid_fight):
+    """Hero speed 30 / cell_size 5 -> a 6-cell budget. Moving 7 cells is over budget: the engine
+    still moves it (advisory-not-block), and the arbiter must now surface `movement_illegal` in
+    the digest entry's `result` (the #1447 gap) instead of discarding move_to_coords's view."""
+    cid, hero, gob = grid_fight
+    out = combat_loop.resolve_player_turn(cid, hero, Intent(kind="move", to_cell=(7, 0)))
+    assert out["ok"] is True, out
+    result = out["resolved"]["result"]
+    assert result["to_cell"] == (7, 0)
+    assert "movement_illegal" in result
+    assert result["movement_illegal"]["budget_cells"] == 6
+    # Advisory-not-block: the move still landed despite being flagged.
+    assert _cell(cid, hero) == (7, 0)
+
+
+def test_blocked_move_surfaces_move_blocked_and_position_unchanged(grid_fight):
+    """An impassable target cell REJECTS the move (move_to_coords stays put) — the arbiter must
+    surface `move_blocked` in `result`, and the hero's position must be unchanged."""
+    cid, hero, gob = grid_fight
+    server.set_grid(cid, 20, 20, obstacles=[[3, 0]])
+    before = _cell(cid, hero)
+    out = combat_loop.resolve_player_turn(cid, hero, Intent(kind="move", to_cell=(3, 0)))
+    assert out["ok"] is True, out
+    result = out["resolved"]["result"]
+    assert "move_blocked" in result
+    assert _cell(cid, hero) == before  # stayed put
+
+
 def test_attack_on_turn_rolls_via_engine(grid_fight):
     cid, hero, gob = grid_fight
     # Place the goblin adjacent so a melee strike is in reach, then attack it on the PC's turn.


### PR DESCRIPTION
## Summary
- `_apply_intent`'s move branch discarded `move_to_coords`/`move_to_zone`'s returned view, writing only `{to_cell, to_zone}` into `entry["result"]` — so `movement_illegal` (over-budget/Speed-0) and `move_blocked` (impassable terrain) never reached the `/move` HTTP response, leaving #1447's player advisory UI dormant.
- Additive fix: capture the verb's return dict and copy `movement_illegal`/`move_blocked` into `entry["result"]` only when present. A legal in-budget move's result dict stays byte-identical to today.
- Verified the full response path: `resolve_player_turn` returns `resolved` (the entry) verbatim as `verdict["resolved"]`, and `viewer/server.py`'s `_resolve_player_combat_turn_locked` passes `verdict` through unmodified as `{"arbiter": verdict, ...}` — no intermediate layer strips unknown keys, so no viewer-side change was needed.
- Invariants preserved: gates still read only gauges; this is advisory payload text only, never gate input. Sole-writer unchanged (no new write path).

## Test plan
- [x] Red-first: 3 new tests in `servers/engine/tests/test_player_turn_arbiter.py` — legal move byte-identical result (exact-dict), over-budget move surfaces `movement_illegal` (move still lands), blocked move surfaces `move_blocked` with position unchanged.
- [x] `uv run pytest tests/test_player_turn_arbiter.py -q` — 13 passed.
- [x] `qa/fast_gate.sh` — Tier 0 deterministic engine: 257 passed.