### PR TITLE
W6.2 (#1461) rest-mode collision + walk_to, plus #1466 FIX A (T3 fetch-wedge watchdog)

### DIFF
--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -1390,7 +1390,10 @@ public class CombatSurfaceClient : MonoBehaviour
     }
 
     // ---- public, for headless/programmatic driving (the box has no mouse) ----
-    public void DoMove(int x, int y) { if (!_busy) StartCoroutine(PostMove(x, y)); }
+    // #1461: in REST mode a programmatic move is a WALK (walk_to_cell), not the combat move_to_cell —
+    // so a headless/QA driver exercises the same rest lane a mouse click does (a move_to_cell at rest is
+    // engine-rejected as a combat move). Combat mode is unchanged (PostMove).
+    public void DoMove(int x, int y) { if (!_busy) StartCoroutine(_restMode ? PostWalk(x, y) : PostMove(x, y)); }
     public void DoAttack() { if (!_busy && _foeId.Length > 0) StartCoroutine(PostAttack()); }
 
     IEnumerator PostMove(int x, int y)
@@ -1423,8 +1426,20 @@ public class CombatSurfaceClient : MonoBehaviour
             req.downloadHandler = new DownloadHandlerBuffer();
             req.SetRequestHeader("Content-Type", "application/json");
             req.timeout = 8;
-            yield return req.SendWebRequest();
-            if (!Ok(req)) { Debug.LogWarning("[CSC] /walk failed: " + req.error + " body=" + req.downloadHandler.text); }
+            // #1466: the SAME elapsed-time watchdog the GET path uses — a hung /move POST would otherwise
+            // wait forever on SendWebRequest with _busy=true, and PollLoop only fetches when !_busy, so the
+            // renderer could never recover. The watchdog guarantees this coroutine terminates and _busy is
+            // released below on EVERY path (success, reject, or timeout/abort).
+            var op = req.SendWebRequest();
+            float t0 = Time.realtimeSinceStartup;
+            bool timedOut = false;
+            while (!op.isDone)
+            {
+                if (Time.realtimeSinceStartup - t0 > FetchTimeout) { req.Abort(); timedOut = true; break; }
+                yield return null;
+            }
+            if (timedOut) Debug.LogWarning("[CSC] /walk TIMEOUT (aborted after " + FetchTimeout.ToString("0.#") + "s) — PollLoop will retry");
+            else if (!Ok(req)) Debug.LogWarning("[CSC] /walk failed: " + req.error + " body=" + req.downloadHandler.text);
             else
             {
                 // walk_to_cell returns {ok, walked, character_id, from, to, path} (NOT the combat surface).
@@ -1436,7 +1451,7 @@ public class CombatSurfaceClient : MonoBehaviour
                 if (resp != null && !resp.ok && !string.IsNullOrEmpty(resp.reason)) ShowAdvisory(resp.reason);
             }
         }
-        _busy = false;
+        _busy = false;   // always released (the watchdog guarantees the loop above terminates)
         yield return Fetch();   // re-render off the engine's fresh surface (stage_cell now updated)
     }
 

--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -84,6 +84,18 @@ public class CombatSurfaceClient : MonoBehaviour
     // list of [x,y] incl. the from-cell). The glide follows THIS polyline; empty -> straight-line fallback.
     readonly System.Collections.Generic.List<int[]> _lastPath = new System.Collections.Generic.List<int[]>();
 
+    // W6.2 (#1461) REST-MODE walk. A rest surface carries NO combat signals (empty `turnToken`, no
+    // isCurrent token); its `stage` block ({mode, tokens:[{id,x,y,rest_role}]}) marks it mode:"rest".
+    // In rest mode a click routes to the engine's `walk_to` verb (the `walk_to_cell` /move intent)
+    // instead of the combat move — with the SAME impassable/occupied pre-validation the combat path got
+    // in #1441 (rest_blocked_cells folds standers INTO the surface `impassable`, so the walkability
+    // overlay + the click gate read one collision truth). `_restMoverId` is WHO walks: the first
+    // rest_role:"party" stage token (the deterministic lead PC), mirroring the browser board's
+    // "selected party token walks" (screen-combat.jsx). Both stay false/empty on a COMBAT surface, so
+    // every combat-mode code path below is byte-identical.
+    bool _restMode = false;
+    string _restMoverId = "";
+
     // #anim-combat: the actor's ANIM_REF (moveset) fbx (registry anim_ref), so a walk/attack/hit clip that
     // lives in a SEPARATE moveset fbx rather than the model fbx is still found. Mirrors _fbxOf; both feed
     // FindOwnClip. (For the wave-2 cast the walk clip is embedded in the MODEL fbx — e.g. goblin.fbx carries
