### PR TITLE
qa/player: PID-targeted input delivery — clicks reach the unfocused player (#1466, completes #1456)

### DIFF
--- a/qa/native_palette/native_input.swift
+++ b/qa/native_palette/native_input.swift
@@ -20,9 +20,24 @@
 //   winfind  <ownerName>            -> {"found":bool,"window_id":int,"x":n,"y":n,"w":n,"h":n,"owner":s,"title":s}
 //   capture  <ownerName> <outPath>  -> {"ok":bool,"window_id":int,"x":n,"y":n,"w":n,"h":n,"px_w":n,"px_h":n,"scale":f,"on_screen":bool}
 //                                      (ScreenCaptureKit PNG of the owner's largest window — ANY Space, NO activation; macOS 14+)
-//   click    <globalX> <globalY> [double]   -> {"ok":true}   (left click at GLOBAL screen points, top-left origin)
-//   key      <name>                 -> {"ok":true}   (Return/Escape/Tab/Space/Arrow*/Delete or a single char)
-//   type     <text…>                -> {"ok":true}   (synthesize a unicode string into the focused field)
+//   click    <globalX> <globalY> [double] [--owner NAME] [--activate-fallback]
+//                                   -> {"ok":true,"delivery":"pid|hid"}   (left click at GLOBAL screen points, top-left origin)
+//   key      <name> [--owner NAME] [--activate-fallback]
+//                                   -> {"ok":true,"delivery":"pid|hid"}   (Return/Escape/Tab/Space/Arrow*/Delete or a single char)
+//   type     <text…> [--owner NAME] [--activate-fallback]
+//                                   -> {"ok":true,"delivery":"pid|hid"}   (synthesize a unicode string into the focused field)
+//
+// #1466 (completes #1456): input delivery is the twin of the no-activation CAPTURE. A HID-tap
+// CGEvent (.cghidEventTap) at a global point is only routed into an app's Input system while that
+// app is ACTIVE/key — but player QA must NEVER activate the owner (no focus theft, no Space switch),
+// so those clicks landed on the window pixels yet never reached Unity's Input.GetMouseButtonDown
+// (the T3/smoke "clicks do nothing" symptom). When an owner NAME is supplied we resolve its PID
+// (kCGWindowOwnerPID of the largest layer-0 window, same pick as winfind) and DELIVER THE EVENT
+// DIRECTLY to that process via CGEvent.postToPid — which reaches an unfocused, off-current-Space app
+// without activating it. No owner -> the legacy HID-tap path (unchanged). `--activate-fallback` is the
+// documented escape if PID delivery proves unreliable for Unity's input polling: a BRIEF
+// activate->post->restore-previous-frontmost (sub-second, current Space only) — OFF by default; the
+// PID path is tried first and this is opt-in with evidence.
 //
 // Coordinate contract: Quartz CGWindow bounds AND CGEvent cursor positions are BOTH global screen
 // POINTS with a top-left origin, so they compose directly. The server maps window-relative screenshot
@@ -37,6 +52,9 @@ import ApplicationServices
 #endif
 #if canImport(ScreenCaptureKit)
 import ScreenCaptureKit
+#endif
+#if canImport(AppKit)
+import AppKit   // #1466: activate->click->restore fallback (NSRunningApplication) only, no Space switch
 #endif
 
 // ---- tiny JSON emit (no Codable ceremony for one-line results) --------------
@@ -204,21 +222,93 @@ func captureWindowSCK(_ owner: String, _ outPath: String) {
 }
 
 // ---- synthetic input --------------------------------------------------------
-func postClick(_ gx: Double, _ gy: Double, doubleClick: Bool) {
+// #1466: how a synthesized CGEvent is delivered. `.pid` posts DIRECTLY to a resolved process
+// (CGEvent.postToPid) so an UNFOCUSED, off-current-Space app still receives it — the no-activation
+// input twin of the SCK capture. `.hid` is the legacy global HID-tap (only routed to the active app).
+enum Delivery {
+    case hid
+    case pid(pid_t)
+    var label: String { switch self { case .hid: return "hid"; case .pid: return "pid" } }
+    func post(_ ev: CGEvent?) {
+        guard let ev = ev else { return }
+        switch self {
+        case .hid: ev.post(tap: .cghidEventTap)
+        case .pid(let p): ev.postToPid(p)
+        }
+    }
+}
+
+// Resolve the owner app's PID the SAME way winfind picks its window: the largest layer-0 window owned
+// by `owner`, on the current Space first (cheap, common case) then any Space. Returns nil if the owner
+// has no such window (caller then keeps the HID path). Owner name + PID are readable WITHOUT the
+// Screen-Recording grant, so this never depends on a capture permission.
+func ownerPID(_ owner: String) -> pid_t? {
+    func pick(_ opts: CGWindowListOption) -> pid_t? {
+        guard let list = CGWindowListCopyWindowInfo(opts, kCGNullWindowID) as? [[String: Any]] else { return nil }
+        var best: pid_t? = nil
+        var bestArea: CGFloat = -1
+        for w in list {
+            guard let o = w[kCGWindowOwnerName as String] as? String, o == owner else { continue }
+            if let layer = w[kCGWindowLayer as String] as? Int, layer != 0 { continue }
+            guard let b = w[kCGWindowBounds as String] as? [String: Any],
+                  let ww = b["Width"] as? CGFloat, let hh = b["Height"] as? CGFloat,
+                  let pidNum = w[kCGWindowOwnerPID as String] as? Int else { continue }
+            let area = ww * hh
+            if area > bestArea { bestArea = area; best = pid_t(pidNum) }
+        }
+        return best
+    }
+    return pick([.optionOnScreenOnly, .excludeDesktopElements]) ?? pick([.excludeDesktopElements])
+}
+
+// #1466 fallback (opt-in): briefly activate the owner, run `body` (an HID post), then restore the
+// previously-frontmost app. Sub-second, CURRENT Space only — never a Space switch. Returns true if it
+// could actually run (AppKit + a resolvable owner app); false lets the caller keep the plain path.
+func withBriefActivation(_ owner: String, _ body: () -> Void) -> Bool {
+#if canImport(AppKit)
+    let apps = NSWorkspace.shared.runningApplications
+    guard let target = apps.first(where: { $0.localizedName == owner }) else { return false }
+    let prev = NSWorkspace.shared.frontmostApplication
+    target.activate(options: [])
+    usleep(120_000)          // let the activation settle before the click routes
+    body()
+    usleep(30_000)
+    if let prev = prev, prev.processIdentifier != target.processIdentifier { prev.activate(options: []) }
+    return true
+#else
+    return false
+#endif
+}
+
+// Choose delivery: an owner with a resolvable PID -> direct PID post; else HID. The activate-fallback
+// is handled by the caller (it wraps an HID post), so here we only pick pid-vs-hid.
+func deliveryFor(_ owner: String?) -> Delivery {
+    if let owner = owner, !owner.isEmpty, let pid = ownerPID(owner) { return .pid(pid) }
+    return .hid
+}
+
+func postClick(_ gx: Double, _ gy: Double, doubleClick: Bool, owner: String?, activateFallback: Bool) {
     let pt = CGPoint(x: gx, y: gy)
     let src = CGEventSource(stateID: .hidSystemState)
-    // move first so hover/enter handlers see the cursor, then down/up.
-    CGEvent(mouseEventSource: src, mouseType: .mouseMoved, mouseCursorPosition: pt, mouseButton: .left)?.post(tap: .cghidEventTap)
-    func clickOnce(_ count: Int64) {
-        let down = CGEvent(mouseEventSource: src, mouseType: .leftMouseDown, mouseCursorPosition: pt, mouseButton: .left)
-        let up = CGEvent(mouseEventSource: src, mouseType: .leftMouseUp, mouseCursorPosition: pt, mouseButton: .left)
-        if count > 1 { down?.setIntegerValueField(.mouseEventClickState, value: count); up?.setIntegerValueField(.mouseEventClickState, value: count) }
-        down?.post(tap: .cghidEventTap)
-        up?.post(tap: .cghidEventTap)
+    func sequence(_ delivery: Delivery) {
+        // move first so hover/enter handlers see the cursor, then down/up.
+        delivery.post(CGEvent(mouseEventSource: src, mouseType: .mouseMoved, mouseCursorPosition: pt, mouseButton: .left))
+        func clickOnce(_ count: Int64) {
+            let down = CGEvent(mouseEventSource: src, mouseType: .leftMouseDown, mouseCursorPosition: pt, mouseButton: .left)
+            let up = CGEvent(mouseEventSource: src, mouseType: .leftMouseUp, mouseCursorPosition: pt, mouseButton: .left)
+            if count > 1 { down?.setIntegerValueField(.mouseEventClickState, value: count); up?.setIntegerValueField(.mouseEventClickState, value: count) }
+            delivery.post(down)
+            delivery.post(up)
+        }
+        clickOnce(1)
+        if doubleClick { clickOnce(2) }
     }
-    clickOnce(1)
-    if doubleClick { clickOnce(2) }
-    emit(["ok": true])
+    if activateFallback, let owner = owner, withBriefActivation(owner, { sequence(.hid) }) {
+        emit(["ok": true, "delivery": "activate", "owner": owner]); return
+    }
+    let delivery = deliveryFor(owner)
+    sequence(delivery)
+    emit(["ok": true, "delivery": delivery.label, "owner": owner ?? ""])
 }
 
 // Named virtual keycodes (US layout) for the keys the palette contract uses. Anything not here that is
@@ -229,32 +319,63 @@ let NAMED_KEYS: [String: CGKeyCode] = [
     "down": 125, "arrowdown": 125, "up": 126, "arrowup": 126,
 ]
 
-func postKey(_ name: String) {
+func postKey(_ name: String, owner: String?, activateFallback: Bool) {
     let src = CGEventSource(stateID: .hidSystemState)
     let key = name.lowercased()
-    if let code = NAMED_KEYS[key] {
-        CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: true)?.post(tap: .cghidEventTap)
-        CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: false)?.post(tap: .cghidEventTap)
-        emit(["ok": true]); return
+    guard let code = NAMED_KEYS[key] else {
+        // single unnamed char -> unicode keystroke (same owner/PID delivery)
+        postType(name, owner: owner, activateFallback: activateFallback); return
     }
-    // single unnamed char -> unicode keystroke
-    postType(name)
+    func sequence(_ delivery: Delivery) {
+        delivery.post(CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: true))
+        delivery.post(CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: false))
+    }
+    if activateFallback, let owner = owner, withBriefActivation(owner, { sequence(.hid) }) {
+        emit(["ok": true, "delivery": "activate", "owner": owner]); return
+    }
+    let delivery = deliveryFor(owner)
+    sequence(delivery)
+    emit(["ok": true, "delivery": delivery.label, "owner": owner ?? ""])
 }
 
-func postType(_ text: String) {
+func postType(_ text: String, owner: String?, activateFallback: Bool) {
     let src = CGEventSource(stateID: .hidSystemState)
-    let down = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: true)
-    let up = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: false)
     var chars = Array(text.utf16)
-    down?.keyboardSetUnicodeString(stringLength: chars.count, unicodeString: &chars)
-    up?.keyboardSetUnicodeString(stringLength: chars.count, unicodeString: &chars)
-    down?.post(tap: .cghidEventTap)
-    up?.post(tap: .cghidEventTap)
-    emit(["ok": true])
+    func sequence(_ delivery: Delivery) {
+        let down = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: true)
+        let up = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: false)
+        down?.keyboardSetUnicodeString(stringLength: chars.count, unicodeString: &chars)
+        up?.keyboardSetUnicodeString(stringLength: chars.count, unicodeString: &chars)
+        delivery.post(down)
+        delivery.post(up)
+    }
+    if activateFallback, let owner = owner, withBriefActivation(owner, { sequence(.hid) }) {
+        emit(["ok": true, "delivery": "activate", "owner": owner]); return
+    }
+    let delivery = deliveryFor(owner)
+    sequence(delivery)
+    emit(["ok": true, "delivery": delivery.label, "owner": owner ?? ""])
 }
 
 // ---- dispatch ---------------------------------------------------------------
