### PR TITLE
tests: refresh stale crypt goldens + pin guiding-bolt attack roll flake

### DIFF
--- a/extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py
+++ b/extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py
@@ -32,6 +32,12 @@ import generate_room  # noqa: E402
 # Byte-identical to the pre-2026-07-03 hardcoded literals in room_recipes.json
 # (layered_pipeline_2026_07_02.pass2_detail_populate.prompt / pass3_staging_last.prompt,
 # as they existed before this fix — copied verbatim for the regression assertion).
+#
+# 2026-07-11 update: refreshed to the CURRENT adopted crypt prompts. The crypt recipe
+# gained the "Do NOT add any characters, people, figures, animals, or creatures..."
+# empty-background-plate trailer (adopted via panel review, camp/crypt recipe evolution
+# in extensions/renderers/shared/room_recipes.json) — this is an intentional recipe
+# change, not a regression, so the golden constants are updated to match (issue #1475).
 LEGACY_CRYPT_PASS2_PROMPT = (
     "Edit this painterly isometric dungeon plate. PRESERVE the exact composition, camera, "
     "room layout, and the dark dramatic lighting with its warm fire pools and deep shadows "
@@ -43,7 +49,9 @@ LEGACY_CRYPT_PASS2_PROMPT = (
     "scattered coins, moss) keeping the open floor areas clear; deepen the black voids at the "
     "openings. Keep the hand-painted oil-paint brushwork feel throughout. Do NOT add any text, "
     "letters, numbers, runic writing that reads as text, labels, legends, map insets, UI "
-    "elements, frames, or borders — the plate must contain ONLY the diegetic painted scene."
+    "elements, frames, or borders — the plate must contain ONLY the diegetic painted scene. "
+    "Do NOT add any characters, people, figures, animals, or creatures of any kind — this is "
+    "an EMPTY background plate; actors are composited in separately by the engine."
 )
 
 LEGACY_CRYPT_PASS3_PROMPT = (
@@ -58,7 +66,9 @@ LEGACY_CRYPT_PASS3_PROMPT = (
     "on shadow-side stone. The scene must read as small pools of firelight in a vast dark "
     "crypt, keeping the hand-painted oil feel. Do NOT add any text, letters, numbers, runic "
     "writing that reads as text, labels, legends, map insets, UI elements, frames, or borders "
-    "— the plate must contain ONLY the diegetic painted scene."
+    "— the plate must contain ONLY the diegetic painted scene. Do NOT add any characters, "
+    "people, figures, animals, or creatures of any kind — this is an EMPTY background plate; "
+    "actors are composited in separately by the engine."
 )
 
 # Nouns that must NOT leak into a tavern's rendered pass2/pass3 prompts (crypt-specific, not

--- a/servers/engine/tests/test_action_economy.py
+++ b/servers/engine/tests/test_action_economy.py
@@ -282,7 +282,7 @@ def _psa(cid):
     return server._require(cid).combat.pending_spell_attack
 
 
-def test_guiding_bolt_then_attack_resolves_and_rearms(bolt_caster):
+def test_guiding_bolt_then_attack_resolves_and_rearms(bolt_caster, monkeypatch):
     """The sprint's exact sequence: cast Guiding Bolt (automated:false) -> the same-turn
     attack() that resolves it lands damage, the on-hit rider is consumed, and the gate
     re-arms (a second independent strike is refused)."""
@@ -292,8 +292,26 @@ def test_guiding_bolt_then_attack_resolves_and_rearms(bolt_caster):
     # The pending spell-attack leg was recorded (keyed to this caster + target).
     psa = _psa(cid)
     assert psa is not None and psa.source_id == cleric and gob in psa.target_ids
-    # The resolving attack() bypasses the cast+attack gate and deals damage (auto-hit nat-20
-    # not needed — a big bonus vs AC 5 hits): the bolt no longer "deals 0".
+    # Pin the resolving attack's d20 to a mid-range natural (15) so the hit is
+    # deterministic: attack_bonus=20 vs AC 5 hits on any roll except a natural 1
+    # (auto-miss per SRD), which flaked CI ~5% of the time (#1395, blocked PR #1474).
+    # Same monkeypatch.setattr(server.dice_mod, "roll", ...) pinning pattern used
+    # throughout tests/test_combat.py and tests/test_grapple_shove.py; damage rolls
+    # pass through to the real roller unpinned.
+    from dice import DiceRoll
+
+    real_roll = server.dice_mod.roll
+
+    def _pinned_roll(expression, *args, **kwargs):
+        if expression.startswith("1d20"):
+            return DiceRoll(
+                expression=expression, total=15 + 20, rolls=[15], is_d20=True, natural=15, crit=False
+            )
+        return real_roll(expression, *args, **kwargs)
+
+    monkeypatch.setattr(server.dice_mod, "roll", _pinned_roll)
+    # The resolving attack() bypasses the cast+attack gate and deals damage (the pinned
+    # natural-15 vs a big bonus and AC 5 hits): the bolt no longer "deals 0".
     atk = server.attack(cid, cleric, gob, attack_bonus=20, damage_dice="4d6")
     assert atk["hit"] is True and atk["damage"]["total"] > 0
     assert atk["attacks_made_this_turn"] == 1


### PR DESCRIPTION
## Summary
- Refresh `LEGACY_CRYPT_PASS2_PROMPT` / `LEGACY_CRYPT_PASS3_PROMPT` in `test_layered_prompt_templating.py` to match the current adopted crypt recipe in `extensions/renderers/shared/room_recipes.json`, which intentionally gained the "empty background plate, no characters" trailer via panel review. Fixes #1475. `generate_room.py` is untouched.
- Pin the resolving attack's d20 in `test_guiding_bolt_then_attack_resolves_and_rearms` (`servers/engine/tests/test_action_economy.py`) to a deterministic mid-roll via `monkeypatch.setattr(server.dice_mod, "roll", ...)`, matching the existing pinning pattern in `test_combat.py`/`test_grapple_shove.py`. The prior assertion (`attack_bonus=20` vs AC 5) auto-missed on a natural 1 ~5% of the time in CI, blocking #1474 (context: #1395). Swept the file for other `attack_bonus=20` + hit-asserting tests — this is the only one that asserts `["hit"]`, so no other tests needed the same fix.

## Test plan
- [x] `python3 -m pytest extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py -q` → 12 passed, 8 subtests passed
- [x] `uv run --directory servers/engine python -m pytest tests/test_action_economy.py -q -p no:xdist` × 5 consecutive runs → 24 passed every time
- [x] `qa/fast_gate.sh` → PASS (257 passed)