@@ -178,7 +190,7 @@ public class CombatSurfaceClient : MonoBehaviour
     System.Collections.Generic.List<object> _occRaw;  // last-parsed raw occluder entries (post-unwrap)
     string _occLocId = "";               // last-parsed location id (a room swap invalidates the proxies)
     string _occSigParsed = "";           // signature of the last-PARSED occluder set + location
-    string _occSigBuilt = " ";      // signature of the last-BUILT proxies (sentinel => first build runs)
+    string _occSigBuilt = "\0";      // signature of the last-BUILT proxies (sentinel => first build runs)
 
     [System.Serializable] public class Tok { public string id; public string name; public string team; public int x; public int y; public bool isCurrent; public int hp; public int hpMax; }
     [System.Serializable] public class Grid { public int cols; public int rows; }
@@ -303,6 +315,26 @@ public class CombatSurfaceClient : MonoBehaviour
                 _occRaw = root["occluders"] as System.Collections.Generic.List<object>;
                 _occLocId = (root.ContainsKey("location") && root["location"] is System.Collections.Generic.Dictionary<string, object> locd && locd.ContainsKey("id")) ? (locd["id"] as string ?? "") : _occLocId;
                 _occSigParsed = OccSignature(_occLocId, _occRaw);
+            }
+            // W6.2 (#1461): the `stage` block ({mode, tokens}) tells rest from combat and names the walk
+            // mover. Only re-derived when the payload actually carries `stage` (every /combat-surface poll
+            // does; a walk_to_cell /move response does NOT), so a walk response never clobbers the rest
+            // state the last poll established. A combat surface carries mode:"combat" -> _restMode false.
+            if (root.ContainsKey("stage") && root["stage"] is System.Collections.Generic.Dictionary<string, object> stage)
+            {
+                _restMode = (stage.ContainsKey("mode") ? stage["mode"] as string : "") == "rest";
+                _restMoverId = "";
+                if (_restMode && stage.ContainsKey("tokens") && stage["tokens"] is System.Collections.Generic.List<object> stoks)
+                {
+                    foreach (var e in stoks)
+                    {
+                        var tk = e as System.Collections.Generic.Dictionary<string, object>; if (tk == null) continue;
+                        string role = tk.ContainsKey("rest_role") ? tk["rest_role"] as string : "";
+                        if (role != "party") continue;                        // party tokens walk; npc tokens are talk-targets
+                        string id = tk.ContainsKey("id") ? tk["id"] as string : "";
+                        if (!string.IsNullOrEmpty(id)) { _restMoverId = id; break; } // first party token = deterministic lead PC
+                    }
+                }
             }
         }
         catch (System.Exception e) { Debug.LogWarning("[CSC] surface-extras parse: " + e.Message); }
@@ -1293,12 +1325,25 @@ public class CombatSurfaceClient : MonoBehaviour
         float tt = (FloorY - ray.origin.y) / ray.direction.y; if (tt < 0) return;
         Vector3 hit = ray.origin + ray.direction * tt;
         if (!WorldToCell(hit, out int c, out int r)) return;
+        int key = CellKey(c, r);
+        // W6.2 (#1461) REST MODE: no combat signals -> the click WALKS a party member to the cell via the
+        // engine's `walk_to` verb (the walk_to_cell /move intent), NOT the combat move. Same #1441
+        // pre-validation as combat — a blocked/occupied cell flashes a red ring instead of a doomed POST
+        // (rest_blocked_cells folds standers into `impassable`, so the _impassable check rejects a cell a
+        // person stands on too). No known party mover (no rest party token yet) -> reject rather than POST
+        // a moverless walk the engine would 400. This whole branch is inert on a combat surface (_restMode
+        // false), so the combat attack/move path below is byte-identical.
+        if (_restMode)
+        {
+            if (string.IsNullOrEmpty(_restMoverId) || _impassable.Contains(key) || _occupied.Contains(key)) { StartCoroutine(FlashReject(c, r)); return; }
+            StartCoroutine(PostWalk(c, r));
+            return;
+        }
         // on-turn attack when the clicked cell holds the foe (allowed even though the foe occupies it).
         if (c == _foeX && r == _foeY && _foeId.Length > 0) { StartCoroutine(PostAttack()); return; }
         // #1441 click pre-validation (UX pre-filter ONLY; the engine stays authoritative and independently
         // rejects illegal moves): a click on an impassable (wall/prop) or token-occupied cell flashes a red
         // ring instead of firing a doomed POST.