-let args = Array(CommandLine.arguments.dropFirst())
+// #1466: click/key/type accept two optional trailing flags — `--owner NAME` (PID-target delivery to
+// the unfocused player) and `--activate-fallback` (opt-in brief activate->post->restore). Strip them
+// out first so the positional parsing below is unchanged for callers that don't pass them.
+var rawArgs = Array(CommandLine.arguments.dropFirst())
+var optOwner: String? = nil
+var optActivateFallback = false
+do {
+    var kept: [String] = []
+    var i = 0
+    while i < rawArgs.count {
+        let a = rawArgs[i]
+        if a == "--owner", i + 1 < rawArgs.count { optOwner = rawArgs[i + 1]; i += 2; continue }
+        if a == "--activate-fallback" { optActivateFallback = true; i += 1; continue }
+        kept.append(a); i += 1
+    }
+    rawArgs = kept
+}
+let args = rawArgs
 guard let cmd = args.first else {
     emit(["ok": false, "error": "usage: native_input <checkperms|winfind|click|key|type> …"]); exit(2)
 }
@@ -269,14 +390,14 @@ case "capture":
     captureWindowSCK(args[1], args[2])
 case "click":
     guard args.count >= 3, let gx = Double(args[1]), let gy = Double(args[2]) else {
-        emit(["ok": false, "error": "usage: click <globalX> <globalY> [double]"]); exit(2)
+        emit(["ok": false, "error": "usage: click <globalX> <globalY> [double] [--owner NAME] [--activate-fallback]"]); exit(2)
     }
