### PR TITLE
Fix #1443: native palette blinded by Mission Control Spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 # (qa/ui_playtest.sh), palette MCP server (qa/playwright/palette_server.js + package.json),
 # persona briefs, and scorer ARE committed; only the run outputs + node_modules are ignored.
 /qa/ui_playtest_runs/
+# player smoke (#1443): qa/player_smoke.sh run artifacts (screenshots + smoke_result.json) — same
+# regenerable-and-bulky rationale as ui_playtest_runs/ above; the runner + driver ARE committed.
+/qa/player_smoke_runs/
 /qa/playwright/node_modules
 /qa/playwright/_*.js
 # The on-demand findings ledger (qa/collect_findings.py output) — a regenerable digest of

--- a/docs/RUNBOOK-INDEX.md
+++ b/docs/RUNBOOK-INDEX.md
@@ -14,6 +14,7 @@
 | Run type | Runner | Tier/cost | Required evidence | Scores surface | Owner doc/skill |
 |---|---|---|---|---|---|
 | fast_gate | `qa/fast_gate.sh` | free, ~30s, EVERY change | pass log (iteration-only, never release evidence) | — (by design) | worldos-dev |
+| player smoke (native build) | `qa/player_smoke.sh` | free, ~30-60s, EVERY player rebuild | smoke_result.json + glide frames in `qa/player_smoke_runs/<run>/` | — (gate; no LLM, no scores_ledger row) | worldos-dev + #1443 |
 | mechanism probe | `qa/mechanism_probe.sh` | ~$1, cue-adjacent PRs | fixture transcript + deterministic ACTED/IGNORED | engine-duo (auto-append) | OPERATIONS QA-econ v2 |
 | combat sprint | `qa/run_combat_sprint.sh` | ~$1.50, combat-adjacent | transcript + mech score + behavioral | engine-duo (auto-append #1414) | worldos-dev |
 | story/mech duo | `qa/run_duo.sh` | ~$6, BATCH/release only, solo-tenant | transcript + 3 lenses + behavioral + infra-health note | engine-duo (auto-append #1414; CONTAMINATED marker on QUOTA/INFRA abort) | worldos-dev + watcher contract |

--- a/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
+++ b/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
@@ -15,6 +15,15 @@ using UnityEngine;
 /// confirms the Universal (x64+AppleSilicon) architecture, registers the current-best combat
 /// scene in Build Settings (was empty), and builds the .app to BuildOutput/ beside the project.
 /// Writes a build-report text file for evidence (qa/evidence/1322-build/).
+///
+/// AFTER EVERY REBUILD (#1443): run `qa/player_smoke.sh` against the fresh .app before trusting
+/// it for a T3 gate run. It is the free (~30-60s, no LLM) deterministic post-build smoke — boots
+/// the camp fixture + this player, scripts a move + attack through the SAME native-palette
+/// primitives the T3 blind-player agent uses, and asserts the engine actually moved/damaged
+/// something and the captured frames actually changed. This is the standing regression check for
+/// the bug the smoke exists to catch: WorldOSPlayer opening on a different Mission Control Space
+/// silently blinded every screenshot/click for the T3 gate (see docs/RUNBOOK-INDEX.md's "player
+/// smoke" row).
 /// </summary>
 public static class BuildMacOSPlayer
 {

--- a/qa/lib_native_player_boot.sh
+++ b/qa/lib_native_player_boot.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# lib_native_player_boot.sh — shared boot helpers for the native-window player harnesses
+# (qa/ui_playtest_player.sh, the T3 LLM gate, and qa/player_smoke.sh, the #1443 deterministic
+# post-build smoke). Extracted 2026-07-09 so the cross-Space launch fix (#1443) lives in ONE
+# place both runners source, instead of drifting across two copies.
+#
+# Source this, don't execute it: `. "$ROOT/qa/lib_native_player_boot.sh"`
+
+# --- locate the installed MCP SDK (worktrees have no node_modules — accept an explicit override
+# or the canonical checkout's qa/playwright install). $PW_DIR must be set by the caller. -----------
+find_sdk_node_modules() {
+  local c
+  for c in "${WORLDOS_NPT_NODE_MODULES:-}" \
+           "${PW_DIR:-}/node_modules" \
+           "/Users/lume/WorldOS/qa/playwright/node_modules"; do
+    [ -n "$c" ] && [ -d "$c/@modelcontextprotocol" ] && { echo "$c"; return 0; }
+  done
+  return 1
+}
+
+# --- locate the player app ----------------------------------------------------------------------
+find_player_app() {
+  local c
+  for c in "${WORLDOS_PLAYER_APP:-}" \
+           "$HOME/Applications/WorldOSPlayer.app" \
+           "/Applications/WorldOSPlayer.app" \
+           "$HOME/worldos-session-notes/w5a-build/WorldOSPlayer.app"; do
+    [ -n "$c" ] && [ -d "$c" ] && { echo "$c"; return 0; }
+  done
+  return 1
+}
+
+# --- free port in 8990-8999 ----------------------------------------------------------------------
+pick_port() {
+  local p
+  for p in $(seq 8990 8999); do
+    if ! (exec 3<>"/dev/tcp/127.0.0.1/$p") 2>/dev/null; then echo "$p"; return 0; fi
+    exec 3>&- 2>/dev/null || true
+  done
+  return 1
+}
+
+# --- #1443 launch-into-same-Space discipline ------------------------------------------------------
+# macOS opens a newly-launched app's window on whichever Space is CURRENT at launch time. The T3
+# finding was WorldOSPlayer opening onto (or drifting to) a different Space than the harness, which
+# then made `screencapture -l <id>` refuse to rasterize it. We cannot reliably know which terminal
+# app is running this script (Terminal/iTerm/VSCode/a detached `claude -p` parent), so instead of
+# guessing a name, we ask macOS which app is CURRENTLY frontmost and re-activate exactly that one —
+# re-asserting "whatever GUI context is in front, stays in front" right before we spawn the player.
+# This is the simplest mechanism that needs no app-name knowledge and no Unity/C# change: it just
+# closes the race window between an earlier Space switch (e.g. a previous run's cleanup) and this
+# run's launch. Never fails loud — a failure here just means we skip the pin, not abort the run;
+# native_palette_core.js's activate-before-capture (#1443) is the real belt-and-suspenders fix that
+# makes screenshot/click work even if the player DOES end up on a different Space.
+activate_current_space_context() {
+  local front
+  front="$(osascript -e 'tell application "System Events" to get name of first application process whose frontmost is true' 2>/dev/null)"
+  if [ -n "$front" ]; then
+    osascript -e "tell application \"$front\" to activate" >/dev/null 2>&1 || true
+    sleep 0.3
+  fi
+}

--- a/qa/native_palette/native_input.swift
+++ b/qa/native_palette/native_input.swift
@@ -82,9 +82,26 @@ func checkPerms() {
 // captured PIXELS require the grant — so a missing grant still lets us find + click the window, and
 // the screenshot (not this helper) is where the loud failure surfaces. We pick the largest on-screen,
 // non-zero-layer window owned by the target app (the game view, not a tiny helper/status window).
+//
+// #1443: Mission Control SPACES blind spot. `.optionOnScreenOnly` only enumerates windows on the
+// CURRENT Space — if WorldOSPlayer opened on (or got dragged to) a different Space, the on-screen
+// pass returns nothing even though the window is very much alive, and the T3 gate silently died
+// (winfind found:false -> every screenshot/click no-ops). Fix: try on-screen-only FIRST (cheap, and
+// the common case), and if the owner isn't in that list, fall back to a search WITHOUT
+// .optionOnScreenOnly (every Space). The result carries "on_screen" so callers (the palette server's
+// screencaptureWindow) know whether `screencapture -l <id>` will actually work from HERE: macOS 15
+// refuses to rasterize a window that isn't on the current Space, so a caller that sees
+// on_screen:false must activate the owner (switch to its Space) before capturing, or fall back to a
+// full-screen grab + crop.
 func winFind(_ owner: String) {
-    let opts: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
-    guard let infoList = CGWindowListCopyWindowInfo(opts, kCGNullWindowID) as? [[String: Any]] else {
+    func listWithOwner(_ opts: CGWindowListOption) -> [[String: Any]]? {
+        guard let raw = CGWindowListCopyWindowInfo(opts, kCGNullWindowID) as? [[String: Any]] else { return nil }
+        return raw.contains { ($0[kCGWindowOwnerName as String] as? String) == owner } ? raw : nil
+    }
+    let onScreenOpts: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+    let allSpacesOpts: CGWindowListOption = [.excludeDesktopElements]
+    var onScreen = true
+    guard let infoList = listWithOwner(onScreenOpts) ?? { onScreen = false; return listWithOwner(allSpacesOpts) }() else {
         emit(["found": false, "error": "window-list-unavailable"]); exit(2)
     }
     var best: [String: Any]? = nil
@@ -109,6 +126,7 @@ func winFind(_ owner: String) {
         "found": true, "window_id": wid,
         "x": Int(x), "y": Int(y), "w": Int(w), "h": Int(h),
         "owner": owner, "title": (win[kCGWindowName as String] as? String) ?? "",
+        "on_screen": onScreen,
     ])
 }
 

--- a/qa/native_palette/native_palette_core.js
+++ b/qa/native_palette/native_palette_core.js
@@ -1,0 +1,210 @@
+"use strict";
+/*
+ * native_palette_core.js — the macOS capture/input PRIMITIVES shared by:
+ *   - native_palette_server.js (the MCP tool wrapper the T3 blind-player agent drives)
+ *   - player_smoke_driver.js   (the #1443 deterministic post-build smoke — same primitives,
+ *                                driven by a SCRIPT instead of an LLM, so bugs in this file are
+ *                                caught by the FREE smoke run on every player rebuild, not just
+ *                                the ~$3 T3 gate.)
+ *
+ * Extracted 2026-07-09 (issue #1443 — the native palette was blind across Mission Control
+ * Spaces): pulling the window-lookup / activate / capture / click plumbing into one module means
+ * the cross-Space fix lives in exactly one place and both consumers get it for free.
+ *
+ * Nothing here talks MCP, nothing here knows about run directories beyond the paths it's given —
+ * pure primitives over a target app OWNER name.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync, spawnSync } = require("child_process");
+
+const SWIFT_SRC = path.join(__dirname, "native_input.swift");
+
+// ---- the Swift primitives helper -------------------------------------------
+// Prefer a prebuilt binary (explicit override); else compile native_input.swift to <workDir>/
+// native_input (fast per-call once built); else fall back to the `swift` interpreter (slower,
+// ~1-2s/call but portable). #1443 force-recompile discipline: a COMPILED binary that predates an
+// edit to native_input.swift is exactly the T3 bug (the in-run patch fixed the source but the
+// already-compiled binary kept the old on-screen-only behavior until the server restarted) — so
+// a stale-by-mtime binary is rebuilt even if a file already exists at `out`, not just an absent one.
+// `swiftSrc` defaults to this module's own native_input.swift; a test may override it to point at
+// a scratch copy so the mtime-staleness logic is exercisable without touching the real repo file.
+function resolveHelper(workDir, explicitPath, swiftSrc) {
+  const explicit = (explicitPath || "").trim();
+  if (explicit && fs.existsSync(explicit)) return { bin: explicit, pre: [] };
+  const src = swiftSrc || SWIFT_SRC;
+  const out = path.join(workDir, "native_input");
+  try {
+    const srcStat = fs.statSync(src);
+    let stale = true;
+    if (fs.existsSync(out)) {
+      const outStat = fs.statSync(out);
+      stale = srcStat.mtimeMs > outStat.mtimeMs;
+    }
+    if (stale) execFileSync("swiftc", [src, "-o", out], { stdio: "pipe" });
+    return { bin: out, pre: [] };
+  } catch (_e) {
+    // fall back to interpreting the source (no compiler, or compile failed)
+    return { bin: "swift", pre: [src] };
+  }
+}
+
+function runHelper(helperCmd, args) {
+  const r = spawnSync(helperCmd.bin, [...helperCmd.pre, ...args], { encoding: "utf8", timeout: 20000 });
+  if (r.status !== 0 && !r.stdout) {
+    return { _error: (r.stderr || r.error || "helper failed").toString().slice(0, 300) };
+  }
+  try { return JSON.parse((r.stdout || "").trim().split("\n").pop()); }
+  catch (_e) { return { _error: "unparseable helper output: " + (r.stdout || "").slice(0, 200) }; }
+}
+
+function haveCliclick() {
+  try { execFileSync("which", ["cliclick"], { stdio: "pipe" }); return true; } catch (_e) { return false; }
+}
+
+// ---- window lookup + cross-Space activation --------------------------------
+function findWindow(helperCmd, owner) {
+  const w = runHelper(helperCmd, ["winfind", owner]);
+  if (w && w.found === true) return w;
+  return null;
+}
+
+// Bring `owner` to the CURRENT Space (macOS switches Spaces to follow an activated app's window,
+// same as clicking its Dock icon). Two mechanisms, in order: NSRunningApplication-style `open -a`
+// activation via `osascript ... activate` (works for a bundled .app), falling back to nothing
+// louder than a logged no-op if the app isn't running — the caller's poll loop below is what
+// actually decides whether activation worked, not this call's exit code.
+function activateOwner(owner) {
+  spawnSync("osascript", ["-e", `tell application "${owner}" to activate`], { encoding: "utf8", timeout: 5000 });
+}
+
+// Poll winfind until the window reports on_screen:true (i.e. the Space switch landed and
+// `screencapture -l` will work) or the timeout elapses. Returns the last window info seen
+// (possibly still on_screen:false) so the caller can decide on a fallback.
+function waitForOnScreen(helperCmd, owner, timeoutMs, pollMs) {
+  const deadline = Date.now() + (timeoutMs || 3000);
+  let last = null;
+  for (;;) {
+    last = findWindow(helperCmd, owner);
+    if (last && last.on_screen !== false) return last; // found + on-screen (or legacy helper w/o the field)
+    if (Date.now() >= deadline) return last;
+    spawnSync("sleep", [String((pollMs || 150) / 1000)]);
+  }
+}
+
+// ---- pixel helpers -----------------------------------------------------------
+function pixelSize(file) {
+  try {
+    const r = spawnSync("sips", ["-g", "pixelWidth", "-g", "pixelHeight", file], { encoding: "utf8" });
+    const w = /pixelWidth:\s*(\d+)/.exec(r.stdout || "");
+    const h = /pixelHeight:\s*(\d+)/.exec(r.stdout || "");
+    if (w && h) return { pw: Number(w[1]), ph: Number(h[1]) };
+  } catch (_e) {}
+  return null;
+}
+
+function fileHash(file) {
+  try {
+    return String(fs.statSync(file).size) + ":" +
+      require("crypto").createHash("sha1").update(fs.readFileSync(file)).digest("hex");
+  } catch (_e) { return ""; }
+}
+
+// Crop a full-screen capture down to a window's bounds, in PIXELS, using a known/assumed scale
+// (capture pixels per global point — 2 on every Retina display, which is the overwhelming common
+// case; a caller with a better-known scale from a prior successful `-l` capture should pass it).
+// Used ONLY as the fallback when `screencapture -l <id>` fails after activation (see
+// captureWindow below) — sips crop, not a real re-render, so it's approximate at the pixel edges
+// but perfectly adequate for click-target math (which works in the same crop's pixel space).
+function fullscreenCropWindow(win, outFile, scale) {
+  const full = outFile + ".full.png";
+  const r = spawnSync("screencapture", ["-x", full], { encoding: "utf8" });
+  if (r.status !== 0 || !fs.existsSync(full)) return false;
+  const s = scale || 2;
+  const offY = Math.max(0, Math.round(win.y * s));
+  const offX = Math.max(0, Math.round(win.x * s));
+  const h = Math.max(1, Math.round(win.h * s));
+  const w = Math.max(1, Math.round(win.w * s));
+  const crop = spawnSync("sips", [
+    "-c", String(h), String(w), "--cropOffset", String(offY), String(offX),
+    full, "--out", outFile,
+  ], { encoding: "utf8" });
+  try { fs.unlinkSync(full); } catch (_e) {}
+  return crop.status === 0 && fs.existsSync(outFile);
+}
+
+// ---- the capture sequence (#1443 core fix) ----------------------------------
+// Find the window; if it's on a DIFFERENT Space, activate the owner + wait for it to land on the
+// current Space (screencapture -l only works on the current Space on macOS 15); capture via
+// `-l <id>`; if that still fails (activation didn't land, or -l refused anyway), fall back to a
+// full-screen grab cropped to the window's bounds. `state` is a small mutable object the caller
+// keeps across calls — `{lastGoodScale}` — so the fallback crop can reuse the last real scale
+// factor observed from a successful `-l` capture instead of guessing.
+function captureWindow({ helperCmd, owner, outFile, fullscreenFallback, state, activateTimeoutMs }) {
+  state = state || {};
+  let win = findWindow(helperCmd, owner);
+  let usedFallback = false;
+  let activated = false;
+  if (win && win.on_screen === false) {
+    activateOwner(owner);
+    activated = true;
+    win = waitForOnScreen(helperCmd, owner, activateTimeoutMs || 3000, 150) || win;
+  }
+  if (!win) {
+    if (!fullscreenFallback) {
+      return { ok: false, mode: "none", window: null, pixels: null, scale: 1, reason: "window not found" };
+    }
+    const ok = spawnSync("screencapture", ["-x", outFile], { encoding: "utf8" }).status === 0 && fs.existsSync(outFile);
+    return { ok, mode: "fullscreen", window: null, pixels: ok ? pixelSize(outFile) : null, scale: 1 };
+  }
+  let ok = false;
+  if (win.on_screen !== false) {
+    const r = spawnSync("screencapture", ["-l", String(win.id), "-o", "-x", outFile], { encoding: "utf8" });
+    ok = r.status === 0 && fs.existsSync(outFile) && fs.statSync(outFile).size > 0;
+  }
+  if (!ok) {
+    // -l refused (still not on this Space, or macOS declined anyway) — crop a full-screen grab.
+    usedFallback = true;
+    ok = fullscreenCropWindow(win, outFile, state.lastGoodScale);
+  }
+  const px = ok && fs.existsSync(outFile) ? pixelSize(outFile) : null;
+  let scale = state.lastGoodScale || 1;
+  if (!usedFallback && px && win.w > 0) {
+    scale = px.pw / win.w;
+    state.lastGoodScale = scale; // remember for a future fallback crop
+  }
+  return {
+    ok, mode: usedFallback ? "fullscreen-crop" : "window", window: win, pixels: px, scale,
+    activated, usedFallback,
+  };
+}
+
+// ---- synthetic click ---------------------------------------------------------
+function clickAt(helperCmd, useCliclick, gx, gy, doubleClick) {
+  if (useCliclick) {
+    const r = spawnSync("cliclick", [(doubleClick ? "dc:" : "c:") + Math.round(gx) + "," + Math.round(gy)], { encoding: "utf8" });
+    if (r.status !== 0) return { ok: false, reason: (r.stderr || "cliclick failed").slice(0, 200) };
+    return { ok: true };
+  }
+  const args = ["click", String(gx), String(gy)];
+  if (doubleClick) args.push("double");
+  const r = runHelper(helperCmd, args);
+  if (!r || r.ok !== true) return { ok: false, reason: (r && r._error) || "click helper failed" };
+  return { ok: true };
+}
+
+module.exports = {
+  SWIFT_SRC,
+  resolveHelper,
+  runHelper,
+  haveCliclick,
+  findWindow,
+  activateOwner,
+  waitForOnScreen,
+  pixelSize,
+  fileHash,
+  fullscreenCropWindow,
+  captureWindow,
+  clickAt,
+};

--- a/qa/native_palette/native_palette_server.js
+++ b/qa/native_palette/native_palette_server.js
@@ -49,7 +49,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const { execFileSync, spawnSync } = require("child_process");
+const { spawnSync } = require("child_process");
 
 // The MCP SDK + zod live in the sibling qa/playwright workspace (the harness already installs them
 // there). Resolve normally first (in case this dir grows its own node_modules), then fall back to the
@@ -121,38 +121,24 @@ function appendLine(file, obj) {
 }
 function nowIso() { return new Date().toISOString().replace(/\.\d+Z$/, "Z"); }
 
-// ---- the Swift primitives helper -------------------------------------------
-// Prefer a prebuilt binary (WORLDOS_NPT_HELPER); else compile native_input.swift once to a temp
-// binary (fast per-call); else fall back to the `swift` interpreter (slower, ~1-2s/call but portable).
-const SWIFT_SRC = path.join(__dirname, "native_input.swift");
-let helperCmd = null; // {file, argv0extra:[]}
+// ---- the Swift primitives helper (shared with player_smoke_driver.js — see #1443) -----------
+// native_palette_core.js owns: resolving/compiling the swiftc helper (with a source-mtime
+// staleness check so an EDITED native_input.swift is never shadowed by a stale compiled binary —
+// the #1443 T3 finding: an in-run source patch didn't take effect until the server restarted),
+// cross-Space window activation + polling, and the screencapture-with-fallback sequence.
+const core = require("./native_palette_core.js");
+const SWIFT_SRC = core.SWIFT_SRC;
+let helperCmd = null; // {bin, pre} — memoized per-process (mtime check still runs each resolve)
 function resolveHelper() {
-  if (helperCmd) return helperCmd;
   const explicit = (process.env.WORLDOS_NPT_HELPER || "").trim();
-  if (explicit && fs.existsSync(explicit)) { helperCmd = { bin: explicit, pre: [] }; return helperCmd; }
-  // try to compile once
-  const out = path.join(PLAYERDIR, "native_input");
-  try {
-    if (!fs.existsSync(out)) execFileSync("swiftc", [SWIFT_SRC, "-o", out], { stdio: "pipe" });
-    helperCmd = { bin: out, pre: [] };
-    return helperCmd;
-  } catch (_e) {
-    // fall back to interpreting the source
-    helperCmd = { bin: "swift", pre: [SWIFT_SRC] };
-    return helperCmd;
-  }
+  helperCmd = core.resolveHelper(PLAYERDIR, explicit);
+  return helperCmd;
 }
 function runHelper(args) {
-  const h = resolveHelper();
-  const r = spawnSync(h.bin, [...h.pre, ...args], { encoding: "utf8", timeout: 20000 });
-  if (r.status !== 0 && !r.stdout) {
-    return { _error: (r.stderr || r.error || "helper failed").toString().slice(0, 300) };
-  }
-  try { return JSON.parse((r.stdout || "").trim().split("\n").pop()); }
-  catch (_e) { return { _error: "unparseable helper output: " + (r.stdout || "").slice(0, 200) }; }
+  return core.runHelper(resolveHelper(), args);
 }
 function haveCliclick() {
-  try { execFileSync("which", ["cliclick"], { stdio: "pipe" }); return true; } catch (_e) { return false; }
+  return core.haveCliclick();
 }
 
 // ---- permission gate (FAIL LOUD) -------------------------------------------
@@ -182,41 +168,31 @@ function assertPermissions() {
 }
 
 // ---- window + screenshot ----------------------------------------------------
+// #1443: cross-Space capture. core.captureWindow() does the activate+poll+capture(-l)+fallback
+// (fullscreen grab cropped to the window's bounds) sequence — see native_palette_core.js. This
+// function stays a thin per-run wrapper: it picks the file name, threads the persistent
+// `captureState` (remembers the last known-good Retina scale across calls, for the fallback
+// crop), and updates `winCache` for click()'s pixel->global-point mapping exactly as before.
+const captureState = {}; // {lastGoodScale} — persists across calls in this process
 function findWindow() {
-  const w = runHelper(["winfind", OWNER]);
-  if (w && w.found === true) return w;
-  return null;
-}
-function pixelSize(file) {
-  // sips is always present on macOS; parse pixelWidth/pixelHeight.
-  try {
-    const r = spawnSync("sips", ["-g", "pixelWidth", "-g", "pixelHeight", file], { encoding: "utf8" });
-    const w = /pixelWidth:\s*(\d+)/.exec(r.stdout || "");
-    const h = /pixelHeight:\s*(\d+)/.exec(r.stdout || "");
-    if (w && h) return { pw: Number(w[1]), ph: Number(h[1]) };
-  } catch (_e) {}
-  return null;
+  return core.findWindow(resolveHelper(), OWNER);
 }
 function screencaptureWindow(label) {
   const name = "step-" + String(seq).padStart(3, "0") + (label ? "-" + label : "") + ".png";
   const file = path.join(SHOTS, name);
   const rel = path.join("player", "screenshots", name);
-  const win = findWindow();
-  let mode = "window";
-  if (win) {
-    spawnSync("screencapture", ["-l", String(win.id), "-o", "-x", file], { encoding: "utf8" });
-  } else if (FULLSCREEN_FALLBACK) {
-    mode = "fullscreen";
-    spawnSync("screencapture", ["-x", file], { encoding: "utf8" });
-  } else {
-    return { ok: false, screenshot: "", reason: "player window '" + OWNER + "' not found (is WorldOSPlayer.app launched? set WORLDOS_NPT_FULLSCREEN_FALLBACK=1 to grab the whole screen)" };
+  const cap = core.captureWindow({
+    helperCmd: resolveHelper(), owner: OWNER, outFile: file,
+    fullscreenFallback: FULLSCREEN_FALLBACK, state: captureState,
+  });
+  if (!cap.window && !cap.ok) {
+    return {
+      ok: false, screenshot: "",
+      reason: "player window '" + OWNER + "' not found (is WorldOSPlayer.app launched? set WORLDOS_NPT_FULLSCREEN_FALLBACK=1 to grab the whole screen)",
+    };
   }
-  const px = fs.existsSync(file) ? pixelSize(file) : null;
-  // scale = capture pixels / window points (Retina = 2). Used to map click pixels -> global points.
-  let scale = 1;
-  if (win && px && win.w > 0) scale = px.pw / win.w;
-  winCache = win ? { x: win.x, y: win.y, w: win.w, h: win.h, id: win.id, scale } : null;
-  return { ok: fs.existsSync(file), screenshot: rel, mode, window: win || null, pixels: px, scale };
+  winCache = cap.window ? { x: cap.window.x, y: cap.window.y, w: cap.window.w, h: cap.window.h, id: cap.window.id, scale: cap.scale } : null;
+  return { ok: cap.ok, screenshot: rel, mode: cap.mode, window: cap.window, pixels: cap.pixels, scale: cap.scale };
 }
 
 // ---- bug + action logging (identical shape to the browser palette) ----------
@@ -306,16 +282,9 @@ server.registerTool(
     const gy = winCache.y + y / winCache.scale;
     const before = (function () { const f = screencaptureWindow("clickbefore"); return f.ok ? fileHash(path.join(RUNDIR, f.screenshot)) : ""; })();
     let ok = true, reason = "";
-    const args = ["click", String(gx), String(gy)];
-    if (double) args.push("double");
     const useCli = CLICK_TOOL === "cliclick" || (CLICK_TOOL === "auto" && haveCliclick());
-    if (useCli) {
-      const r = spawnSync("cliclick", [(double ? "dc:" : "c:") + Math.round(gx) + "," + Math.round(gy)], { encoding: "utf8" });
-      if (r.status !== 0) { ok = false; reason = (r.stderr || "cliclick failed").slice(0, 200); }
-    } else {
-      const r = runHelper(args);
-      if (!r || r.ok !== true) { ok = false; reason = (r && r._error) || "click helper failed"; }
-    }
+    const clickResult = core.clickAt(resolveHelper(), useCli, gx, gy, !!double);
+    if (!clickResult.ok) { ok = false; reason = clickResult.reason || "click failed"; }
     spawnSync("sleep", ["0.7"]);
     const after = screencaptureWindow("click");
     const afterHash = after.ok ? fileHash(path.join(RUNDIR, after.screenshot)) : "";

--- a/qa/native_palette/player_smoke_driver.js
+++ b/qa/native_palette/player_smoke_driver.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/*
+ * player_smoke_driver.js — the SCRIPTED (no LLM) sequence for qa/player_smoke.sh (#1443).
+ *
+ * Drives the EXACT SAME primitives native_palette_server.js exposes to the T3 blind-player agent
+ * (native_palette_core.js: findWindow/activateOwner/captureWindow/clickAt) but through a fixed
+ * script instead of an MCP tool loop, so a post-build smoke run needs no LLM call: screenshot ->
+ * click a known walkable grid cell (move) -> capture glide frames -> screenshot -> click the
+ * goblin's cell (on-turn attack) -> capture glide frames -> screenshot. Assertions on the
+ * resulting game state (mover's cell changed, goblin HP dropped) are done by the CALLER
+ * (qa/player_smoke.sh, reading the campaign snapshot) — this driver's job is purely the
+ * cross-Space capture/click plumbing + reporting inter-frame hashes for the motion-liveness check.
+ *
+ * Click targets are computed from GRID CELL coordinates via the locked dimetric camera projection
+ * (qa/visual_pregate.py::CameraSpec is the source-of-truth authority this mirrors — orthoSize=13,
+ * pitch=30deg, yaw=45deg, camera pulled back 80 world units, isotropic 2.0-world-unit cells) with
+ * ASPECT DERIVED FROM THE ACTUAL CAPTURED WINDOW SIZE (not the pregate's fixed 1920x1097) since the
+ * live player window can open at any resolution — an orthographic camera's horizontal half-width
+ * scales with aspect, so this keeps the projection correct regardless of window size.
+ *
+ * Usage:
+ *   node player_smoke_driver.js --rundir <dir> --owner WorldOSPlayer --cols 16 --rows 12 \
+ *     --hero-cell 7,9 --goblin-cell 10,8 --walk-cell 8,9 [--helper <bin>] [--fullscreen-fallback]
+ *
+ * Prints ONE JSON summary line to stdout: {ok, reason?, window, screenshots:[...],
+ *   glide_move:[...], glide_attack:[...], glide_move_distinct, glide_attack_distinct}
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+const core = require("./native_palette_core.js");
+
+// ---- CLI args ---------------------------------------------------------------
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    if (key === "fullscreen-fallback") { out[key] = true; continue; }
+    out[key] = argv[++i];
+  }
+  return out;
+}
+function cell(s) { const [c, r] = String(s).split(",").map(Number); return { c, r }; }
+
+const args = parseArgs(process.argv.slice(2));
+const RUNDIR = args.rundir || path.join(require("os").tmpdir(), "worldos-smoke-run");
+const OWNER = args.owner || "WorldOSPlayer";
+const COLS = Number(args.cols || 16);
+const ROWS = Number(args.rows || 12);
+const HERO = cell(args["hero-cell"] || "7,9");
+const GOBLIN = cell(args["goblin-cell"] || "10,8");
+const WALK = cell(args["walk-cell"] || "8,9");
+const HELPER = args.helper || "";
+const FULLSCREEN_FALLBACK = !!args["fullscreen-fallback"];
+const GLIDE_FRAMES = 4;
+const GLIDE_INTERVAL_MS = 150;
+const SETTLE_MS = 500;
+
+const SHOTS = path.join(RUNDIR, "player", "screenshots");
+fs.mkdirSync(SHOTS, { recursive: true });
+
+const helperCmd = core.resolveHelper(path.join(RUNDIR, "player"), HELPER);
+const captureState = {};
+let seq = 0;
+
+function sleepMs(ms) { spawnSync("sleep", [String(ms / 1000)]); }
+
+function shoot(label) {
+  seq += 1;
+  const name = "smoke-" + String(seq).padStart(3, "0") + "-" + label + ".png";
+  const file = path.join(SHOTS, name);
+  const cap = core.captureWindow({
+    helperCmd, owner: OWNER, outFile: file, fullscreenFallback: FULLSCREEN_FALLBACK, state: captureState,
+  });
+  return { ...cap, file, rel: path.join("player", "screenshots", name) };
+}
+
+// ---- the locked dimetric camera projection (mirrors qa/visual_pregate.py::CameraSpec) ----------
+const ORTHO_SIZE = 13.0, PITCH_DEG = 30.0, YAW_DEG = 45.0, CAM_DIST = 80.0;
+function cellToWorld(c, r, cols, rows) {
+  const cx0 = (cols - 1) / 2.0, cy0 = (rows - 1) / 2.0;
+  return { wx: (c - cx0) * 2.0, wy: 0.0, wz: (cy0 - r) * 2.0 };
+}
+function worldToScreen(wx, wy, wz, pxW, pxH) {
+  const p = (PITCH_DEG * Math.PI) / 180, y = (YAW_DEG * Math.PI) / 180;
+  const fwd = [Math.sin(y) * Math.cos(p), -Math.sin(p), Math.cos(y) * Math.cos(p)];
+  const right = [Math.cos(y), 0.0, -Math.sin(y)];
+  const up = [
+    fwd[1] * right[2] - fwd[2] * right[1],
+    fwd[2] * right[0] - fwd[0] * right[2],
+    fwd[0] * right[1] - fwd[1] * right[0],
+  ];
+  const pos = [-fwd[0] * CAM_DIST, -fwd[1] * CAM_DIST, -fwd[2] * CAM_DIST];
+  const dx = wx - pos[0], dy = wy - pos[1], dz = wz - pos[2];
+  const camR = dx * right[0] + dy * right[1] + dz * right[2];
+  const camU = dx * up[0] + dy * up[1] + dz * up[2];
+  const halfH = ORTHO_SIZE;
+  const aspect = pxW / pxH; // DYNAMIC — the actual captured window, not a fixed pregate resolution
+  const halfW = ORTHO_SIZE * aspect;
+  const sx = (camR / halfW) * (pxW / 2.0) + pxW / 2.0;
+  const sy = pxH / 2.0 - (camU / halfH) * (pxH / 2.0);
+  return { sx, sy };
+}
+function cellPixel(c, r, cols, rows, pxW, pxH) {
+  const { wx, wy, wz } = cellToWorld(c, r, cols, rows);
+  return worldToScreen(wx, wy, wz, pxW, pxH);
+}
+
+function clickCell(target, pxW, pxH, winCache, label) {
+  const { sx, sy } = cellPixel(target.c, target.r, COLS, ROWS, pxW, pxH);
+  // sx,sy are in the SAME capture-pixel space screenshots are saved in -> map to global points
+  // exactly like native_palette_server.js's click tool does (winCache.x/y are global points).
+  const gx = winCache.x + sx / winCache.scale;
+  const gy = winCache.y + sy / winCache.scale;
+  const useCli = core.haveCliclick();
+  const r = core.clickAt(helperCmd, useCli, gx, gy, false);
+  return { ...r, sx, sy, gx, gy, label };
+}
+
+function distinctHashes(frames) {
+  const hashes = frames.map((f) => (f.ok ? core.fileHash(f.file) : ""));
+  return new Set(hashes.filter(Boolean)).size;
+}
+
+function main() {
+  const result = { ok: false, screenshots: [], steps: [] };
+  const start = shoot("start");
+  result.screenshots.push(start.rel);
+  if (!start.ok || !start.window || !start.pixels) {
+    result.reason = "initial screenshot/window-find failed: " + JSON.stringify({
+      ok: start.ok, hasWindow: !!start.window, hasPixels: !!start.pixels,
+    });
+    process.stdout.write(JSON.stringify(result) + "\n");
+    process.exit(1);
+  }
+  const winCache = { x: start.window.x, y: start.window.y, w: start.window.w, h: start.window.h, scale: start.scale || 1 };
+  const pxW = start.pixels.pw, pxH = start.pixels.ph;
+  result.window = { x: winCache.x, y: winCache.y, w: winCache.w, h: winCache.h, pxW, pxH, scale: winCache.scale };
+
+  // --- MOVE: click a known walkable cell near the hero -----------------------
+  const moveClick = clickCell(WALK, pxW, pxH, winCache, "move");
+  result.steps.push({ action: "click_move", cell: WALK, ...moveClick });
+  const glideMove = [];
+  for (let i = 0; i < GLIDE_FRAMES; i++) {
+    sleepMs(GLIDE_INTERVAL_MS);
+    const f = shoot("glide-move-" + i);
+    glideMove.push(f);
+    result.screenshots.push(f.rel);
+  }
+  sleepMs(SETTLE_MS);
+  const postMove = shoot("post-move");
+  result.screenshots.push(postMove.rel);
+
+  // --- ATTACK: click the goblin's cell ----------------------------------------
+  const attackClick = clickCell(GOBLIN, pxW, pxH, winCache, "attack");
+  result.steps.push({ action: "click_attack", cell: GOBLIN, ...attackClick });
+  const glideAttack = [];
+  for (let i = 0; i < GLIDE_FRAMES; i++) {
+    sleepMs(GLIDE_INTERVAL_MS);
+    const f = shoot("glide-attack-" + i);
+    glideAttack.push(f);
+    result.screenshots.push(f.rel);
+  }
+  sleepMs(SETTLE_MS);
+  const postAttack = shoot("post-attack");
+  result.screenshots.push(postAttack.rel);
+
+  result.glide_move = glideMove.map((f) => f.rel);
+  result.glide_attack = glideAttack.map((f) => f.rel);
+  result.glide_move_distinct = distinctHashes(glideMove);
+  result.glide_attack_distinct = distinctHashes(glideAttack);
+  result.ok = moveClick.ok && attackClick.ok;
+  process.stdout.write(JSON.stringify(result) + "\n");
+  process.exit(result.ok ? 0 : 1);
+}
+
+main();

--- a/qa/player_smoke.sh
+++ b/qa/player_smoke.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# WorldOS PLAYER SMOKE — the deterministic, headless-of-agents post-build check (#1443).
+#
+# The T3 native-palette gate (qa/ui_playtest_player.sh) needs an LLM player (~$3, several minutes)
+# and was BLIND for weeks before anyone noticed (Mission Control Spaces silently broke every
+# screenshot/click — see #1443). This script is the standing, FREE (~30-60s, no LLM) substitute
+# that should run after EVERY player rebuild: it boots the SAME camp fixture + WorldOSPlayer.app,
+# then drives a fixed SCRIPTED sequence through the exact same native-palette primitives
+# (qa/native_palette/native_palette_core.js) a blind player agent would use —
+#
+#   screenshot -> click a known walkable cell (move) -> wait -> screenshot
+#              -> click the goblin (on-turn attack)  -> wait -> screenshot
+#
+# — and asserts, against the ENGINE'S OWN campaign snapshot (ground truth, not the public/player-
+# facing surface):
+#   1. the mover's grid cell CHANGED (the click's raycast really landed and posted move_to_cell)
+#   2. the goblin's current_hp DROPPED (the attack click really landed and the engine resolved it —
+#      deterministic because the fixture (qa/seed_gfx_camp_smoke.py) sandboxes force_hit so the
+#      attack always connects; damage is still rolled normally, so hp still drops by a real amount)
+#   3. MOTION-LIVENESS: consecutive glide frames captured during each action differ (a frozen/black
+#      viewport would pass "the engine mutated" but fail this — the #1443 bug's actual symptom was
+#      screenshots silently not updating at all)
+#
+# This is a GATE, not a scored run: no LLM, no scores_ledger row (see docs/RUNBOOK-INDEX.md — free,
+# every rebuild, alongside fast_gate). Frames + a smoke_result.json land in the run dir for evidence.
+#
+# CLICK-TARGET CALIBRATION (read before debugging a FAIL here): click pixels are computed from grid
+# cells via the locked dimetric camera projection qa/visual_pregate.py::CameraSpec documents for the
+# STRUCTURAL/asset-gen capture pipeline (paint_combat_v1.cs). A live validation run (#1443) proved
+# the CROSS-SPACE mechanism end-to-end — a real synthetic click landed on the real window and the
+# engine registered a real move — but also surfaced that the LIVE gameplay camera/view (WorldOSPlayer
+# runtime, CombatSurfaceClient.cs) may frame the scene differently than that offline capture camera
+# (e.g. an establishing/pre-combat shot before the tactical grid view settles), so exact cell->pixel
+# math may need on-box recalibration. This is a SEPARATE, orthogonal gap from the #1443 bug (Spaces
+# blindness) — this script still fails LOUD with a clear reason rather than silently passing, which
+# is the property #1443 needed. If this FAILs on a build known to be otherwise healthy, capture one
+# frame by hand (`node qa/native_palette/player_smoke_driver.js` won't do it standalone — use
+# native_palette_core.js's captureWindow() directly, no click) and re-derive the projection constants.
+#
+# Usage:   qa/player_smoke.sh [<runid>]
+# Env:     WORLDOS_PLAYER_APP        — path to WorldOSPlayer.app (same search order as the T3 runner)
+#          WORLDOS_NPT_WINDOW_OWNER  — CGWindowList owner name (default "WorldOSPlayer")
+#          WORLDOS_NPT_HELPER        — path to a prebuilt native_input binary (else compiled fresh)
+#          WORLDOS_NPT_FULLSCREEN_FALLBACK — "1" to allow the full-screen+crop fallback capture
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 1
+
+NPT_DIR="$ROOT/qa/native_palette"
+OWNER="${WORLDOS_NPT_WINDOW_OWNER:-WorldOSPlayer}"
+CID="camp_gfxdemo01"
+
+# --- shared boot helpers (#1443 — see qa/ui_playtest_player.sh for the sibling T3 harness) -------
+. "$ROOT/qa/lib_native_player_boot.sh"
+
+RUN="${1:-smoke-$(date +%H%M%S)}"
+RUNDIR="$ROOT/qa/player_smoke_runs/$RUN"
+PLAYERDIR="$RUNDIR/player"
+STATE_DIR="$RUNDIR/state"
+rm -rf "$RUNDIR" 2>/dev/null
+mkdir -p "$PLAYERDIR/screenshots" "$STATE_DIR"
+
+# --- fail-loud permission preflight (same two grants the T3 gate requires) ----------------------
+PERMS="$(swift "$NPT_DIR/native_input.swift" checkperms 2>/dev/null)"
+if ! echo "$PERMS" | grep -q '"screen_recording":true'; then
+  echo "[smoke] FATAL: Screen Recording NOT granted → System Settings ▸ Privacy & Security ▸ Screen Recording" >&2
+  echo "        (enable the app running this script, then RESTART it). probe=$PERMS" >&2; exit 5; fi
+if ! echo "$PERMS" | grep -q '"accessibility":true'; then
+  echo "[smoke] FATAL: Accessibility NOT granted → System Settings ▸ Privacy & Security ▸ Accessibility" >&2
+  echo "        (enable the app running this script, then RESTART it). probe=$PERMS" >&2; exit 5; fi
+echo "[smoke] permissions OK: $PERMS"
+
+# --- #1443 force-recompile discipline (see ui_playtest_player.sh for the full rationale) ---------
+rm -f "$PLAYERDIR/native_input"
+
+APP="$(find_player_app)" || { echo "[smoke] WorldOSPlayer.app not found (set WORLDOS_PLAYER_APP)." >&2; exit 2; }
+PLAYER_BIN="$APP/Contents/MacOS/WorldOSPlayer"
+[ -x "$PLAYER_BIN" ] || { echo "[smoke] player binary not executable: $PLAYER_BIN" >&2; exit 2; }
+
+PORT="$(pick_port)" || { echo "[smoke] no free port in 8990-8999 — aborting" >&2; exit 3; }
+BASE_URL="http://127.0.0.1:$PORT"
+
+# --- seed the DETERMINISTIC (sandbox + force_hit) camp fixture (#1443; see the seed's docstring) --
+echo "[smoke] seeding $CID via qa/seed_gfx_camp_smoke.py…"
+SEED_JSON="$(WORLDOS_STATE_DIR="$STATE_DIR" uv run --directory servers/engine python "$ROOT/qa/seed_gfx_camp_smoke.py" "$STATE_DIR" 2>"$RUNDIR/seed.err")" \
+  || { echo "[smoke] seed failed (see $RUNDIR/seed.err)" >&2; cat "$RUNDIR/seed.err" >&2; exit 4; }
+echo "[smoke] seeded: $SEED_JSON"
+
+# --- compute a WALKABLE cell adjacent to the goblin (so the move lands the hero in melee range,
+# then the attack click lands on-turn) — derived from the seed's OWN impassable set + cells, so a
+# future fixture change can't silently break this into an out-of-range attack. ---------------------
+TARGETS_JSON="$(python3 - "$SEED_JSON" <<'PY'
+import json, sys
+seed = json.loads(sys.argv[1])
+hx, hy = seed["hero_cell"]; gx, gy = seed["goblin_cell"]
+cols, rows = map(int, seed["grid"].split("x"))
+blocked = {tuple(c) for c in seed["impassable"]}
+blocked.add((gx, gy))
+best, best_dist = None, None
+for dx in (-1, 0, 1):
+    for dy in (-1, 0, 1):
+        if dx == 0 and dy == 0:
+            continue
+        c, r = gx + dx, gy + dy
+        if not (0 <= c < cols and 0 <= r < rows):
+            continue
+        if (c, r) in blocked or (c, r) == (hx, hy):
+            continue
+        dist = max(abs(c - hx), abs(r - hy))  # chebyshev — matches the engine's default diagonal_mode
+        if best is None or dist < best_dist:
+            best, best_dist = (c, r), dist
+if best is None:
+    print(json.dumps({"ok": False, "reason": "no walkable cell adjacent to the goblin"}))
+    sys.exit(1)
+print(json.dumps({"ok": True, "walk_cell": list(best), "cols": cols, "rows": rows,
+                   "hero_cell": [hx, hy], "goblin_cell": [gx, gy]}))
+PY
+)" || { echo "[smoke] FATAL: could not derive a walkable cell adjacent to the goblin: $TARGETS_JSON" >&2; exit 4; }
+echo "[smoke] targets: $TARGETS_JSON"
+WALK_C="$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['walk_cell'][0])" "$TARGETS_JSON")"
+WALK_R="$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['walk_cell'][1])" "$TARGETS_JSON")"
+COLS="$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['cols'])" "$TARGETS_JSON")"
+ROWS="$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['rows'])" "$TARGETS_JSON")"
+HERO_C="$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['hero_cell'][0])" "$TARGETS_JSON")"
+HERO_R="$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['hero_cell'][1])" "$TARGETS_JSON")"
+GOB_C="$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['goblin_cell'][0])" "$TARGETS_JSON")"
+GOB_R="$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['goblin_cell'][1])" "$TARGETS_JSON")"
+HERO_ID="$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['hero_id'])" "$SEED_JSON")"
+GOBLIN_ID="$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['goblin_id'])" "$SEED_JSON")"
+
+# --- start engine + viewer. WORLDOS_COMBAT_TEST=1 arms the double-guarded force_hit toggle (the
+# OTHER half of the guard is Campaign.is_sandbox, set by the seed) for the grid-combat arbiter that
+# runs IN-PROCESS inside this viewer. WORLDOS_PLAYER_MOVES must be a writable path even though a
+# move_to_cell/attack never actually appends to it (they're engine-resolved in-process before the
+# append path) — the do_POST /move gate refuses ALL moves up-front when it's unset. -----------------
+WORLDOS_STATE_DIR="$STATE_DIR" WORLDOS_PLAYER_MOVES="$STATE_DIR/player_moves.jsonl" \
+WORLDOS_COMBAT_TEST=1 \
+  python3 viewer/server.py "" "$PORT" > "$RUNDIR/viewer.log" 2>&1 &
+VIEWER=$!
+PLAYER_APP_PID=""
+cleanup() {
+  kill "$VIEWER" 2>/dev/null
+  [ -n "$PLAYER_APP_PID" ] && kill "$PLAYER_APP_PID" 2>/dev/null
+  osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+ready=0
+for _ in $(seq 1 40); do
+  code="$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/combat-surface?campaign=$CID" 2>/dev/null)"
+  [ "$code" = "200" ] && { ready=1; break; }
+  sleep 0.5
+done
+[ "$ready" = "1" ] || { echo "[smoke] viewer never served /combat-surface at $BASE_URL (see $RUNDIR/viewer.log)" >&2; exit 4; }
+echo "[smoke] viewer ready — /combat-surface serving $CID."
+
+# --- #1443 launch-into-same-Space, then launch the player build -----------------------------------
+osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
+sleep 1
+activate_current_space_context
+WORLDOS_ENGINE_BASE_URL="$BASE_URL" WORLDOS_CAMPAIGN_ID="$CID" "$PLAYER_BIN" \
+  > "$RUNDIR/player_app.log" 2>&1 &
+PLAYER_APP_PID=$!
+echo "[smoke] player app launched (pid $PLAYER_APP_PID) — engine=$BASE_URL campaign=$CID"
+# Let Unity open its window, fetch /combat-surface, and settle into the TACTICAL GRID camera
+# framing (not whatever establishing/pre-combat view it opens on) before the scripted clicks —
+# the click-target math below assumes the locked dimetric combat camera is on screen.
+sleep 10
+
+# --- BASELINE snapshot (before the scripted click sequence) ---------------------------------------
+snapshot_field() {  # snapshot_field <python-expr-on-'snap'>
+  python3 -c "
+import json, sys
+snap = json.load(open('$STATE_DIR/campaigns/$CID/snapshot.json'))
+print($1)
+" 2>/dev/null
+}
+BASE_HERO_XY="$(snapshot_field "next((c['x'],c['y']) for c in snap['combat']['order'] if c['character_id']=='$HERO_ID')")"
+BASE_GOBLIN_HP="$(snapshot_field "snap['characters']['$GOBLIN_ID']['current_hp']")"
+echo "[smoke] baseline: hero_xy=$BASE_HERO_XY goblin_hp=$BASE_GOBLIN_HP"
+
+# --- the SCRIPTED sequence (no LLM) — same primitives the T3 palette exposes ----------------------
+echo "[smoke] driving scripted sequence: move ($HERO_C,$HERO_R)->($WALK_C,$WALK_R), attack ($GOB_C,$GOB_R)…"
+DRIVER_JSON="$(node "$NPT_DIR/player_smoke_driver.js" \
+  --rundir "$RUNDIR" --owner "$OWNER" --cols "$COLS" --rows "$ROWS" \
+  --hero-cell "$HERO_C,$HERO_R" --goblin-cell "$GOB_C,$GOB_R" --walk-cell "$WALK_C,$WALK_R" \
+  ${WORLDOS_NPT_HELPER:+--helper "$WORLDOS_NPT_HELPER"} \
+  ${WORLDOS_NPT_FULLSCREEN_FALLBACK:+--fullscreen-fallback} \
+  2>"$RUNDIR/driver.err")"
+DRIVER_RC=$?
+echo "[smoke] driver rc=$DRIVER_RC: $DRIVER_JSON"
+
+# Settle beat so the engine-resolved move/attack (already applied server-side the instant the
+# client's click POSTed) is reflected in the just-written snapshot before we re-read it.
+sleep 1
+
+# --- FINAL snapshot + assertions --------------------------------------------------------------
+FINAL_HERO_XY="$(snapshot_field "next((c['x'],c['y']) for c in snap['combat']['order'] if c['character_id']=='$HERO_ID')")"
+FINAL_GOBLIN_HP="$(snapshot_field "snap['characters']['$GOBLIN_ID']['current_hp']")"
+echo "[smoke] final: hero_xy=$FINAL_HERO_XY goblin_hp=$FINAL_GOBLIN_HP"
+
+GLIDE_MOVE_DISTINCT="$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('glide_move_distinct',0))" "$DRIVER_JSON" 2>/dev/null || echo 0)"
+GLIDE_ATTACK_DISTINCT="$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('glide_attack_distinct',0))" "$DRIVER_JSON" 2>/dev/null || echo 0)"
+
+PASS=1
+REASONS=()
+[ "$DRIVER_RC" = "0" ] || { PASS=0; REASONS+=("driver reported a click failure (rc=$DRIVER_RC)"); }
+[ -n "$BASE_HERO_XY" ] && [ -n "$FINAL_HERO_XY" ] && [ "$BASE_HERO_XY" != "$FINAL_HERO_XY" ] \
+  || { PASS=0; REASONS+=("hero cell did not change (base=$BASE_HERO_XY final=$FINAL_HERO_XY) — move click did not land"); }
+[ -n "$BASE_GOBLIN_HP" ] && [ -n "$FINAL_GOBLIN_HP" ] && [ "$FINAL_GOBLIN_HP" -lt "$BASE_GOBLIN_HP" ] 2>/dev/null \
+  || { PASS=0; REASONS+=("goblin HP did not drop (base=$BASE_GOBLIN_HP final=$FINAL_GOBLIN_HP) — attack click did not land"); }
+[ "${GLIDE_MOVE_DISTINCT:-0}" -ge 2 ] 2>/dev/null \
+  || { PASS=0; REASONS+=("move glide frames were not distinct (motion-liveness failed, distinct=$GLIDE_MOVE_DISTINCT)"); }
+[ "${GLIDE_ATTACK_DISTINCT:-0}" -ge 2 ] 2>/dev/null \
+  || { PASS=0; REASONS+=("attack glide frames were not distinct (motion-liveness failed, distinct=$GLIDE_ATTACK_DISTINCT)"); }
+
+python3 - "$RUNDIR/smoke_result.json" "$PASS" "$BASE_HERO_XY" "$FINAL_HERO_XY" "$BASE_GOBLIN_HP" "$FINAL_GOBLIN_HP" \
+  "$GLIDE_MOVE_DISTINCT" "$GLIDE_ATTACK_DISTINCT" "$DRIVER_RC" "$RUN" <<'PY'
+import json, sys
+out, passed, bhero, fhero, bhp, fhp, gmove, gattack, drc, run = sys.argv[1:11]
+json.dump({
+    "run": run, "pass": bool(int(passed)),
+    "hero_xy": {"base": bhero, "final": fhero},
+    "goblin_hp": {"base": bhp, "final": fhp},
+    "glide_distinct": {"move": int(gmove or 0), "attack": int(gattack or 0)},
+    "driver_rc": int(drc),
+}, open(out, "w"), indent=2)
+PY
+
+echo "[smoke] driver output + snapshots: $RUNDIR"
+if [ "$PASS" = "1" ]; then
+  echo "[smoke] PASS — cell changed, goblin HP dropped, glide frames distinct."
+  exit 0
+else
+  echo "[smoke] FAIL:"
+  for r in "${REASONS[@]}"; do echo "  - $r"; done
+  exit 1
+fi

--- a/qa/seed_gfx_camp_smoke.py
+++ b/qa/seed_gfx_camp_smoke.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""seed_gfx_camp_smoke.py — seeds camp_gfxdemo01 IDENTICALLY to seed_gfx_camp.py (imports + reuses
+its `_author_camp_grid`, so the grid/props/obstacles stay ONE source), but additionally marks the
+campaign `is_sandbox` + `house_rules.force_hit` so qa/player_smoke.sh's scripted attack step is
+DETERMINISTIC.
+
+Why: the #1443 smoke test drives a REAL synthetic click on the goblin's cell to trigger the
+engine's grid-combat arbiter (viewer/server.py::_resolve_player_combat_turn -> attack Intent), then
+asserts the goblin's current_hp dropped. A real attack roll can MISS (a hero attack bonus of +6 vs
+a goblin AC 15 has a real miss chance), which would make the smoke flaky. `force_hit` is a
+TEST-ONLY, DOUBLE-GUARDED toggle in servers/engine/server.py (`_combat_test_mode_enabled`: requires
+BOTH env WORLDOS_COMBAT_TEST=1 AND Campaign.is_sandbox — see servers/engine/server.py) that forces
+the HIT BOOLEAN only; damage is still rolled normally (still >=1), so current_hp genuinely drops by
+a real amount without faking a crit or the damage number. This keeps seed_gfx_camp.py itself
+byte-for-byte unchanged (the T3 LLM-player harness wants an honest, missable fight) while giving the
+headless smoke test a deterministic pass/fail.
+
+  WORLDOS_STATE_DIR=<dir> uv run --directory servers/engine python \
+    "$PWD/qa/seed_gfx_camp_smoke.py" <state_dir>
+
+(qa/player_smoke.sh additionally exports WORLDOS_COMBAT_TEST=1 on the VIEWER process — the engine
+bridge that actually resolves the attack — not needed here at seed time.)
+
+Engine = SOLE WRITER: writes only via server.* engine calls + save_campaign, exactly like
+seed_gfx_camp.py. Additive: a new seed script, touches no existing seed/contract.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import seed_gfx_camp as base  # noqa: E402  (reuse _author_camp_grid — ONE grid source)
+
+CID = base.CID
+GRID_W, GRID_H = base.GRID_W, base.GRID_H
+HERO_CELL, GOBLIN_CELL = base.HERO_CELL, base.GOBLIN_CELL
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: seed_gfx_camp_smoke.py <state_dir>", file=sys.stderr)
+        sys.exit(2)
+    state_dir = sys.argv[1]
+    os.environ["WORLDOS_STATE_DIR"] = state_dir
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "servers", "engine"))
+    import server  # noqa: PLC0415
+    from models import Campaign  # noqa: PLC0415
+
+    server.save_campaign(Campaign(
+        id=CID, title="GFX Camp Demo (smoke)",
+        summary="Deterministic headless smoke fixture (#1443) — sandbox force_hit, no LLM player.",
+        is_sandbox=True,
+    ))
+    server.add_location(campaign_id=CID, name="Campfire Clearing", make_current=True,
+                        description="A moonlit forest clearing: a low campfire, bedrolls, a fallen-log "
+                                    "seat, supply crates, boulders, and a loose tree-line boundary.")
+
+    # SAME grid/props/obstacles as seed_gfx_camp.py — one source (#1441 P2 scene<->grid coherence).
+    grid = base._author_camp_grid(server, CID)  # noqa: SLF001 (deliberate reuse; see module docstring)
+
+    server.start_session(CID, title="GFX Camp Demo (smoke)")
+    hero = server.create_character(
+        campaign_id=CID, name="Aldric", kind="player", race="human", class_name="fighter", level=4,
+        abilities={"strength": 18, "dexterity": 14, "constitution": 16,
+                   "intelligence": 10, "wisdom": 12, "charisma": 10},
+        apply_srd_defaults=True, add_to_party=True,
+    )
+    hero_id = hero["id"]
+    gob = server.spawn_monster(CID, name="Goblin", count=1)
+    goblin_id = gob["spawned"][0]["id"]
+
+    import scene_grid as sg  # noqa: PLC0415
+    impassable = sg.impassable_cells(grid, GRID_W, GRID_H)
+    server.start_combat(CID, [hero_id, goblin_id], surpriser_ids=[hero_id])
+    server.set_grid(CID, width=GRID_W, height=GRID_H, obstacles=impassable)
+    server.place_combatant_at_coords(CID, hero_id, HERO_CELL[0], HERO_CELL[1])
+    server.place_combatant_at_coords(CID, goblin_id, GOBLIN_CELL[0], GOBLIN_CELL[1])
+
+    # TEST-ONLY, double-guarded (see servers/engine/server.py::_combat_test_mode_enabled): a
+    # deterministic HIT so the scripted smoke attack always drops the goblin's HP. Damage is
+    # still rolled normally (>=1) — only the hit/miss coin flip is forced.
+    c = server._require(CID)  # noqa: SLF001
+    c.house_rules.force_hit = True
+    server.save_campaign(c)
+
+    print(json.dumps({
+        "campaign_id": CID, "hero_id": hero_id, "goblin_id": goblin_id,
+        "grid": f"{GRID_W}x{GRID_H}", "impassable": impassable,
+        "hero_cell": HERO_CELL, "goblin_cell": GOBLIN_CELL,
+        "sandbox": True, "force_hit": True,
+    }))
+
+
+if __name__ == "__main__":
+    main()

--- a/qa/test_native_palette.py
+++ b/qa/test_native_palette.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -112,6 +113,27 @@ class SwiftHelperTests(unittest.TestCase):
             w = subprocess.run([str(out), "winfind", "NoSuchApp_ZZZ"], capture_output=True, text=True)
             self.assertEqual(json.loads(w.stdout.strip().splitlines()[-1]).get("found"), False)
 
+    @unittest.skipUnless(shutil.which("swiftc"), "swiftc not available (non-macOS CI)")
+    def test_winfind_reports_on_screen_and_has_all_spaces_fallback(self):
+        """#1443: winFind must (a) always report an `on_screen` bool when found (so callers know
+        whether `screencapture -l` will work from here), and (b) fall back to an all-Spaces search
+        when the owner isn't in the on-screen-only pass — proven here by finding Finder (whose
+        actual on-screen window content is environment-dependent, but the owner is ALWAYS present
+        in one pass or the other on a running Mac, since it's always running)."""
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "native_input"
+            subprocess.run(["swiftc", str(SWIFT), "-o", str(out)], check=True, capture_output=True)
+            w = subprocess.run([str(out), "winfind", "Finder"], capture_output=True, text=True)
+            data = json.loads(w.stdout.strip().splitlines()[-1])
+            self.assertTrue(data.get("found"), f"Finder should always be findable: {data}")
+            self.assertIn("on_screen", data, "winfind must report on_screen so callers can decide to activate")
+            self.assertIsInstance(data["on_screen"], bool)
+
+    def test_source_has_all_spaces_fallback(self):
+        src = SWIFT.read_text(encoding="utf-8")
+        self.assertIn("allSpacesOpts", src, "winFind must retry without .optionOnScreenOnly (#1443)")
+        self.assertIn("on_screen", src, "winFind must emit on_screen so capture callers can activate+retry")
+
 
 class ServerBootTests(unittest.TestCase):
     @unittest.skipUnless(shutil.which("node"), "node not available")
@@ -172,6 +194,126 @@ class ScorerCompatibilityTests(unittest.TestCase):
             self.assertEqual(score["console_errors"], 0)
             self.assertEqual(score["network_failures"], 0)
             self.assertTrue((rundir / "summary.md").is_file())
+
+
+CORE = NPT / "native_palette_core.js"
+LIB_BOOT = ROOT / "qa" / "lib_native_player_boot.sh"
+SMOKE_RUNNER = ROOT / "qa" / "player_smoke.sh"
+SMOKE_DRIVER = NPT / "player_smoke_driver.js"
+SEED_SMOKE = ROOT / "qa" / "seed_gfx_camp_smoke.py"
+
+
+class CoreModuleTests(unittest.TestCase):
+    """native_palette_core.js (#1443) — the capture/activate/click primitives shared by
+    native_palette_server.js (the T3 MCP tool) and player_smoke_driver.js (the scripted smoke)."""
+
+    def test_core_module_exists_and_is_required_by_the_server(self):
+        self.assertTrue(CORE.is_file())
+        src = SERVER.read_text(encoding="utf-8")
+        self.assertIn('require("./native_palette_core.js")', src,
+                      "native_palette_server.js must share the #1443 capture fix, not fork it")
+
+    def test_core_module_exports_the_capture_primitives(self):
+        src = CORE.read_text(encoding="utf-8")
+        for name in ("resolveHelper", "findWindow", "activateOwner", "waitForOnScreen",
+                     "captureWindow", "clickAt", "fullscreenCropWindow"):
+            self.assertIn(name, src, f"native_palette_core.js must export {name}")
+
+    def test_capture_window_activates_and_falls_back(self):
+        src = CORE.read_text(encoding="utf-8")
+        self.assertIn("activateOwner(owner)", src, "#1443: must activate the owner when off-screen")
+        self.assertIn("fullscreenCropWindow", src, "#1443: must fall back to a cropped full-screen grab")
+
+    @unittest.skipUnless(shutil.which("swiftc") and shutil.which("node"), "swiftc/node not available (non-macOS CI)")
+    def test_stale_compiled_binary_is_rebuilt_on_source_edit(self):
+        """The T3 finding: an in-run source patch to native_input.swift didn't take effect until the
+        server restarted, because the compiled binary was reused whenever it already existed. This
+        proves the FIX (mtime staleness check) actually recompiles — not just that the code exists."""
+        with tempfile.TemporaryDirectory() as td:
+            work = Path(td) / "work"; work.mkdir()
+            src_copy = Path(td) / "native_input.swift"
+            src_copy.write_text(SWIFT.read_text(encoding="utf-8"), encoding="utf-8")
+
+            def resolve():
+                script = (
+                    f'const core = require({json.dumps(str(CORE))});\n'
+                    f'const h = core.resolveHelper({json.dumps(str(work))}, "", {json.dumps(str(src_copy))});\n'
+                    f'console.log(JSON.stringify(h));\n'
+                )
+                r = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+                self.assertEqual(r.returncode, 0, f"resolveHelper failed:\n{r.stderr}")
+                return json.loads(r.stdout.strip().splitlines()[-1])
+
+            h1 = resolve()
+            mtime1 = os.stat(h1["bin"]).st_mtime
+            # No source change -> the binary must NOT be recompiled (mtime unchanged).
+            h2 = resolve()
+            self.assertEqual(os.stat(h2["bin"]).st_mtime, mtime1, "resolveHelper recompiled an up-to-date binary")
+            # Edit the source and push its mtime forward -> MUST recompile.
+            with src_copy.open("a", encoding="utf-8") as f:
+                f.write("\n// touched for test\n")
+            future = time.time() + 5
+            os.utime(src_copy, (future, future))
+            h3 = resolve()
+            self.assertGreater(os.stat(h3["bin"]).st_mtime, mtime1,
+                                "a stale compiled binary was NOT rebuilt after the source changed (#1443 T3 bug)")
+
+
+class LaunchIntoSpaceTests(unittest.TestCase):
+    """#1443: the harnesses re-activate the current GUI context right before launching
+    WorldOSPlayer.app, so the new window opens on the harness's current Space."""
+
+    def test_shared_lib_defines_activation_helper(self):
+        self.assertTrue(LIB_BOOT.is_file())
+        src = LIB_BOOT.read_text(encoding="utf-8")
+        self.assertIn("activate_current_space_context()", src)
+        self.assertIn("frontmost", src)
+
+    def test_ui_playtest_player_sources_shared_lib_and_activates_before_launch(self):
+        text = (ROOT / "qa" / "ui_playtest_player.sh").read_text(encoding="utf-8")
+        self.assertIn("lib_native_player_boot.sh", text)
+        self.assertIn("activate_current_space_context", text)
+        # force-recompile discipline: the runner deletes a stale compiled binary before launch.
+        self.assertIn('rm -f "$PLAYERDIR/native_input"', text)
+
+    def test_player_smoke_sources_shared_lib_and_activates_before_launch(self):
+        text = SMOKE_RUNNER.read_text(encoding="utf-8")
+        self.assertIn("lib_native_player_boot.sh", text)
+        self.assertIn("activate_current_space_context", text)
+        self.assertIn('rm -f "$PLAYERDIR/native_input"', text)
+
+
+class PlayerSmokeTests(unittest.TestCase):
+    """qa/player_smoke.sh (#1443) — the deterministic, headless-of-agents post-build check."""
+
+    def test_files_exist_and_are_executable(self):
+        for p in (SMOKE_RUNNER, SMOKE_DRIVER, SEED_SMOKE):
+            self.assertTrue(p.is_file(), f"missing {p}")
+        self.assertTrue(os.access(SMOKE_RUNNER, os.X_OK), "player_smoke.sh must be executable")
+
+    def test_seed_smoke_is_sandboxed_and_forces_hits_deterministically(self):
+        src = SEED_SMOKE.read_text(encoding="utf-8")
+        self.assertIn("is_sandbox=True", src)
+        self.assertIn("force_hit = True", src)
+        self.assertIn("_author_camp_grid", src, "must reuse seed_gfx_camp.py's grid, not fork it")
+
+    def test_smoke_drives_the_shared_core_primitives(self):
+        src = SMOKE_DRIVER.read_text(encoding="utf-8")
+        self.assertIn('require("./native_palette_core.js")', src)
+        for name in ("captureWindow", "clickAt"):
+            self.assertIn(name, src)
+
+    def test_smoke_asserts_cell_change_hp_drop_and_motion_liveness(self):
+        text = SMOKE_RUNNER.read_text(encoding="utf-8")
+        self.assertIn("hero cell did not change", text)
+        self.assertIn("goblin HP did not drop", text)
+        self.assertIn("motion-liveness failed", text)
+
+    @unittest.skipUnless(shutil.which("node"), "node not available")
+    def test_driver_reports_glide_frame_distinctness_fields(self):
+        src = SMOKE_DRIVER.read_text(encoding="utf-8")
+        self.assertIn("glide_move_distinct", src)
+        self.assertIn("glide_attack_distinct", src)
 
 
 if __name__ == "__main__":

--- a/qa/ui_playtest_player.sh
+++ b/qa/ui_playtest_player.sh
@@ -79,29 +79,10 @@ fixture_for_scene() {
   esac
 }
 
-# --- locate the installed MCP SDK (worktrees have no node_modules — accept an explicit override or
-# the canonical checkout's qa/playwright install, matching native_palette_server.js's resolution). --
-find_sdk_node_modules() {
-  local c
-  for c in "${WORLDOS_NPT_NODE_MODULES:-}" \
-           "$PW_DIR/node_modules" \
-           "/Users/lume/WorldOS/qa/playwright/node_modules"; do
-    [ -n "$c" ] && [ -d "$c/@modelcontextprotocol" ] && { echo "$c"; return 0; }
-  done
-  return 1
-}
-
-# --- locate the player app ---------------------------------------------------
-find_player_app() {
-  local c
-  for c in "${WORLDOS_PLAYER_APP:-}" \
-           "$HOME/Applications/WorldOSPlayer.app" \
-           "/Applications/WorldOSPlayer.app" \
-           "$HOME/worldos-session-notes/w5a-build/WorldOSPlayer.app"; do
-    [ -n "$c" ] && [ -d "$c" ] && { echo "$c"; return 0; }
-  done
-  return 1
-}
+# --- shared boot helpers (find_sdk_node_modules / find_player_app / pick_port /
+# activate_current_space_context — #1443: the cross-Space launch/capture fix lives in ONE place,
+# shared with qa/player_smoke.sh). ------------------------------------------------------------
+. "$ROOT/qa/lib_native_player_boot.sh"
 
 # --- --preflight: validate prerequisites + permissions, then exit (no run) ---
 if [ "${1:-}" = "--preflight" ]; then
@@ -189,10 +170,7 @@ if ! echo "$PERMS" | grep -q '"accessibility":true'; then
   echo "       (enable the app running this script, then RESTART it). probe=$PERMS" >&2; exit 5; fi
 echo "[t3] permissions OK: $PERMS"
 
-# --- free port in 8990–8999 --------------------------------------------------
-pick_port() { local p; for p in $(seq 8990 8999); do
-  if ! (exec 3<>"/dev/tcp/127.0.0.1/$p") 2>/dev/null; then echo "$p"; return 0; fi
-  exec 3>&- 2>/dev/null || true; done; return 1; }
+# --- free port in 8990–8999 (pick_port from lib_native_player_boot.sh) -------
 PORT="$(pick_port)" || { echo "[t3] no free port in 8990-8999 — aborting" >&2; exit 3; }
 BASE_URL="http://127.0.0.1:$PORT"
 
@@ -266,6 +244,25 @@ for _ in $(seq 1 40); do
 done
 [ "$ready" = "1" ] || { echo "[t3] viewer never served /combat-surface at $BASE_URL (see $RUNDIR/viewer.log)" >&2; exit 4; }
 echo "[t3] viewer ready — /combat-surface serving $CID."
+
+# --- #1443 force-recompile discipline ----------------------------------------
+# A compiled native_input binary that predates the CURRENT native_input.swift is exactly the T3
+# bug (an in-run source patch didn't take effect until the palette server restarted, because
+# resolveHelper() only compiled once per process and only when the output file was absent).
+# native_palette_core.js now also checks source mtime vs binary mtime on every resolve, but this
+# is the belt-and-suspenders half: never START a run with a stale binary already sitting in the
+# run dir (e.g. left over from a manually-poked debug session against the same RUNDIR).
+rm -f "$PLAYERDIR/native_input"
+
+# --- #1443 launch-into-same-Space ---------------------------------------------
+# Re-activate whatever GUI app is currently frontmost (see lib_native_player_boot.sh) right
+# before spawning WorldOSPlayer, so the new window opens on the harness's CURRENT Space instead
+# of wherever focus happened to drift (Mission Control auto-switch, a prior run's cleanup, etc.)
+# — the root cause the T3 run tripped over. This is best-effort or launch position; the real
+# safety net for a player that STILL ends up on another Space is native_palette_core.js's
+# activate-before-capture (screencaptureWindow -> core.captureWindow), which recovers at
+# screenshot time regardless of where the window landed.
+activate_current_space_context
 
 # --- launch the native player build with the env launch-contract -------------
 # WorldOSPlayer.app reads WORLDOS_ENGINE_BASE_URL + WORLDOS_CAMPAIGN_ID at startup


### PR DESCRIPTION
## Summary
- `winFind` (native_input.swift) falls back to an all-Spaces `CGWindowList` search when the on-screen-only pass misses the owner, and reports `on_screen` so callers know whether `screencapture -l` will work.
- New `qa/native_palette/native_palette_core.js` (shared by `native_palette_server.js` and the new `player_smoke_driver.js`) activates the owner + polls for `on_screen` before capturing, falls back to a full-screen grab cropped to the window bounds when `-l` still fails, and rebuilds the compiled swift helper whenever `native_input.swift`'s mtime is newer than the binary — the exact T3 bug where an in-run source patch didn't take effect until the server restarted.
- `ui_playtest_player.sh` and the new `qa/player_smoke.sh` re-activate the current GUI context right before launching `WorldOSPlayer.app` (via new `qa/lib_native_player_boot.sh`) so it opens on the harness's current Space, and delete any stale compiled binary before each run.
- New `qa/player_smoke.sh`: a deterministic, headless-of-agents (no LLM) post-build smoke. Boots the camp fixture (`qa/seed_gfx_camp_smoke.py`, a sandboxed `force_hit` variant of `seed_gfx_camp.py` reusing its grid so the scripted attack is deterministic), drives screenshot → click a walkable cell → wait → screenshot → click the goblin (attack) → wait → screenshot through the real palette primitives, and asserts against the engine's own campaign snapshot that the mover's cell changed, the goblin's HP dropped, and glide frames are motion-distinct. Wired into `BuildMacOSPlayer.cs`'s docs and `docs/RUNBOOK-INDEX.md`.

## Test plan
- [x] `python3 -m pytest -q qa/test_native_palette.py` — 25 passed (extended with cross-Space fallback, core-module, force-recompile-on-mtime, launch-into-Space, and player-smoke coverage)
- [x] `qa/fast_gate.sh` — PASS (257 deterministic engine tests)
- [x] Live validation on this box: `native_palette_core.js`'s `findWindow`/`captureWindow` confirmed working end-to-end (cross-Space find + activate + `-l` capture), and a real synthetic click through the built `WorldOSPlayer.app` was confirmed to land and mutate real engine state (a `move_to_cell` resolved server-side) — proving the #1443 cross-Space pipeline fix works live, not just in unit tests.
- [ ] Note: `player_smoke.sh`'s exact click-target pixel math (grid cell → screen point) is a best-effort projection borrowed from `qa/visual_pregate.py`'s structural-capture camera contract; live validation surfaced that the runtime gameplay camera/view may differ from that offline contract, so the goblin-HP-drop assertion may need on-box recalibration of the projection constants — this is flagged in the script's header and is orthogonal to the #1443 Spaces bug this PR fixes (the script fails loud with a clear reason rather than silently passing either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)