-        int key = CellKey(c, r);
         if (_impassable.Contains(key) || _occupied.Contains(key)) { StartCoroutine(FlashReject(c, r)); return; }
         StartCoroutine(PostMove(c, r));
     }
@@ -1334,6 +1379,39 @@ public class CombatSurfaceClient : MonoBehaviour
         _busy = true;
         yield return Post("{\"kind\":\"attack\",\"target_id\":\"" + _foeId + "\",\"turn_token\":\"" + _turnToken + "\",\"campaign\":\"" + CampaignId + "\"}");
         _busy = false;
+    }
+
+    // W6.2 (#1461) REST-MODE walk: POST the `walk_to_cell` intent (the rest-mode twin of move_to_cell)
+    // so the engine's `walk_to` paths around walls/props/standers, writes Character.stage_cell, and
+    // returns the CONFIRMED route. The engine stays the SOLE WRITER — the client never predicts a path;
+    // it re-fetches the surface so the board reflects the engine-written stage_cell (same discipline as
+    // the combat re-render). A refusal (unreachable / off-grid the pre-filter missed) toasts its reason.
+    IEnumerator PostWalk(int x, int y)
+    {
+        _busy = true;
+        _lastPostCell = new[] { x, y };   // #Phase4: anchor any advisory pulse on the walk's target cell
+        string body = "{\"kind\":\"walk_to_cell\",\"character_id\":\"" + _restMoverId + "\",\"x\":" + x + ",\"y\":" + y + ",\"campaign\":\"" + CampaignId + "\"}";
+        using (var req = new UnityWebRequest(ViewerUrl + "/move", "POST"))
+        {
+            req.uploadHandler = new UploadHandlerRaw(System.Text.Encoding.UTF8.GetBytes(body));
+            req.downloadHandler = new DownloadHandlerBuffer();
+            req.SetRequestHeader("Content-Type", "application/json");
+            req.timeout = 8;
+            yield return req.SendWebRequest();
+            if (!Ok(req)) { Debug.LogWarning("[CSC] /walk failed: " + req.error + " body=" + req.downloadHandler.text); }
+            else
+            {
+                // walk_to_cell returns {ok, walked, character_id, from, to, path} (NOT the combat surface).
+                // A rejected walk ({ok:false, reason}) toasts its reason; a success is reflected by the
+                // re-fetch below (the engine wrote stage_cell; we never render a predicted route).
+                MoveResp resp = null;
+                try { resp = JsonUtility.FromJson<MoveResp>(req.downloadHandler.text); }
+                catch (System.Exception e) { Debug.LogWarning("[CSC] walk parse: " + e.Message); }
+                if (resp != null && !resp.ok && !string.IsNullOrEmpty(resp.reason)) ShowAdvisory(resp.reason);
+            }
+        }
+        _busy = false;
+        yield return Fetch();   // re-render off the engine's fresh surface (stage_cell now updated)
     }
 
     IEnumerator Post(string body)

--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -42,6 +42,11 @@ public class CombatSurfaceClient : MonoBehaviour
     public string ViewerUrl = "http://127.0.0.1:8765";
     public string CampaignId = "";
     public float PollInterval = 1.5f;
+    // #1466 FIX A: hard wall-clock ceiling for ONE /combat-surface fetch. UnityWebRequest.timeout is
+    // unreliable (a hung connect never fires it), so an explicit elapsed-time watchdog Aborts a stuck
+    // request instead — the T3 wedge (t3-gate-1454) where the FIRST fetch hung forever and bricked the
+    // whole PollLoop. 8s > PollInterval, so a healthy poll never trips it.
+    public float FetchTimeout = 8f;
 
     [Header("Grid — mirror paint_combat_v1 (14x11, cell 2.0); overridden by the surface `grid` block")]
     public int Cols = 14;