-    postClick(gx, gy, doubleClick: args.count >= 4 && args[3] == "double")
+    postClick(gx, gy, doubleClick: args.count >= 4 && args[3] == "double", owner: optOwner, activateFallback: optActivateFallback)
 case "key":
-    guard args.count >= 2 else { emit(["ok": false, "error": "usage: key <name>"]); exit(2) }
-    postKey(args[1])
+    guard args.count >= 2 else { emit(["ok": false, "error": "usage: key <name> [--owner NAME] [--activate-fallback]"]); exit(2) }
+    postKey(args[1], owner: optOwner, activateFallback: optActivateFallback)
 case "type":
-    postType(args.dropFirst().joined(separator: " "))
+    postType(args.dropFirst().joined(separator: " "), owner: optOwner, activateFallback: optActivateFallback)
 default:
     emit(["ok": false, "error": "unknown subcommand: \(cmd)"]); exit(2)
 }

--- a/qa/native_palette/native_palette_core.js
+++ b/qa/native_palette/native_palette_core.js
@@ -190,17 +190,24 @@ function captureWindow({ helperCmd, owner, outFile, fullscreenFallback, state })
 }
 
 // ---- synthetic click ---------------------------------------------------------
-function clickAt(helperCmd, useCliclick, gx, gy, doubleClick) {
-  if (useCliclick) {
+// #1466: when an `owner` is supplied we ALWAYS route through the swift helper's PID-targeted delivery
+// (CGEvent.postToPid) — cliclick can only post global HID taps, which a no-activation player never
+// receives (the T3/smoke "clicks do nothing" bug). `owner` empty/undefined keeps the legacy behavior
+// (cliclick when available, else an HID-tap helper click). `activateFallback` opts into the brief
+// activate->click->restore escape (off by default). Returns the helper's `delivery` for observability.
+function clickAt(helperCmd, useCliclick, gx, gy, doubleClick, owner, activateFallback) {
+  if (useCliclick && !owner) {
     const r = spawnSync("cliclick", [(doubleClick ? "dc:" : "c:") + Math.round(gx) + "," + Math.round(gy)], { encoding: "utf8" });
     if (r.status !== 0) return { ok: false, reason: (r.stderr || "cliclick failed").slice(0, 200) };
-    return { ok: true };
+    return { ok: true, delivery: "cliclick" };
   }
   const args = ["click", String(gx), String(gy)];
   if (doubleClick) args.push("double");
+  if (owner) args.push("--owner", String(owner));
+  if (activateFallback) args.push("--activate-fallback");
   const r = runHelper(helperCmd, args);
   if (!r || r.ok !== true) return { ok: false, reason: (r && r._error) || "click helper failed" };
-  return { ok: true };
+  return { ok: true, delivery: r.delivery };
 }
 
 module.exports = {

--- a/qa/native_palette/native_palette_server.js
+++ b/qa/native_palette/native_palette_server.js
@@ -93,6 +93,15 @@ const OWNER = (process.env.WORLDOS_NPT_WINDOW_OWNER || "WorldOSPlayer").trim();
 const CLICK_TOOL = (process.env.WORLDOS_NPT_CLICK_TOOL || "auto").trim();
 const SCREEN_LABEL = (process.env.WORLDOS_NPT_SCREEN || "player").trim();
 const FULLSCREEN_FALLBACK = process.env.WORLDOS_NPT_FULLSCREEN_FALLBACK === "1";
+// #1466: input (click/key/type) is PID-delivered to OWNER so the no-activation player actually
+// receives it (see native_input.swift). ACTIVATE_FALLBACK is the opt-in brief activate->post->restore
+// escape if PID delivery proves unreliable for Unity's input polling — OFF by default.
+const CLICK_ACTIVATE_FALLBACK = process.env.WORLDOS_CLICK_ACTIVATE_FALLBACK === "1";
+function inputFlags() {
+  const f = OWNER ? ["--owner", OWNER] : [];
+  if (OWNER && CLICK_ACTIVATE_FALLBACK) f.push("--activate-fallback");
+  return f;
+}
 const SELFCHECK = process.argv.includes("--selfcheck");
 const MAX_WAIT_MS = 8000;
 
@@ -284,7 +293,7 @@ server.registerTool(
     const before = (function () { const f = screencaptureWindow("clickbefore"); return f.ok ? fileHash(path.join(RUNDIR, f.screenshot)) : ""; })();
     let ok = true, reason = "";
     const useCli = CLICK_TOOL === "cliclick" || (CLICK_TOOL === "auto" && haveCliclick());
-    const clickResult = core.clickAt(resolveHelper(), useCli, gx, gy, !!double);
+    const clickResult = core.clickAt(resolveHelper(), useCli, gx, gy, !!double, OWNER, CLICK_ACTIVATE_FALLBACK);
     if (!clickResult.ok) { ok = false; reason = clickResult.reason || "click failed"; }
     spawnSync("sleep", ["0.7"]);
     const after = screencaptureWindow("click");
@@ -311,9 +320,9 @@ server.registerTool(
   },
   async ({ text, submit }) => {
     let ok = true, reason = "";
-    const r = runHelper(["type", String(text)]);
+    const r = runHelper(["type", String(text), ...inputFlags()]);
     if (!r || r.ok !== true) { ok = false; reason = (r && r._error) || "type helper failed"; }
-    if (ok && submit) { runHelper(["key", "return"]); spawnSync("sleep", ["0.9"]); }
+    if (ok && submit) { runHelper(["key", "return", ...inputFlags()]); spawnSync("sleep", ["0.9"]); }
     const after = screencaptureWindow("type");
     const s = logAction("type", { text: String(text).slice(0, 200), submit: !!submit, ok, reason });
     return textResult({ ok, seq: s, screen: SCREEN_LABEL, screenshot: after.screenshot, submitted: !!submit, reason });
@@ -330,7 +339,7 @@ server.registerTool(
   },
   async ({ name }) => {
     let ok = true, reason = "";
-    const r = runHelper(["key", String(name)]);
+    const r = runHelper(["key", String(name), ...inputFlags()]);
     if (!r || r.ok !== true) { ok = false; reason = (r && r._error) || "key helper failed"; }
     spawnSync("sleep", ["0.4"]);
     const after = screencaptureWindow("key");

--- a/qa/native_palette/player_smoke_driver.js
+++ b/qa/native_palette/player_smoke_driver.js
@@ -39,7 +39,7 @@ function parseArgs(argv) {
     const a = argv[i];
     if (!a.startsWith("--")) continue;
     const key = a.slice(2);
-    if (key === "fullscreen-fallback") { out[key] = true; continue; }
+    if (key === "fullscreen-fallback" || key === "activate-fallback") { out[key] = true; continue; }
     out[key] = argv[++i];
   }
   return out;
@@ -56,6 +56,9 @@ const GOBLIN = cell(args["goblin-cell"] || "10,8");
 const WALK = cell(args["walk-cell"] || "8,9");
 const HELPER = args.helper || "";
 const FULLSCREEN_FALLBACK = !!args["fullscreen-fallback"];
+// #1466: opt-in brief activate->click->restore escape if PID-targeted delivery proves unreliable for
+// Unity's input polling. OFF by default (via --activate-fallback or WORLDOS_CLICK_ACTIVATE_FALLBACK=1).
+const ACTIVATE_FALLBACK = !!args["activate-fallback"] || process.env.WORLDOS_CLICK_ACTIVATE_FALLBACK === "1";
 const GLIDE_FRAMES = 4;
 const GLIDE_INTERVAL_MS = 150;
 const SETTLE_MS = 500;
@@ -116,8 +119,10 @@ function clickCell(target, pxW, pxH, winCache, label) {
   // exactly like native_palette_server.js's click tool does (winCache.x/y are global points).
   const gx = winCache.x + sx / winCache.scale;
   const gy = winCache.y + sy / winCache.scale;
+  // #1466: pass OWNER so the click is PID-delivered to the unfocused player (a global HID tap /
+  // cliclick never reaches a no-activation window's Input). ACTIVATE_FALLBACK is the opt-in escape.
   const useCli = core.haveCliclick();
-  const r = core.clickAt(helperCmd, useCli, gx, gy, false);
+  const r = core.clickAt(helperCmd, useCli, gx, gy, false, OWNER, ACTIVATE_FALLBACK);
   return { ...r, sx, sy, gx, gy, label };
 }
 

--- a/qa/test_native_palette.py
+++ b/qa/test_native_palette.py
@@ -142,6 +142,46 @@ class SwiftHelperTests(unittest.TestCase):
         self.assertIn("SCScreenshotManager", src, "capture must use SCScreenshotManager (no activation)")
         self.assertIn('case "capture":', src, "helper must dispatch a `capture` subcommand")
 
+    def test_source_input_is_pid_targeted_with_optin_activate_fallback(self):
+        """#1466 (completes #1456): input delivery is the no-activation twin of capture. When an
+        owner is supplied the helper must resolve its PID (kCGWindowOwnerPID) and deliver the event
+        DIRECTLY to that process (CGEvent.postToPid) so an unfocused player still receives it — a
+        plain global HID tap only reaches the ACTIVE app. The activate->post->restore path must stay
+        OPT-IN (never the default), preserving the no-focus-theft contract."""
+        src = SWIFT.read_text(encoding="utf-8")
+        self.assertIn("kCGWindowOwnerPID", src, "input must resolve the owner PID for direct delivery")
+        self.assertIn("postToPid", src, "#1466: input must PID-target via CGEvent.postToPid")
+        self.assertIn("--owner", src, "click/key/type must accept --owner for PID delivery")
+        self.assertIn("--activate-fallback", src, "the activate fallback must be an opt-in flag")
+        # The fallback must be gated on the flag, not run unconditionally (no default focus theft).
+        self.assertIn("activateFallback, let owner", src,
+                      "activate fallback must be guarded by the opt-in flag + an owner")
+
+    @unittest.skipUnless(shutil.which("swiftc"), "swiftc not available (non-macOS CI)")
+    def test_click_pid_delivery_selects_pid_for_running_owner_and_hid_otherwise(self):
+        """#1466: end-to-end delivery SELECTION. A `--owner` that resolves to a running app (Finder,
+        always present) reports delivery:"pid"; a bogus owner has no window/PID so it gracefully
+        falls back to delivery:"hid" (never a crash). Coordinates are a harmless top-left corner."""
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "native_input"
+            subprocess.run(["swiftc", str(SWIFT), "-o", str(out)], check=True, capture_output=True)
+            # bogus owner -> no PID -> HID fallback, still ok:true
+            b = subprocess.run([str(out), "click", "2", "2", "--owner", "NoSuchApp_ZZZ"],
+                               capture_output=True, text=True)
+            bd = json.loads(b.stdout.strip().splitlines()[-1])
+            self.assertTrue(bd.get("ok"), f"bogus-owner click must not fail: {bd}")
+            self.assertEqual(bd.get("delivery"), "hid", f"unresolved owner must fall back to HID: {bd}")
+            # running owner -> PID resolves -> direct postToPid delivery
+            f = subprocess.run([str(out), "click", "2", "2", "--owner", "Finder"],
+                               capture_output=True, text=True)
+            fd = json.loads(f.stdout.strip().splitlines()[-1])
+            self.assertTrue(fd.get("ok"), f"Finder click must not fail: {fd}")
+            self.assertEqual(fd.get("delivery"), "pid",
+                             f"a running owner must PID-target (Finder is always running): {fd}")
+            # legacy path (no owner) stays HID — byte-compatible with pre-#1466 callers
+            n = subprocess.run([str(out), "click", "2", "2"], capture_output=True, text=True)
+            self.assertEqual(json.loads(n.stdout.strip().splitlines()[-1]).get("delivery"), "hid")
+
     @unittest.skipUnless(shutil.which("swiftc"), "swiftc not available (non-macOS CI)")
     def test_capture_subcommand_images_a_window_without_activation(self):
         """Prove the SCK `capture` path actually images an EXISTING window (Finder is always
@@ -255,6 +295,18 @@ class CoreModuleTests(unittest.TestCase):
         self.assertNotIn("activateOwner", src, "#1456: activate-before-capture must be removed (no focus theft)")
         self.assertNotIn("waitForOnScreen", src, "#1456: cross-Space activation polling must be removed")
         self.assertNotIn("to activate", src, "#1456: the module must not osascript-activate the owner")
+
+    def test_clickAt_forwards_owner_for_pid_delivery_and_bypasses_cliclick(self):
+        """#1466: clickAt must forward `--owner` to the swift helper so the click is PID-delivered to
+        the unfocused player, and it must NOT use cliclick when an owner is set (cliclick can only
+        post global HID taps, which a no-activation window never receives)."""
+        src = CORE.read_text(encoding="utf-8")
+        self.assertIn("function clickAt(helperCmd, useCliclick, gx, gy, doubleClick, owner", src,
+                      "clickAt must accept an owner (and activateFallback) for PID delivery")
+        self.assertIn("useCliclick && !owner", src,
+                      "clickAt must skip cliclick when an owner is set (cliclick cannot PID-target)")
+        self.assertIn('args.push("--owner", String(owner))', src,
+                      "clickAt must forward --owner to the helper")
 
     @unittest.skipUnless(shutil.which("swiftc") and shutil.which("node"), "swiftc/node not available (non-macOS CI)")
     def test_stale_compiled_binary_is_rebuilt_on_source_edit(self):


### PR DESCRIPTION
## What
Completes #1456 (no-hijack player QA). #1456 fixed no-activation **capture**; input stayed on a global HID-tap CGEvent, which macOS only routes to the **active** app — so synthetic clicks landed on the player's pixels but never reached Unity's `Input.GetMouseButtonDown`.

## Evidence (smoke-w6batch root-cause)
- `combat.active=True` and live `/combat-surface` returns `stage.mode=combat` + valid turnToken + foe token → the client took the **combat** path; the W6.2 rest-vs-combat branch is byte-identical here (**refuted** as the cause).
- Engine session recorded **zero** move/attack intents; all 11 frames byte-identical with **no FlashReject ring** → `HandleClick` never fired → the click never arrived.
- `native_input.swift` posted `.cghidEventTap` at global coords and **never activates** the owner (#1456 contract) → unfocused Unity ignores it.

## Fix
When an owner NAME is supplied, resolve its PID (`kCGWindowOwnerPID`, same window pick as `winfind`) and deliver the event via `CGEvent.postToPid` — reaches an unfocused, off-current-Space app **without activation**, preserving never-fullscreen / never-steal-focus. No owner → legacy HID path (byte-identical). A brief activate→post→restore fallback is plumbed but **opt-in** (`--activate-fallback` / `WORLDOS_CLICK_ACTIVATE_FALLBACK=1`); PID is tried first.

- `native_input.swift`: `--owner`/`--activate-fallback` on click/key/type; `ownerPID()` + `Delivery` enum; opt-in `withBriefActivation` (AppKit).
- `native_palette_core.js`: `clickAt` forwards `--owner`, bypasses cliclick when owner set.
- `native_palette_server.js` + `player_smoke_driver.js`: pass OWNER through click/key/type.
- `test_native_palette.py`: PID-vs-HID delivery selection + source guards + clickAt owner-forwarding.

## Test
`qa/test_native_palette.py` — **30 passed** (swiftc compile + Finder=pid / bogus=hid / no-owner=hid legacy). Unblocks #1466's smoke + T3 verification (re-run pending on this branch's app).