### PR TITLE
qa: capture Unity player log per run (#1466 FIX B)

### DIFF
--- a/qa/lib_native_player_boot.sh
+++ b/qa/lib_native_player_boot.sh
@@ -74,8 +74,28 @@ owner_active_guard() {
 # takes over the display. -screen-fullscreen/-screen-width/-screen-height are Unity's built-in
 # standalone-player command-line args, honored before the app's own window setup — no Unity/C#
 # change needed. Emits one arg per line; callers read it into an array. Size is env-overridable.
+# #1466 FIX B: an optional first arg is a run-dir log path — when given, appends Unity's own
+# -logFile <path> so THIS run's player log lands in the run dir instead of the shared, overwritten-
+# every-launch default (~/Library/Logs/worldos/WorldOSPlayer/Player.log).
 player_windowed_launch_args() {
-  printf '%s\n' -screen-fullscreen 0 \
+  local logfile="${1:-}"
+  local args=(-screen-fullscreen 0 \
     -screen-width "${WORLDOS_PLAYER_WIN_W:-1280}" \
-    -screen-height "${WORLDOS_PLAYER_WIN_H:-800}"
+    -screen-height "${WORLDOS_PLAYER_WIN_H:-800}")
+  [ -n "$logfile" ] && args+=(-logFile "$logfile")
+  printf '%s\n' "${args[@]}"
+}
+
+# --- #1466 FIX B: fallback copy of Unity's own default player log ----------------------------------
+# Belt-and-suspenders for -logFile above: if it was ignored, stripped, or the run predates this fix,
+# copy the shared default log location (overwritten on every launch — Player-prev.log is the PRIOR
+# run) into THIS run's dir under distinct names so it's never confused with the -logFile capture.
+# Silent no-op if the source dir/files don't exist (e.g. never launched, or a non-default log path).
+copy_player_log_fallback() {
+  local dest="$1"
+  local src_dir="$HOME/Library/Logs/worldos/WorldOSPlayer"
+  [ -d "$dest" ] || return 0
+  [ -f "$src_dir/Player.log" ] && cp -f "$src_dir/Player.log" "$dest/Player.log.fallback" 2>/dev/null
+  [ -f "$src_dir/Player-prev.log" ] && cp -f "$src_dir/Player-prev.log" "$dest/Player-prev.log.fallback" 2>/dev/null
+  return 0
 }

--- a/qa/lib_native_player_boot.sh
+++ b/qa/lib_native_player_boot.sh
@@ -102,7 +102,11 @@ copy_player_log_fallback() {
   if [ -n "$primary_log" ] && [ -s "$primary_log" ]; then
     return 0  # -logFile capture already landed and is non-empty — nothing stale to guard against
   fi
-  [ -f "$src_dir/Player.log" ] && cp -f "$src_dir/Player.log" "$dest/Player.log.fallback" 2>/dev/null
-  [ -f "$src_dir/Player-prev.log" ] && cp -f "$src_dir/Player-prev.log" "$dest/Player-prev.log.fallback" 2>/dev/null
+  # An EXISTING-but-empty primary_log is ambiguous (Unity crashed before flushing vs. a genuine
+  # no-logFile run) — flag the copy distinctly so a reader never mistakes it for a confirmed capture.
+  local suffix="fallback"
+  [ -n "$primary_log" ] && [ -e "$primary_log" ] && suffix="fallback.stale-src"
+  [ -f "$src_dir/Player.log" ] && cp -f "$src_dir/Player.log" "$dest/Player.log.$suffix" 2>/dev/null
+  [ -f "$src_dir/Player-prev.log" ] && cp -f "$src_dir/Player-prev.log" "$dest/Player-prev.log.$suffix" 2>/dev/null
   return 0
 }

--- a/qa/lib_native_player_boot.sh
+++ b/qa/lib_native_player_boot.sh
@@ -91,10 +91,17 @@ player_windowed_launch_args() {
 # copy the shared default log location (overwritten on every launch — Player-prev.log is the PRIOR
 # run) into THIS run's dir under distinct names so it's never confused with the -logFile capture.
 # Silent no-op if the source dir/files don't exist (e.g. never launched, or a non-default log path).
+# Second arg (optional) is the run's OWN -logFile path: when it exists and is non-empty, -logFile was
+# honored and the shared default wasn't written THIS run, so the fallback copy is skipped — without
+# this guard a leftover Player.log from an unrelated prior launch could be copied in and mislabeled
+# as this run's fallback (review finding on PR #1467).
 copy_player_log_fallback() {
-  local dest="$1"
+  local dest="$1" primary_log="${2:-}"
   local src_dir="$HOME/Library/Logs/worldos/WorldOSPlayer"
   [ -d "$dest" ] || return 0
+  if [ -n "$primary_log" ] && [ -s "$primary_log" ]; then
+    return 0  # -logFile capture already landed and is non-empty — nothing stale to guard against
+  fi
   [ -f "$src_dir/Player.log" ] && cp -f "$src_dir/Player.log" "$dest/Player.log.fallback" 2>/dev/null
   [ -f "$src_dir/Player-prev.log" ] && cp -f "$src_dir/Player-prev.log" "$dest/Player-prev.log.fallback" 2>/dev/null
   return 0

--- a/qa/player_smoke.sh
+++ b/qa/player_smoke.sh
@@ -145,7 +145,7 @@ cleanup() {
   kill "$VIEWER" 2>/dev/null
   [ -n "$PLAYER_APP_PID" ] && kill "$PLAYER_APP_PID" 2>/dev/null
   osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
-  copy_player_log_fallback "$PLAYERDIR"  # #1466 FIX B: fallback if -logFile capture didn't land
+  copy_player_log_fallback "$PLAYERDIR" "$PLAYERDIR/unity_player.log"  # #1466 FIX B: fallback if -logFile capture didn't land
 }
 trap cleanup EXIT INT TERM
 

--- a/qa/player_smoke.sh
+++ b/qa/player_smoke.sh
@@ -145,6 +145,7 @@ cleanup() {
   kill "$VIEWER" 2>/dev/null
   [ -n "$PLAYER_APP_PID" ] && kill "$PLAYER_APP_PID" 2>/dev/null
   osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
+  copy_player_log_fallback "$PLAYERDIR"  # #1466 FIX B: fallback if -logFile capture didn't land
 }
 trap cleanup EXIT INT TERM
 
@@ -162,7 +163,7 @@ echo "[smoke] viewer ready — /combat-surface serving $CID."
 # instance and spawn a fixed-size WINDOWED player in the background. ---------------------------------
 osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
 sleep 1
-PLAYER_WIN_ARGS=(); while IFS= read -r __a; do PLAYER_WIN_ARGS+=("$__a"); done < <(player_windowed_launch_args)
+PLAYER_WIN_ARGS=(); while IFS= read -r __a; do PLAYER_WIN_ARGS+=("$__a"); done < <(player_windowed_launch_args "$PLAYERDIR/unity_player.log")
 WORLDOS_ENGINE_BASE_URL="$BASE_URL" WORLDOS_CAMPAIGN_ID="$CID" "$PLAYER_BIN" "${PLAYER_WIN_ARGS[@]}" \
   > "$RUNDIR/player_app.log" 2>&1 &
 PLAYER_APP_PID=$!

--- a/qa/player_smoke.sh
+++ b/qa/player_smoke.sh
@@ -145,7 +145,9 @@ cleanup() {
   kill "$VIEWER" 2>/dev/null
   [ -n "$PLAYER_APP_PID" ] && kill "$PLAYER_APP_PID" 2>/dev/null
   osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
-  copy_player_log_fallback "$PLAYERDIR" "$PLAYERDIR/unity_player.log"  # #1466 FIX B: fallback if -logFile capture didn't land
+  # #1466 FIX B: fallback if -logFile capture didn't land — gated on PLAYER_APP_PID so a pre-launch
+  # exit (e.g. viewer never came up) never copies a stale prior-run Player.log into this run's dir.
+  [ -n "$PLAYER_APP_PID" ] && copy_player_log_fallback "$PLAYERDIR" "$PLAYERDIR/unity_player.log"
 }
 trap cleanup EXIT INT TERM
 

--- a/qa/player_smoke.sh
+++ b/qa/player_smoke.sh
@@ -163,6 +163,10 @@ echo "[smoke] viewer ready — /combat-surface serving $CID."
 # instance and spawn a fixed-size WINDOWED player in the background. ---------------------------------
 osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
 sleep 1
+# #1466 FIX B: -logFile below redirects Unity's own stdout/stderr into unity_player.log, so
+# player_app.log (the shell redirect just below) is now expected to be sparse/near-empty in the
+# common case — it's kept as a belt-and-suspenders capture of anything emitted before Unity's
+# logging takes over (e.g. dyld/early native errors). unity_player.log is the primary player log.
 PLAYER_WIN_ARGS=(); while IFS= read -r __a; do PLAYER_WIN_ARGS+=("$__a"); done < <(player_windowed_launch_args "$PLAYERDIR/unity_player.log")
 WORLDOS_ENGINE_BASE_URL="$BASE_URL" WORLDOS_CAMPAIGN_ID="$CID" "$PLAYER_BIN" "${PLAYER_WIN_ARGS[@]}" \
   > "$RUNDIR/player_app.log" 2>&1 &

--- a/qa/player_smoke.sh
+++ b/qa/player_smoke.sh
@@ -147,7 +147,9 @@ cleanup() {
   osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
   # #1466 FIX B: fallback if -logFile capture didn't land — gated on PLAYER_APP_PID so a pre-launch
   # exit (e.g. viewer never came up) never copies a stale prior-run Player.log into this run's dir.
-  [ -n "$PLAYER_APP_PID" ] && copy_player_log_fallback "$PLAYERDIR" "$PLAYERDIR/unity_player.log"
+  # A short settle beat gives Unity's logger a moment to flush unity_player.log before the
+  # emptiness check below (killed-before-flush would otherwise misread as "never captured").
+  [ -n "$PLAYER_APP_PID" ] && { sleep 0.3; copy_player_log_fallback "$PLAYERDIR" "$PLAYERDIR/unity_player.log"; }
 }
 trap cleanup EXIT INT TERM
 

--- a/qa/ui_playtest_player.sh
+++ b/qa/ui_playtest_player.sh
@@ -237,7 +237,9 @@ cleanup() {
   [ -n "${DMLOOP:-}" ] && kill "$DMLOOP" 2>/dev/null
   [ -n "$PLAYER_APP_PID" ] && kill "$PLAYER_APP_PID" 2>/dev/null
   osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
-  copy_player_log_fallback "$PLAYERDIR" "$PLAYERDIR/unity_player.log"  # #1466 FIX B: fallback if -logFile capture didn't land
+  # #1466 FIX B: fallback if -logFile capture didn't land — gated on PLAYER_APP_PID so a pre-launch
+  # exit (e.g. viewer never came up) never copies a stale prior-run Player.log into this run's dir.
+  [ -n "$PLAYER_APP_PID" ] && copy_player_log_fallback "$PLAYERDIR" "$PLAYERDIR/unity_player.log"
 }
 trap cleanup EXIT INT TERM
 

--- a/qa/ui_playtest_player.sh
+++ b/qa/ui_playtest_player.sh
@@ -268,6 +268,10 @@ rm -f "$PLAYERDIR/native_input"
 # background (Unity -screen-fullscreen 0 / -screen-width / -screen-height).
 osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
 sleep 1
+# #1466 FIX B: -logFile below redirects Unity's own stdout/stderr into unity_player.log, so
+# player_app.log (the shell redirect just below) is now expected to be sparse/near-empty in the
+# common case — it's kept as a belt-and-suspenders capture of anything emitted before Unity's
+# logging takes over (e.g. dyld/early native errors). unity_player.log is the primary player log.
 PLAYER_WIN_ARGS=(); while IFS= read -r __a; do PLAYER_WIN_ARGS+=("$__a"); done < <(player_windowed_launch_args "$PLAYERDIR/unity_player.log")
 WORLDOS_ENGINE_BASE_URL="$BASE_URL" WORLDOS_CAMPAIGN_ID="$CID" "$PLAYER_BIN" "${PLAYER_WIN_ARGS[@]}" \
   > "$RUNDIR/player_app.log" 2>&1 &

--- a/qa/ui_playtest_player.sh
+++ b/qa/ui_playtest_player.sh
@@ -237,7 +237,7 @@ cleanup() {
   [ -n "${DMLOOP:-}" ] && kill "$DMLOOP" 2>/dev/null
   [ -n "$PLAYER_APP_PID" ] && kill "$PLAYER_APP_PID" 2>/dev/null
   osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
-  copy_player_log_fallback "$PLAYERDIR"  # #1466 FIX B: fallback if -logFile capture didn't land
+  copy_player_log_fallback "$PLAYERDIR" "$PLAYERDIR/unity_player.log"  # #1466 FIX B: fallback if -logFile capture didn't land
 }
 trap cleanup EXIT INT TERM
 

--- a/qa/ui_playtest_player.sh
+++ b/qa/ui_playtest_player.sh
@@ -237,6 +237,7 @@ cleanup() {
   [ -n "${DMLOOP:-}" ] && kill "$DMLOOP" 2>/dev/null
   [ -n "$PLAYER_APP_PID" ] && kill "$PLAYER_APP_PID" 2>/dev/null
   osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
+  copy_player_log_fallback "$PLAYERDIR"  # #1466 FIX B: fallback if -logFile capture didn't land
 }
 trap cleanup EXIT INT TERM
 
@@ -267,7 +268,7 @@ rm -f "$PLAYERDIR/native_input"
 # background (Unity -screen-fullscreen 0 / -screen-width / -screen-height).
 osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
 sleep 1
-PLAYER_WIN_ARGS=(); while IFS= read -r __a; do PLAYER_WIN_ARGS+=("$__a"); done < <(player_windowed_launch_args)
+PLAYER_WIN_ARGS=(); while IFS= read -r __a; do PLAYER_WIN_ARGS+=("$__a"); done < <(player_windowed_launch_args "$PLAYERDIR/unity_player.log")
 WORLDOS_ENGINE_BASE_URL="$BASE_URL" WORLDOS_CAMPAIGN_ID="$CID" "$PLAYER_BIN" "${PLAYER_WIN_ARGS[@]}" \
   > "$RUNDIR/player_app.log" 2>&1 &
 PLAYER_APP_PID=$!

--- a/qa/ui_playtest_player.sh
+++ b/qa/ui_playtest_player.sh
@@ -239,7 +239,9 @@ cleanup() {
   osascript -e 'quit app "WorldOSPlayer"' >/dev/null 2>&1 || true
   # #1466 FIX B: fallback if -logFile capture didn't land — gated on PLAYER_APP_PID so a pre-launch
   # exit (e.g. viewer never came up) never copies a stale prior-run Player.log into this run's dir.
-  [ -n "$PLAYER_APP_PID" ] && copy_player_log_fallback "$PLAYERDIR" "$PLAYERDIR/unity_player.log"
+  # A short settle beat gives Unity's logger a moment to flush unity_player.log before the
+  # emptiness check below (killed-before-flush would otherwise misread as "never captured").
+  [ -n "$PLAYER_APP_PID" ] && { sleep 0.3; copy_player_log_fallback "$PLAYERDIR" "$PLAYERDIR/unity_player.log"; }
 }
 trap cleanup EXIT INT TERM
 


### PR DESCRIPTION
## Summary
- FIX B only from #1466 (harness observability). FIX A (CombatSurfaceClient watchdog/Abort) is owned by the W6.2 lane, separately.
- `lib_native_player_boot.sh::player_windowed_launch_args` now accepts an optional run-dir log path and appends Unity's `-logFile <path>` launch arg; new `copy_player_log_fallback()` copies the shared default `~/Library/Logs/worldos/WorldOSPlayer/{Player,Player-prev}.log` into the run dir under distinct `.fallback` names.
- `ui_playtest_player.sh` and `player_smoke.sh` both pass `$PLAYERDIR/unity_player.log` at launch and call `copy_player_log_fallback "$PLAYERDIR"` from `cleanup()`, so a silent in-run hang (the #1466 root-cause symptom) leaves an on-disk player log instead of nothing.
- No behavior change otherwise: launch args, window size, and cleanup process-kill order are unchanged.

## Test plan
- [x] `bash -n` on all three modified scripts
- [x] Dry-run of `player_windowed_launch_args` (with/without logfile arg) and `copy_player_log_fallback` (confirmed it finds and copies the real `~/Library/Logs/worldos/WorldOSPlayer/{Player,Player-prev}.log` on this box)
- [x] `qa/fast_gate.sh` — 257 passed, T0 PASS
- [ ] Not run: an actual player-app launch (out of scope per task — validated via dry-run + fast_gate only)