@@ -240,6 +245,10 @@ public class CombatSurfaceClient : MonoBehaviour
 
     IEnumerator PollLoop()
     {
+        // #1466 FIX A: the poll loop must SURVIVE any single bad fetch — one hung/failed request must
+        // never end the loop (the T3 wedge: a forever-hung first Fetch left the loop dead and no surface
+        // was ever applied). Fetch below is now self-limiting (watchdog + Abort), so it always returns
+        // and the NEXT tick recovers; this loop is unconditional-forever by construction.
         while (true)
         {
             if (!_busy) yield return Fetch();
@@ -258,12 +267,29 @@ public class CombatSurfaceClient : MonoBehaviour
 
     IEnumerator Fetch()
     {
+        // #1466 FIX A (T3 wedge): drive the request with an EXPLICIT elapsed-time watchdog — req.timeout=6
+        // is an unreliable backstop (a hung connect can never fire it, wedging this coroutine AND PollLoop
+        // forever: Player.log dies at "[CSC] start" then 10min of silence, zero surfaces applied). If the
+        // request has not completed within FetchTimeout we Abort() it and bail so the next 1.5s poll tick
+        // recovers. A per-fetch outcome line (ok/status/timeout) makes the wedge observable in Player.log.
+        // ADDITIVE + byte-identical on the happy path: a prompt response falls straight through to ApplyJson.
         using (var req = UnityWebRequest.Get(ViewerUrl + "/combat-surface?campaign=" + CampaignId))
         {
-            req.timeout = 6;
-            yield return req.SendWebRequest();
-            if (!Ok(req)) { Debug.LogWarning("[CSC] GET failed: " + req.error); yield break; }
-            ApplyJson(req.downloadHandler.text);
+            req.timeout = 6;   // built-in backstop retained; the watchdog below is the real guard
+            var op = req.SendWebRequest();
+            float t0 = Time.realtimeSinceStartup;
+            while (!op.isDone)
+            {
+                if (Time.realtimeSinceStartup - t0 > FetchTimeout)
+                {
+                    req.Abort();
+                    Debug.LogWarning("[CSC] fetch TIMEOUT (aborted after " + FetchTimeout.ToString("0.#") + "s) — PollLoop will retry next tick");
+                    yield break;   // `using` disposes the aborted request; PollLoop continues
+                }
+                yield return null;
+            }
+            if (Ok(req)) { Debug.Log("[CSC] fetch ok (" + req.responseCode + ")"); ApplyJson(req.downloadHandler.text); }
+            else Debug.LogWarning("[CSC] fetch FAILED status=" + req.responseCode + " err=" + req.error);
         }
     }
 

--- a/qa/test_seed_gfx_camp_rest.py
+++ b/qa/test_seed_gfx_camp_rest.py
@@ -21,8 +21,11 @@ Run with the engine venv (pydantic + pytest live there):
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 _ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_ROOT / "qa"))
@@ -30,6 +33,22 @@ sys.path.insert(0, str(_ROOT / "servers" / "engine"))
 
 import server  # noqa: E402  imported FIRST: resolves the models<->scene_grid import cycle
 import seed_gfx_camp_clearing as seed  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state_env():
+    """_seed_camp points WORLDOS_STATE_DIR at a per-test tmp dir (store.py reads it live on every
+    call). Save + restore the process-global env around each test so a later test in the same pytest
+    process never inherits this module's (torn-down) tmp state dir — a classic order-dependent-flake
+    foot-gun the review flagged."""
+    prev = os.environ.get("WORLDOS_STATE_DIR")
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("WORLDOS_STATE_DIR", None)
+        else:
+            os.environ["WORLDOS_STATE_DIR"] = prev
 
 
 # Load the stdlib viewer server under a distinct module name (its file is also `server.py`), the same
@@ -54,8 +73,6 @@ def _seed_camp(state_dir: Path):
     Reuses seed_gfx_camp_clearing's own authoring code (the CANONICAL fixture) so the test can never
     drift from what ships. Returns the campaign snapshot dict the viewer consumes + the authored
     SceneGrid (its props are the painted set we assert against)."""
-    import os
-
     os.environ["WORLDOS_STATE_DIR"] = str(state_dir)
     server.save_campaign(
         server.Campaign(id=seed.CID, title="GFX Camp Clearing Demo (rest test)")
@@ -123,7 +140,9 @@ def test_rest_surface_matches_engine_rest_blocked_cells(tmp_path):
 
 def test_combat_surface_impassable_is_byte_identical(tmp_path):
     """BYTE-IDENTITY: the rest branch must never touch a combat surface. When combat is active the
-    `impassable` field stays EXACTLY `combat.grid_impassable` (the pre-W6.2 expression)."""
+    `impassable` field stays EXACTLY `combat.grid_impassable` (the pre-W6.2 expression). Also pin
+    `stage.mode == "combat"` — the SAME predicate the client actually branches on — so an inversion of
+    the surface's rest/combat decision trips here, not just a happens-to-match value."""
     combat_impassable = [[3, 3], [4, 4], [9, 1]]
     snapshot = {
         "current_location_id": "loc1",
@@ -134,7 +153,24 @@ def test_combat_surface_impassable_is_byte_identical(tmp_path):
             "order": [{"character_id": "pc", "name": "Hero", "kind": "player", "initiative": 12}],
         },
     }
-    assert _surface(snapshot)["impassable"] == combat_impassable
+    surface = _surface(snapshot)
+    assert surface["impassable"] == combat_impassable
+    assert surface["stage"]["mode"] == "combat"  # the client's rest/combat branch key
+
+
+def test_rest_branch_is_consulted_when_combat_inactive(tmp_path):
+    """Pin the BRANCH DECISION, not just the value: with combat INACTIVE the surface must derive
+    `impassable` from rest_blocked_cells() and must IGNORE any stale `combat.grid_impassable`. A stray
+    combat-only cell (a corner that is NOT a painted prop) must NOT appear; the log cells MUST. This is
+    what a mis-ordered ternary (rest arm accidentally skipped) would break, which the byte-identity
+    combat case above — combat.active=True — can never reach."""
+    snapshot, _grid = _seed_camp(tmp_path)
+    # A stale, inactive combat block carrying a corner cell no rest prop occupies.
+    snapshot["combat"] = {"active": False, "grid_enabled": True, "grid_impassable": [[15, 11]]}
+    imp = {tuple(c) for c in surface_impassable(snapshot)}
+    assert (15, 11) not in imp, "rest branch must ignore stale combat.grid_impassable when combat is inactive"
+    assert (6, 6) in imp and (6, 7) in imp, "rest branch (rest_blocked_cells) must be the one consulted"
+    assert surface_impassable(snapshot) and _surface(snapshot)["stage"]["mode"] == "rest"
 
 
 def surface_impassable(snapshot: dict) -> list:

--- a/qa/test_seed_gfx_camp_rest.py
+++ b/qa/test_seed_gfx_camp_rest.py
@@ -1,0 +1,141 @@
+"""RED-FIRST regression for W6.2 (#1461) — the owner's walking-over-logs bug.
+
+qa/test_seed_gfx_camp.py pins the COMBAT camp fixture (camp_gfxdemo01): every painted prop cell must
+be in the engine's `impassable_cells` set. This file is the REST-MODE sibling: it pins the canonical
+rest-camp fixture (qa/seed_gfx_camp_clearing.py, campaign camp_gfxcampnight01) through the viewer's
+`build_combat_surface`, asserting every painted-prop cell — the fallen-log seat especially — appears
+in the REST-MODE surface `impassable` set.
+
+Before W6.2 existed, `build_combat_surface`'s `impassable` field had no rest-mode branch: with no
+active combat, `combat.grid_impassable` is empty, so the surface reported `impassable: []` and the
+CombatSurfaceClient had no collision truth at all — actors walked straight over the logs. This file
+would fail (`impassable` empty) against that pre-fix surface; it pins the rest-mode branch that
+surfaces `rest_blocked_cells()` so the regression can't silently return.
+
+Byte-identity guard: a COMBAT snapshot's `impassable` must stay EXACTLY `combat.grid_impassable`
+(the pre-W6.2 expression) — the rest branch may never touch a combat surface.
+
+Run with the engine venv (pydantic + pytest live there):
+    uv run --directory servers/engine python -m pytest ../../qa/test_seed_gfx_camp_rest.py -q -p no:xdist
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "qa"))
+sys.path.insert(0, str(_ROOT / "servers" / "engine"))
+
+import server  # noqa: E402  imported FIRST: resolves the models<->scene_grid import cycle
+import seed_gfx_camp_clearing as seed  # noqa: E402
+
+
+# Load the stdlib viewer server under a distinct module name (its file is also `server.py`), the same
+# way viewer/tests/test_scene_at_rest_stage.py does — so both the engine `server` (for seeding) and
+# the viewer `build_combat_surface` (the thing under test) are importable in one process.
+_VIEWER_PATH = _ROOT / "viewer" / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server_camprest", _VIEWER_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+viewer = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(viewer)
+
+
+def _surface(snapshot: dict) -> dict:
+    return viewer.build_combat_surface(
+        snapshot, campaign_id=seed.CID, live=False, is_live_view=False, recent_events=[]
+    )
+
+
+def _seed_camp(state_dir: Path):
+    """Seed the canonical rest-camp fixture into a temp state dir and return (snapshot, grid).
+
+    Reuses seed_gfx_camp_clearing's own authoring code (the CANONICAL fixture) so the test can never
+    drift from what ships. Returns the campaign snapshot dict the viewer consumes + the authored
+    SceneGrid (its props are the painted set we assert against)."""
+    import os
+
+    os.environ["WORLDOS_STATE_DIR"] = str(state_dir)
+    server.save_campaign(
+        server.Campaign(id=seed.CID, title="GFX Camp Clearing Demo (rest test)")
+    )
+    server.add_location(
+        campaign_id=seed.CID, name="Campfire Clearing (at rest)", make_current=True,
+        description="A quiet forest clearing at night: a low campfire, bedrolls, packs against a log.",
+    )
+    grid = seed._author_camp_grid(server, seed.CID)
+    server.create_character(
+        campaign_id=seed.CID, name="Aldric", kind="player", race="human",
+        class_name="fighter", level=4, apply_srd_defaults=True, add_to_party=True,
+    )
+    campaign = server._require(seed.CID)
+    return campaign.model_dump(mode="json"), grid
+
+
+def _prop_cells(grid) -> set[tuple[int, int]]:
+    cells: set[tuple[int, int]] = set()
+    for prop in grid.props:
+        for (c, r) in prop.cells:
+            cells.add((int(c), int(r)))
+    return cells
+
+
+def test_rest_surface_exposes_a_non_empty_impassable_set(tmp_path):
+    """RED-FIRST: with no active combat the rest camp surface must carry the geometry-derived blocked
+    set — NOT the empty `[]` the pre-W6.2 surface reported (grid_impassable is empty at rest)."""
+    snapshot, _grid = _seed_camp(tmp_path)
+    surface = _surface(snapshot)
+    assert surface["impassable"], (
+        "rest-mode surface must expose a non-empty impassable set from rest_blocked_cells() "
+        "(pre-W6.2 this was [] and actors walked over the logs)"
+    )
+
+
+def test_rest_surface_impassable_contains_every_painted_prop(tmp_path):
+    """Every painted prop footprint on the camp_clearing_night plate — trees, boulders, campfire,
+    bedrolls, the fallen-log seat, supply crates — must be a pathing obstacle on the REST surface."""
+    snapshot, grid = _seed_camp(tmp_path)
+    imp = {tuple(c) for c in surface_impassable(snapshot)}
+    for cell in _prop_cells(grid):
+        assert cell in imp, f"painted prop cell {cell} missing from rest-mode impassable (#1461)"
+
+
+def test_the_logs_are_impassable_at_rest(tmp_path):
+    """The felt-bug, pinned explicitly: the fallen-log seat cells (6,6) and (6,7) — the ones the
+    owner watched an actor walk straight over — must both be blocked on the rest surface."""
+    snapshot, _grid = _seed_camp(tmp_path)
+    imp = {tuple(c) for c in surface_impassable(snapshot)}
+    assert (6, 6) in imp and (6, 7) in imp, "the log seat (the owner's walking-over-logs cells) must block"
+
+
+def test_rest_surface_matches_engine_rest_blocked_cells(tmp_path):
+    """The surface's rest impassable is EXACTLY the engine's rest_blocked_cells() set — the same
+    function walk_to validates against. Byte-agreement between the client's collision picture and the
+    engine's mover is the whole point (a divergence IS the walking-over-logs class of bug)."""
+    snapshot, _grid = _seed_camp(tmp_path)
+    campaign = server._require(seed.CID)
+    loc = campaign.locations.get(campaign.current_location_id)
+    _w, _h, blocked = server.rest_blocked_cells(campaign, loc)
+    imp = {tuple(c) for c in surface_impassable(snapshot)}
+    assert imp == {(int(x), int(y)) for (x, y) in blocked}
+
+
+def test_combat_surface_impassable_is_byte_identical(tmp_path):
+    """BYTE-IDENTITY: the rest branch must never touch a combat surface. When combat is active the
+    `impassable` field stays EXACTLY `combat.grid_impassable` (the pre-W6.2 expression)."""
+    combat_impassable = [[3, 3], [4, 4], [9, 1]]
+    snapshot = {
+        "current_location_id": "loc1",
+        "locations": {"loc1": {"name": "A Room", "scene_grid": {"grid": {"cols": 14, "rows": 11}}}},
+        "combat": {
+            "active": True, "turn_index": 0, "grid_enabled": True,
+            "grid_impassable": combat_impassable,
+            "order": [{"character_id": "pc", "name": "Hero", "kind": "player", "initiative": 12}],
+        },
+    }
+    assert _surface(snapshot)["impassable"] == combat_impassable
+
+
+def surface_impassable(snapshot: dict) -> list:
+    return _surface(snapshot)["impassable"]

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3523,6 +3523,44 @@ def _combat_occluders(snapshot: dict) -> list[dict]:
     return out
 
 
+def _rest_impassable(snapshot: dict) -> list[list[int]]:
+    """W6.2 (#1461) REST-MODE collision: the geometry-derived blocked cells for the current room when
+    NO combat is active — the out-of-combat sibling of ``combat.grid_impassable``. This is the surface
+    field the CombatSurfaceClient's rest-mode walk pre-validation + the walkability overlay read, so an
+    actor can't walk over the painted logs (the owner's felt-bug: the surface reported ``[]`` at rest,
+    so the client had no collision truth at all).
+
+    Mirrors ``_director_advisory``'s engine-primary + graceful-degrade idiom: reconstruct the Campaign
+    from the engine-owned snapshot and call the engine's own ``rest_blocked_cells`` — the SAME set
+    ``walk_to`` validates against, so the client's collision picture can never drift from the mover
+    (a drift IS this class of bug). Read-only: nothing is mutated or persisted.
+
+    ADDITIVE / default-safe: returns ``[]`` (today's empty rest impassable) when the current location
+    has no ``scene_grid``, when the engine module isn't importable, or on any reconstruction failure —
+    so a pre-W6.2 snapshot (or a degraded QA-only context where ``walk_to`` also wouldn't run) projects
+    exactly as before. Shape is the sorted ``list[list[int]]`` ``grid_impassable`` uses."""
+    loc_id = _text(snapshot.get("current_location_id"))
+    locs = snapshot.get("locations") if isinstance(snapshot.get("locations"), dict) else {}
+    loc = locs.get(loc_id) if isinstance(locs, dict) and loc_id else None
+    sg = loc.get("scene_grid") if isinstance(loc, dict) else None
+    if not isinstance(sg, dict):
+        return []  # no painted room -> rest walk unavailable, byte-identical to today's empty field
+    engine = _load_engine_server()
+    if engine is None:
+        return []
+    try:
+        import models as _models  # engine dir is on sys.path after _load_engine_server
+
+        campaign = _models.Campaign.model_validate(snapshot)
+        location = campaign.locations.get(loc_id) if loc_id else None
+        if location is None:
+            return []
+        _w, _h, blocked = engine.rest_blocked_cells(campaign, location)
+        return [[int(x), int(y)] for (x, y) in sorted(blocked)]
+    except Exception:
+        return []  # any reconstruction/derivation failure -> degrade to today's empty rest impassable
+
+
 def _is_dead_or_downed(ch: dict) -> bool:
     """True for a character who must not stand upright in a rest projection: `dead`, or at 0 HP
     (unconscious/dying, or stabilized-but-still-down — engine fields `stable`/`current_hp`, see
@@ -3762,7 +3800,16 @@ def build_combat_surface(
         # P1: the most-recent routed move path (incl. the from-cell) + the impassable cells, so the
         # read-only renderer can draw the detour around walls/props. Presentation-only; [] == none.
         "lastPath": (snapshot.get("combat") or {}).get("last_move_path") or [],
-        "impassable": (snapshot.get("combat") or {}).get("grid_impassable") or [],
+        # W6.2 (#1461) the walking-over-logs fix — a rest-mode branch on `impassable`. In COMBAT the
+        # field stays EXACTLY the engine's `combat.grid_impassable` (byte-identical to pre-W6.2, the
+        # never-clobber-explicit half of `_derive_grid_from_scene`); when combat is INACTIVE it
+        # surfaces the geometry-derived rest blocked set from `rest_blocked_cells()` (see
+        # `_rest_impassable`), so the client's rest walk has the same collision truth `walk_to` uses.
+        "impassable": (
+            ((snapshot.get("combat") or {}).get("grid_impassable") or [])
+            if combat_active
+            else _rest_impassable(snapshot)
+        ),
         # M-E room transition: the authored doorway cells + their destination room-unit, so the renderer
         # can mark the doorway and the UI can offer to cross. [] == no doors/connections (today's shape).
         "doors": _combat_doors(snapshot),


### PR DESCRIPTION
Closes #1461 and #1466 (FIX A only — FIX B harness -logFile is dispatched separately). Parent epic #1457 (W6 The Living Stage); design docs/roadmap/W6-LIVING-STAGE-DESIGN.md.

## #1461 — the walking-over-logs bug
Collision truth existed but the wire dropped it: `build_combat_surface`'s `impassable` had no rest-mode branch, so out of combat the surface reported `impassable: []` and CombatSurfaceClient had no rest collision at all — actors walked over the painted logs.

**Engine/viewer** (`viewer/server.py`, additive; engine = SOLE WRITER; default unchanged)
- New `_rest_impassable(snapshot)`: reconstructs the Campaign and calls the engine's own `rest_blocked_cells()` — the SAME set `walk_to` validates against (engine-primary + graceful degrade, mirroring `_director_advisory`; degrades to `[]` with no scene_grid / no engine).
- `build_combat_surface` gates `impassable` on `combat_active`: COMBAT keeps EXACTLY `combat.grid_impassable` (byte-identical, never-clobber-explicit — the `_derive_grid_from_scene` pattern); REST surfaces the geometry-derived set.

**Renderer** (`CombatSurfaceClient.cs`, every combat path byte-identical)
- Parses the surface `stage` block for rest mode + the walk mover (first `rest_role:"party"` token). Rest-mode `HandleClick` routes to the `walk_to_cell` verb with the SAME #1441 impassable/occupied pre-validation + reject flash; the G overlay reads the rest impassable identically.

## #1466 FIX A — T3 fetch-wedge watchdog (`CombatSurfaceClient.cs`)
`Fetch()` drove `SendWebRequest` with only the unreliable `UnityWebRequest.timeout`; a hung connect never fired it, wedging the fetch coroutine AND `PollLoop` forever (t3-gate-1454: Player.log dies at `[CSC] start` then 10min silence, zero surfaces). Added an explicit elapsed-time watchdog (`FetchTimeout=8s`) that `Abort()`s a stuck request, a per-fetch outcome log line (ok/status/timeout), and a loop that keeps polling so the next tick recovers. Additive + byte-identical on the happy path.

## Drive-by hygiene
Removed a stray raw NUL byte that #1460 shipped in the `_occSigBuilt` sentinel string literal (`"<NUL>"` -> `"\0"`, runtime-identical) — it made the .cs read as binary to grep/preflight.

## Tests (red-first) + verification
- `qa/test_seed_gfx_camp_rest.py` pins the canonical rest-camp fixture (`camp_gfxcampnight01`): every painted prop (logs at (6,6)/(6,7)) is in the rest surface impassable; surface == engine `rest_blocked_cells()`; combat impassable byte-identical. 5 passed (was 4 red pre-fix).
- Existing viewer surface + combat-fixture suites green; `qa/fast_gate.sh` PASS (257).
- C# compiled 0 errors on the GEX44 box (rebased/merged file, incl. #1460 occluders).