### PR TITLE
qa/player: land the cell-based QA input channel on main (#1466; carries #1477)

### DIFF
--- a/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
+++ b/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
@@ -123,6 +123,13 @@ public static class BuildMacOSPlayer
         PlayerSettings.productName = "WorldOSPlayer";
         PlayerSettings.applicationIdentifier = "com.worldos.WorldOSPlayer";
 
+        // #1466: RUN IN BACKGROUND. The no-hijack QA/beauty launch (#1456/#1458) never activates the
+        // window, and a macOS player with this OFF PAUSES its player loop (Update/coroutines/input) while
+        // backgrounded — so the surface poll + QA click channel froze and every input path silently did
+        // nothing. Bake it on so the player keeps running from frame 0 whether or not it has focus.
+        // (CombatSurfaceClient also sets Application.runInBackground=true at runtime as a backstop.)
+        PlayerSettings.runInBackground = true;
+
         // --- Architecture: Universal (Intel + Apple Silicon) if the module supports it,
         //     else fall back to x64 only. Never fail the build over this. ---
         string archResult;

--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -1,4 +1,7 @@
 using System.Collections;
+using System.Collections.Concurrent;   // #1466: thread-safe hand-off from the QA HTTP thread to Update()
+using System.Net;                      // #1466: localhost HttpListener for the QA input channel
+using System.Threading;                // #1466: the QA listener runs off the Unity main thread
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -294,6 +297,14 @@ public class CombatSurfaceClient : MonoBehaviour
 
         Debug.Log("[CSC] start: campaign=" + CampaignId + " url=" + ViewerUrl + " overlay=" + _overlayOn + " onboard=" + _onboard);
         StartCoroutine(PollLoop());
+
+        // #1466 QA INPUT CHANNEL (env-gated, OFF by default = byte-identical player). OS-synthetic mouse
+        // never reaches a no-activation background Unity window (Input never sees it — HID/postToPid/
+        // brief-activation all REFUTED; see docs/research register + #1466), so player QA had no way to
+        // exercise the click path. When WORLDOS_QA_INPUT=1 we open a LOCALHOST-only HttpListener that
+        // accepts a normalized viewport coord and feeds it through the SAME HandleClickAt raycast->cell->
+        // pre-validation->POST path a human click takes — the client does everything else identically.
+        if (System.Environment.GetEnvironmentVariable("WORLDOS_QA_INPUT") == "1") StartQaInput();
     }
 
     // Resolve the token's already-placed actor by the registry naming (Actor_ + token.id).
@@ -349,7 +360,7 @@ public class CombatSurfaceClient : MonoBehaviour
                 }
                 yield return null;
             }
-            if (Ok(req)) { Debug.Log("[CSC] fetch ok (" + req.responseCode + ")"); ApplyJson(req.downloadHandler.text); }
+            if (Ok(req)) { Debug.Log("[CSC] fetch ok (" + req.responseCode + ")"); _dbgSurf++; ApplyJson(req.downloadHandler.text); }
             else Debug.LogWarning("[CSC] fetch FAILED status=" + req.responseCode + " err=" + req.error);
         }
     }
@@ -1346,6 +1357,20 @@ public class CombatSurfaceClient : MonoBehaviour
         UpdateHpBars();
         UpdateTurnPulse();
         if (_busy) return;
+        // #1466: drain at most one queued QA click per frame on the MAIN thread (Camera/raycast/coroutines
+        // AND Screen.width/height are main-thread only). Same _busy gate as a real click. A cell request
+        // runs the shared HandleCell validation+POST; a viewport request runs the full raycast first.
+        if (_qaClicks != null)
+        {
+            _screenW = Screen.width; _screenH = Screen.height;   // cache for the off-thread /health
+            if (_qaClicks.TryDequeue(out var qc))
+            {
+                _dbgDeq++;
+                if (qc.cell) HandleCell(qc.c, qc.r);
+                else HandleClickAt(new Vector3(qc.vx * Screen.width, qc.vy * Screen.height, 0f));
+                return;
+            }
+        }
         if (Input.GetMouseButtonDown(0)) HandleClick();
     }
 
@@ -1427,18 +1452,35 @@ public class CombatSurfaceClient : MonoBehaviour
         Object.Destroy(q);
     }
 
+    // A real mouse click -> the SAME coordinate-level handler the QA input channel (#1466) drives, so
+    // the raycast->cell->pre-validation->POST product path is identical whether a human or the T3 gate
+    // clicks. Input.mousePosition is screen pixels, bottom-left origin (what ScreenPointToRay wants).
+    void HandleClick() { HandleClickAt(Input.mousePosition); }
+
     // Minimal input: raycast the click onto the floor plane -> cell -> POST the existing /move kinds
     // ONLY (move_to_cell, or an on-turn attack when the clicked cell holds the foe). Payload mirrors
-    // the viewer driver (qa/drive_gfx_combat.py) exactly.
-    void HandleClick()
+    // the viewer driver (qa/drive_gfx_combat.py) exactly. `screenPoint` is screen pixels (bottom-left
+    // origin); the QA channel converts its normalized viewport coord to this via Screen.width/height.
+    void HandleClickAt(Vector3 screenPoint)
     {
         var cam = Camera.main; if (cam == null) return;
-        Ray ray = cam.ScreenPointToRay(Input.mousePosition);
+        Ray ray = cam.ScreenPointToRay(screenPoint);
         if (Mathf.Abs(ray.direction.y) < 1e-4f) return;
         float tt = (FloorY - ray.origin.y) / ray.direction.y; if (tt < 0) return;
         Vector3 hit = ray.origin + ray.direction * tt;
         if (!WorldToCell(hit, out int c, out int r)) return;
+        HandleCell(c, r);
+    }
+
+    // The cell-level half of a click: identical rest-vs-combat pre-validation + POST whether the cell
+    // came from a mouse raycast (HandleClickAt) or the QA input channel's cell path (#1466). This is the
+    // "SAME HandleClick validation path" the QA channel runs — NOT a DoMove/DoAttack shortcut: it still
+    // honors _restMode, the mover check, and the #1441 impassable/occupied pre-filter (FlashReject).
+    void HandleCell(int c, int r)
+    {
         int key = CellKey(c, r);
+        _dbgActed++;
+        _dbgLast = "cell(" + c + "," + r + ") rest=" + _restMode + " foe=(" + _foeX + "," + _foeY + ")'" + _foeId + "' imp=" + (_impassable.Contains(key) ? "Y" : "n") + " occ=" + (_occupied.Contains(key) ? "Y" : "n");
         // W6.2 (#1461) REST MODE: no combat signals -> the click WALKS a party member to the cell via the
         // engine's `walk_to` verb (the walk_to_cell /move intent), NOT the combat move. Same #1441
         // pre-validation as combat — a blocked/occupied cell flashes a red ring instead of a doomed POST
@@ -1460,6 +1502,101 @@ public class CombatSurfaceClient : MonoBehaviour
         if (_impassable.Contains(key) || _occupied.Contains(key)) { StartCoroutine(FlashReject(c, r)); return; }
         StartCoroutine(PostMove(c, r));
     }
+
+    // ---- #1466 QA input channel ------------------------------------------------------------------
+    // Localhost HttpListener that turns a click request into a synthetic click fed through the SAME
+    // validation+POST path a human click takes. OFF unless WORLDOS_QA_INPUT=1 (byte-identical player
+    // otherwise). Port from WORLDOS_QA_INPUT_PORT (default 8971), mirroring the WORLDOS_ENGINE_BASE_URL
+    // env-contract style. Two request shapes on POST /click (queued; resolved next frame on the main thread):
+    //   {"c":9,"r":8}        -> HandleCell(c,r)  — the ROBUST path QA uses. Skips only the raycast; still
+    //                           runs the rest-vs-combat + #1441 impassable/occupied pre-validation + POST.
+    //                           No pixel/titlebar/aspect calibration to get wrong (the SCK capture includes
+    //                           the macOS titlebar, so a captured-pixel viewport never matched Unity's).
+    //   {"vx":0..1,"vy":0..1} -> HandleClickAt  — viewport coord (BOTTOM-LEFT origin), runs the full raycast
+    //                           too; kept as real product-fidelity input for a correctly-calibrated caller.
+    //   GET /health          -> {"ok":true}
+    [System.Serializable] class QaClick { public int c = -1; public int r = -1; public float vx = float.NaN; public float vy = float.NaN; }
+    struct QaCmd { public bool cell; public int c; public int r; public float vx; public float vy; }
+    ConcurrentQueue<QaCmd> _qaClicks;
+    HttpListener _qaListener;
+    Thread _qaThread;
+    volatile bool _qaStop;
+    // Unity's render dims, cached on the MAIN thread (Screen.* is main-thread only) so the off-thread
+    // /health handler can report them. A pixel-space caller (the T3 palette) needs Screen.height to undo
+    // the macOS titlebar the SCK capture includes (captured height != Screen.height).
+    volatile int _screenW, _screenH;
+    // #1466 diagnostics: a no-activation player's Player.log is buffered and unreliable, so the channel
+    // exposes its own counters via GET /debug (enqueued/dequeued/acted + the last branch HandleCell took
+    // + surface-derived state). Single-writer per field in practice; volatile is enough for a QA probe.
+    volatile int _dbgEnq, _dbgDeq, _dbgActed, _dbgSurf;
+    volatile string _dbgLast = "none";
+
+    void StartQaInput()
+    {
+        int port = 8971;
+        string p = System.Environment.GetEnvironmentVariable("WORLDOS_QA_INPUT_PORT");
+        if (!string.IsNullOrEmpty(p) && int.TryParse(p, out int pv) && pv > 0) port = pv;
+        _qaClicks = new ConcurrentQueue<QaCmd>();
+        try
+        {
+            _qaListener = new HttpListener();
+            _qaListener.Prefixes.Add("http://127.0.0.1:" + port + "/");
+            _qaListener.Start();
+        }
+        catch (System.Exception e)
+        { Debug.LogWarning("[CSC] QA input listener failed to bind :" + port + " — " + e.Message); _qaListener = null; return; }
+        _qaThread = new Thread(QaListenLoop) { IsBackground = true, Name = "CSC-QAInput" };
+        _qaThread.Start();
+        Debug.Log("[CSC] QA input channel LISTENING on http://127.0.0.1:" + port + "/click (cell {c,r} or viewport {vx,vy} -> HandleCell/HandleClickAt)");
+    }
+
+    // Runs OFF the Unity main thread: it may ONLY do pure/thread-safe work (parse + Mathf.Clamp01 + queue).
+    // NO Unity API here (Screen/Camera/coroutines) — those happen when Update() drains the queue.
+    void QaListenLoop()
+    {
+        while (!_qaStop && _qaListener != null && _qaListener.IsListening)
+        {
+            HttpListenerContext ctx;
+            try { ctx = _qaListener.GetContext(); }
+            catch { break; }   // listener stopped/disposed -> exit the loop cleanly
+            try
+            {
+                string body = "";
+                if (ctx.Request.HasEntityBody)
+                    using (var sr = new System.IO.StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding)) body = sr.ReadToEnd();
+                string resp = "{\"ok\":false}";
+                if (ctx.Request.Url.AbsolutePath == "/click" && ctx.Request.HttpMethod == "POST")
+                {
+                    var q = JsonUtility.FromJson<QaClick>(body);
+                    if (q != null && q.c >= 0 && q.r >= 0)
+                    { _qaClicks.Enqueue(new QaCmd { cell = true, c = q.c, r = q.r }); _dbgEnq++; resp = "{\"ok\":true}"; }
+                    else if (q != null && !float.IsNaN(q.vx) && !float.IsNaN(q.vy))
+                    { _qaClicks.Enqueue(new QaCmd { cell = false, vx = Mathf.Clamp01(q.vx), vy = Mathf.Clamp01(q.vy) }); _dbgEnq++; resp = "{\"ok\":true}"; }
+                }
+                else if (ctx.Request.Url.AbsolutePath == "/health")
+                    resp = "{\"ok\":true,\"screenW\":" + _screenW + ",\"screenH\":" + _screenH + "}";
+                else if (ctx.Request.Url.AbsolutePath == "/debug")
+                    resp = "{\"ok\":true,\"enq\":" + _dbgEnq + ",\"deq\":" + _dbgDeq + ",\"acted\":" + _dbgActed
+                         + ",\"surf\":" + _dbgSurf + ",\"busy\":" + (_busy ? "true" : "false") + ",\"last\":\"" + _dbgLast + "\"}";
+                byte[] buf = System.Text.Encoding.UTF8.GetBytes(resp);
+                ctx.Response.ContentType = "application/json";
+                ctx.Response.ContentLength64 = buf.Length;
+                ctx.Response.OutputStream.Write(buf, 0, buf.Length);
+                ctx.Response.OutputStream.Close();
+            }
+            catch { /* one bad request must never kill the QA loop */ }
+        }
+    }
+
+    void StopQaInput()
+    {
+        _qaStop = true;
+        try { if (_qaListener != null) { _qaListener.Stop(); _qaListener.Close(); } } catch { }
+        _qaListener = null;
+    }
+
+    void OnDestroy() { StopQaInput(); }
+    void OnApplicationQuit() { StopQaInput(); }
 
     // Brief red ring flash at a rejected cell — immediate "you can't go there" with no server round-trip.
     IEnumerator FlashReject(int c, int r)

--- a/qa/native_palette/native_palette_core.js
+++ b/qa/native_palette/native_palette_core.js
@@ -210,6 +210,31 @@ function clickAt(helperCmd, useCliclick, gx, gy, doubleClick, owner, activateFal
   return { ok: true, delivery: r.delivery };
 }
 
+// ---- #1466 QA input channel ---------------------------------------------------
+// The player's in-process localhost listener (CombatSurfaceClient StartQaInput) is the ROBUST input
+// path for the no-activation player: OS-synthetic mouse never reaches a background Unity window
+// (HID/postToPid/brief-activation all REFUTED — see #1466). When WORLDOS_QA_INPUT=1 the driver + T3
+// palette route clicks HERE and the player runs them through the SAME HandleCell rest-vs-combat +
+// #1441 pre-validation + POST path a human click takes. Synchronous (curl) to match the spawnSync style.
+function qaPostClick(port, payload) {
+  const r = spawnSync("curl", ["-s", "-m", "3", "-X", "POST", "-H", "Content-Type: application/json",
+    "-d", JSON.stringify(payload), `http://127.0.0.1:${port}/click`], { encoding: "utf8" });
+  if (r.status !== 0) return { ok: false, reason: (r.stderr || "qa-click curl failed").slice(0, 200) };
+  try { return { ok: JSON.parse(r.stdout || "{}").ok === true, delivery: "qa-channel" }; }
+  catch { return { ok: false, reason: "qa-click bad response: " + (r.stdout || "").slice(0, 120) }; }
+}
+// CELL path (robust — no pixel/titlebar/aspect calibration): the caller already knows the grid cell.
+function qaClickCell(port, c, r) { return qaPostClick(port, { c, r }); }
+// VIEWPORT path (full raycast fidelity): vx,vy are 0..1, BOTTOM-LEFT origin (Unity screen space).
+function qaClick(port, vx, vy) { return qaPostClick(port, { vx, vy }); }
+// GET the player's Screen.width/height so a pixel-space caller can undo the macOS titlebar the SCK
+// capture includes (captured height != Screen.height). Returns { ok, screenW, screenH } or { ok:false }.
+function qaHealth(port) {
+  const r = spawnSync("curl", ["-s", "-m", "3", `http://127.0.0.1:${port}/health`], { encoding: "utf8" });
+  if (r.status !== 0) return { ok: false };
+  try { return JSON.parse(r.stdout || "{}"); } catch { return { ok: false }; }
+}
+
 module.exports = {
   SWIFT_SRC,
   resolveHelper,
@@ -222,4 +247,7 @@ module.exports = {
   fullscreenCropWindow,
   captureWindow,
   clickAt,
+  qaClick,
+  qaClickCell,
+  qaHealth,
 };

--- a/qa/native_palette/native_palette_server.js
+++ b/qa/native_palette/native_palette_server.js
@@ -103,6 +103,17 @@ function inputFlags() {
   if (OWNER && CLICK_ACTIVATE_FALLBACK) f.push("--activate-fallback");
   return f;
 }
+// #1466 QA INPUT CHANNEL: when the player is launched with WORLDOS_QA_INPUT=1, the click tool routes
+// through its in-process localhost listener (viewport coord -> HandleClickAt) instead of OS-synthetic
+// mouse — the only path that reaches a no-activation Unity window. Empty => legacy synthetic-click path.
+const QA_INPUT_PORT = process.env.WORLDOS_QA_INPUT === "1" ? String(process.env.WORLDOS_QA_INPUT_PORT || "8971") : "";
+// Cache the player's Screen dims (from /health) once — they're stable for a windowed run and every
+// click needs the titlebar band (captured.ph - screenH) to map a screenshot pixel to a Unity viewport.
+let _qaHealth = null;
+function qaHealthCached() {
+  if (_qaHealth === null) _qaHealth = QA_INPUT_PORT ? (core.qaHealth(QA_INPUT_PORT) || { ok: false }) : { ok: false };
+  return _qaHealth;
+}
 const SELFCHECK = process.argv.includes("--selfcheck");
 const MAX_WAIT_MS = 8000;
 
@@ -202,7 +213,9 @@ function screencaptureWindow(label) {
       reason: "player window '" + OWNER + "' not found (is WorldOSPlayer.app launched? set WORLDOS_NPT_FULLSCREEN_FALLBACK=1 to grab the whole screen)",
     };
   }
-  winCache = cap.window ? { x: cap.window.x, y: cap.window.y, w: cap.window.w, h: cap.window.h, id: cap.window.id, scale: cap.scale } : null;
+  // #1466: keep the capture PIXEL dims (pw/ph) so the QA input channel can normalize a screenshot
+  // pixel (x,y) into a viewport coord for HandleClickAt.
+  winCache = cap.window ? { x: cap.window.x, y: cap.window.y, w: cap.window.w, h: cap.window.h, id: cap.window.id, scale: cap.scale, pw: cap.pixels ? cap.pixels.pw : null, ph: cap.pixels ? cap.pixels.ph : null } : null;
   return { ok: cap.ok, screenshot: rel, mode: cap.mode, window: cap.window, pixels: cap.pixels, scale: cap.scale };
 }
 
@@ -288,13 +301,29 @@ server.registerTool(
       const s = logAction("click", { x, y, ok: false, reason: "no window" });
       return textResult({ ok: false, seq: s, reason: "player window not located — take a screenshot first." });
     }
-    // window-relative pixels -> global screen points
+    // window-relative pixels -> global screen points (legacy synthetic-mouse path)
     const gx = winCache.x + x / winCache.scale;
     const gy = winCache.y + y / winCache.scale;
     const before = (function () { const f = screencaptureWindow("clickbefore"); return f.ok ? fileHash(path.join(RUNDIR, f.screenshot)) : ""; })();
     let ok = true, reason = "";
-    const useCli = CLICK_TOOL === "cliclick" || (CLICK_TOOL === "auto" && haveCliclick());
-    const clickResult = core.clickAt(resolveHelper(), useCli, gx, gy, !!double, OWNER, CLICK_ACTIVATE_FALLBACK);
+    // #1466: prefer the QA input channel when the player exposes it — normalize the screenshot pixel
+    // (top-left origin, winCache.pw x winCache.ph) into a Unity viewport coord (bottom-left origin) and
+    // hand it to HandleClickAt (full raycast fidelity). The SCK capture includes the macOS titlebar, so
+    // captured height != Screen.height — /health gives Screen.height so we subtract the titlebar band
+    // (captured.ph - screenH) before normalizing. Falls back to synthetic mouse if the channel isn't
+    // enabled or pixel dims are unknown (e.g. a fullscreen-crop capture).
+    let clickResult;
+    if (QA_INPUT_PORT && winCache.pw && winCache.ph) {
+      const h = qaHealthCached();
+      const screenH = h && h.screenH ? h.screenH : winCache.ph;   // fallback: assume no titlebar band
+      const titlebarPx = Math.max(0, winCache.ph - screenH);       // captured extra height = macOS titlebar
+      const vx = x / winCache.pw;
+      const vy = 1 - (y - titlebarPx) / screenH;
+      clickResult = core.qaClick(QA_INPUT_PORT, vx, vy);
+    } else {
+      const useCli = CLICK_TOOL === "cliclick" || (CLICK_TOOL === "auto" && haveCliclick());
+      clickResult = core.clickAt(resolveHelper(), useCli, gx, gy, !!double, OWNER, CLICK_ACTIVATE_FALLBACK);
+    }
     if (!clickResult.ok) { ok = false; reason = clickResult.reason || "click failed"; }
     spawnSync("sleep", ["0.7"]);
     const after = screencaptureWindow("click");

--- a/qa/native_palette/player_smoke_driver.js
+++ b/qa/native_palette/player_smoke_driver.js
@@ -64,6 +64,11 @@ const FULLSCREEN_FALLBACK = !!args["fullscreen-fallback"];
 // AUTHORITATIVE — it must win over the explicit --activate-fallback flag too (matches
 // native_palette_server.js's CLICK_ACTIVATE_FALLBACK exactly, which has no such flag to override it).
 const ACTIVATE_FALLBACK = process.env.WORLDOS_CLICK_ACTIVATE_FALLBACK !== "0";
+// #1466/#1477 QA INPUT CHANNEL (preferred, zero-activation): when the player is launched with
+// WORLDOS_QA_INPUT=1, route clicks through its in-process localhost listener (cell {c,r} -> HandleCell)
+// instead of OS-synthetic mouse — titlebar-immune and skips the activate-fallback path entirely. Empty
+// => falls through to the synthetic-click path (ACTIVATE_FALLBACK, above) as before.
+const QA_INPUT_PORT = process.env.WORLDOS_QA_INPUT === "1" ? String(process.env.WORLDOS_QA_INPUT_PORT || "8971") : "";
 const GLIDE_FRAMES = 4;
 const GLIDE_INTERVAL_MS = 150;
 const SETTLE_MS = 500;
@@ -120,6 +125,16 @@ function cellPixel(c, r, cols, rows, pxW, pxH) {
 
 function clickCell(target, pxW, pxH, winCache, label) {
   const { sx, sy } = cellPixel(target.c, target.r, COLS, ROWS, pxW, pxH);
+  // #1466 QA INPUT CHANNEL (preferred when the player exposes it): the smoke KNOWS the target grid cell,
+  // so it uses the ROBUST cell path — the player runs the SAME HandleCell rest-vs-combat + #1441
+  // pre-validation + POST a human click triggers, with none of the OS synthetic-mouse delivery problem
+  // AND none of the capture-pixel->Unity-viewport calibration risk (the SCK capture includes the macOS
+  // titlebar, so a captured-pixel viewport never matched Unity's screen; the T3 palette handles that via
+  // /health, but the deterministic smoke needs neither).
+  if (QA_INPUT_PORT) {
+    const r = core.qaClickCell(QA_INPUT_PORT, target.c, target.r);
+    return { ...r, delivery: r.delivery || "qa-channel", cell: { c: target.c, r: target.r }, sx, sy, label };
+  }
   // sx,sy are in the SAME capture-pixel space screenshots are saved in -> map to global points
   // exactly like native_palette_server.js's click tool does (winCache.x/y are global points).
   const gx = winCache.x + sx / winCache.scale;

--- a/qa/player_smoke.sh
+++ b/qa/player_smoke.sh
@@ -42,6 +42,10 @@
 #          WORLDOS_NPT_WINDOW_OWNER  — CGWindowList owner name (default "WorldOSPlayer")
 #          WORLDOS_NPT_HELPER        — path to a prebuilt native_input binary (else compiled fresh)
 #          WORLDOS_NPT_FULLSCREEN_FALLBACK — "1" to allow the full-screen+crop fallback capture
+# #1466:   the player is launched with WORLDOS_QA_INPUT=1 + WORLDOS_QA_INPUT_PORT (engine port +100),
+#          opening an in-process localhost click listener; the driver routes clicks there (viewport
+#          coord -> HandleClickAt) because OS-synthetic mouse never reaches a no-activation Unity
+#          window (HID/postToPid/brief-activation REFUTED — see #1466 + docs/research register).
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 1
 
@@ -172,10 +176,17 @@ sleep 1
 # common case — it's kept as a belt-and-suspenders capture of anything emitted before Unity's
 # logging takes over (e.g. dyld/early native errors). unity_player.log is the primary player log.
 PLAYER_WIN_ARGS=(); while IFS= read -r __a; do PLAYER_WIN_ARGS+=("$__a"); done < <(player_windowed_launch_args "$PLAYERDIR/unity_player.log")
-WORLDOS_ENGINE_BASE_URL="$BASE_URL" WORLDOS_CAMPAIGN_ID="$CID" "$PLAYER_BIN" "${PLAYER_WIN_ARGS[@]}" \
+# #1466 QA INPUT CHANNEL: launch the player with an in-process localhost click listener so the driver
+# can inject clicks the ROBUST way (OS-synthetic mouse never reaches a no-activation Unity window —
+# HID/postToPid/brief-activation all REFUTED). Port is derived from the engine port (unique per run).
+# Byte-identical player when WORLDOS_QA_INPUT is unset — this smoke opts in.
+QA_INPUT_PORT="$((PORT + 100))"
+export WORLDOS_QA_INPUT=1 WORLDOS_QA_INPUT_PORT="$QA_INPUT_PORT"
+WORLDOS_ENGINE_BASE_URL="$BASE_URL" WORLDOS_CAMPAIGN_ID="$CID" \
+WORLDOS_QA_INPUT=1 WORLDOS_QA_INPUT_PORT="$QA_INPUT_PORT" "$PLAYER_BIN" "${PLAYER_WIN_ARGS[@]}" \
   > "$RUNDIR/player_app.log" 2>&1 &
 PLAYER_APP_PID=$!
-echo "[smoke] player app launched WINDOWED (pid $PLAYER_APP_PID) — engine=$BASE_URL campaign=$CID args=${PLAYER_WIN_ARGS[*]}"
+echo "[smoke] player app launched WINDOWED (pid $PLAYER_APP_PID) — engine=$BASE_URL campaign=$CID qa_input=:$QA_INPUT_PORT args=${PLAYER_WIN_ARGS[*]}"
 # Let Unity open its window, fetch /combat-surface, and settle into the TACTICAL GRID camera
 # framing (not whatever establishing/pre-combat view it opens on) before the scripted clicks —
 # the click-target math below assumes the locked dimetric combat camera is on screen.

--- a/qa/test_native_palette.py
+++ b/qa/test_native_palette.py
@@ -462,5 +462,128 @@ class PlayerSmokeTests(unittest.TestCase):
         self.assertIn("glide_attack_distinct", src)
 
 
+CSHARP = ROOT / "extensions" / "renderers" / "unity" / "scripts" / "CombatSurfaceClient.cs"
+
+
+class QaInputChannelTests(unittest.TestCase):
+    """#1466: OS-synthetic mouse never reaches a no-activation Unity window (HID/postToPid/activation
+    REFUTED). The QA input channel is the robust path: an env-gated in-process localhost listener in the
+    PLAYER that runs a normalized viewport coord through the SAME HandleClickAt raycast->cell->POST path
+    a human click takes; the driver + T3 palette route clicks there when the flag is set."""
+
+    def test_player_runs_in_background_so_a_no_hijack_window_keeps_ticking(self):
+        """#1466 ROOT CAUSE: a macOS player with Run-In-Background OFF pauses its player loop (Update,
+        coroutines, input) while it is not the foreground app — and the no-hijack launch never activates
+        it. So the surface poll AND any injected click froze. The fix must force run-in-background both at
+        runtime (CombatSurfaceClient) and at build time (BuildMacOSPlayer)."""
+        csc = CSHARP.read_text(encoding="utf-8")
+        self.assertIn("Application.runInBackground = true", csc,
+                      "the client must force run-in-background at runtime (no-hijack window would freeze)")
+        build = (ROOT / "extensions" / "renderers" / "unity" / "scripts" / "BuildMacOSPlayer.cs").read_text(encoding="utf-8")
+        self.assertIn("PlayerSettings.runInBackground = true", build,
+                      "the build must bake run-in-background so the player ticks from frame 0")
+
+    def test_player_click_path_is_coordinate_refactored_and_shared(self):
+        src = CSHARP.read_text(encoding="utf-8")
+        # HandleClick is now a thin wrapper over a coordinate-level handler both a mouse and the channel use.
+        self.assertIn("void HandleClickAt(Vector3 screenPoint)", src)
+        self.assertIn("void HandleClick() { HandleClickAt(Input.mousePosition); }", src)
+        self.assertIn("ScreenPointToRay(screenPoint)", src, "raycast must use the injected screen point")
+        # The cell-level validation+POST is a shared method both the raycast and the QA cell path run —
+        # NOT a DoMove/DoAttack shortcut (still honors rest-vs-combat + #1441 pre-validation).
+        self.assertIn("void HandleCell(int c, int r)", src)
+        self.assertIn("HandleCell(c, r)", src, "HandleClickAt must delegate the post-raycast half to HandleCell")
+
+    def test_player_channel_is_env_gated_localhost_and_main_thread(self):
+        src = CSHARP.read_text(encoding="utf-8")
+        # OFF by default: only started when WORLDOS_QA_INPUT=1 (byte-identical player otherwise).
+        self.assertIn('GetEnvironmentVariable("WORLDOS_QA_INPUT") == "1"', src)
+        self.assertIn("StartQaInput", src)
+        self.assertIn("WORLDOS_QA_INPUT_PORT", src, "port must be configurable (env-contract style)")
+        # localhost-only bind, /click + /health endpoints.
+        self.assertIn('"http://127.0.0.1:"', src, "listener must bind localhost only")
+        self.assertIn("HttpListener", src)
+        self.assertIn("/click", src)
+        self.assertIn("/health", src)
+        self.assertIn("screenH", src, "/health must report Screen.height so a pixel caller can undo the titlebar")
+        # Both request shapes dispatch on the MAIN thread (queue drained in Update).
+        self.assertIn("ConcurrentQueue<QaCmd>", src, "queue must hold a cell-or-viewport command")
+        self.assertIn("_qaClicks.TryDequeue", src, "queued clicks must be drained on the main thread in Update")
+        self.assertIn("if (qc.cell) HandleCell(qc.c, qc.r)", src, "a cell request must run HandleCell on the main thread")
+        self.assertIn("Screen.width", src)
+
+    def test_core_exports_qa_channel_helpers(self):
+        src = CORE.read_text(encoding="utf-8")
+        for fn in ("function qaClickCell(port, c, r)", "function qaClick(port, vx, vy)", "function qaHealth(port)"):
+            self.assertIn(fn, src)
+        for ex in ("qaClick,", "qaClickCell,", "qaHealth,"):
+            self.assertIn(ex, src, f"core must export {ex}")
+        self.assertIn("/click", src)
+        self.assertIn("/health", src)
+
+    def test_driver_uses_cell_path_and_server_uses_calibrated_viewport(self):
+        drv = SMOKE_DRIVER.read_text(encoding="utf-8")
+        self.assertIn("QA_INPUT_PORT", drv)
+        # The smoke knows the target cell -> robust cell path (no pixel/titlebar calibration).
+        self.assertIn("core.qaClickCell(QA_INPUT_PORT, target.c, target.r)", drv)
+        srv = SERVER.read_text(encoding="utf-8")
+        self.assertIn("QA_INPUT_PORT", srv)
+        # The T3 AI clicks screenshot pixels -> viewport path, titlebar-corrected via /health.
+        self.assertIn("core.qaClick(QA_INPUT_PORT", srv, "T3 palette must route pixel clicks through the channel")
+        self.assertIn("qaHealthCached()", srv, "server must fetch Screen dims to undo the titlebar band")
+        self.assertIn("winCache.ph - screenH", srv, "titlebar band = captured height - Screen.height")
+
+    def test_runners_launch_player_with_qa_input_enabled(self):
+        for runner in (SMOKE_RUNNER, ROOT / "qa" / "ui_playtest_player.sh"):
+            text = runner.read_text(encoding="utf-8")
+            self.assertIn("WORLDOS_QA_INPUT=1", text, f"{runner.name} must launch the player with the channel on")
+            self.assertIn("WORLDOS_QA_INPUT_PORT", text)
+
+    @unittest.skipUnless(shutil.which("node") and shutil.which("curl"), "node/curl not available")
+    def test_qa_channel_round_trips_cell_viewport_and_health_over_http(self):
+        """Functional: qaClickCell POSTs {c,r}, qaClick POSTs {vx,vy} (both to /click), and qaHealth
+        GETs the player's Screen dims — proving the JS->HTTP contract the player listener implements."""
+        import http.server, threading, json as _json
+        posts = []
+
+        class H(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a): pass
+            def _send(self, obj):
+                body = _json.dumps(obj).encode()
+                self.send_response(200); self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body))); self.end_headers()
+                self.wfile.write(body)
+            def do_POST(self):
+                n = int(self.headers.get("Content-Length", 0))
+                rec = _json.loads(self.rfile.read(n) or b"{}"); rec["path"] = self.path
+                posts.append(rec); self._send({"ok": True})
+            def do_GET(self):
+                self._send({"ok": True, "screenW": 1280, "screenH": 800})
+
+        srv = http.server.HTTPServer(("127.0.0.1", 0), H)
+        port = srv.server_address[1]
+        t = threading.Thread(target=srv.serve_forever, daemon=True); t.start()
+        try:
+            script = (
+                f'const core = require({json.dumps(str(CORE))});\n'
+                f'const cell = core.qaClickCell({port}, 9, 8);\n'
+                f'const vp = core.qaClick({port}, 0.5, 0.25);\n'
+                f'const h = core.qaHealth({port});\n'
+                f'console.log(JSON.stringify({{cell, vp, h}}));\n'
+            )
+            r = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+            self.assertEqual(r.returncode, 0, f"qa-channel node call failed:\n{r.stderr}")
+            out = json.loads(r.stdout.strip().splitlines()[-1])
+            self.assertTrue(out["cell"]["ok"] and out["cell"]["delivery"] == "qa-channel")
+            self.assertTrue(out["vp"]["ok"])
+            self.assertEqual(out["h"].get("screenH"), 800, "qaHealth must return the player's Screen.height")
+            cell_post = next(p for p in posts if p["path"] == "/click" and "c" in p)
+            self.assertEqual((cell_post["c"], cell_post["r"]), (9, 8))
+            vp_post = next(p for p in posts if p["path"] == "/click" and "vx" in p)
+            self.assertAlmostEqual(vp_post["vx"], 0.5); self.assertAlmostEqual(vp_post["vy"], 0.25)
+        finally:
+            srv.shutdown()
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/qa/ui_playtest_player.sh
+++ b/qa/ui_playtest_player.sh
@@ -177,6 +177,10 @@ owner_active_guard || exit $?
 # --- free port in 8990–8999 (pick_port from lib_native_player_boot.sh) -------
 PORT="$(pick_port)" || { echo "[t3] no free port in 8990-8999 — aborting" >&2; exit 3; }
 BASE_URL="http://127.0.0.1:$PORT"
+# #1466 QA INPUT CHANNEL port (engine port +100, unique per run): the player opens an in-process
+# localhost click listener and the palette routes clicks there (viewport coord -> HandleClickAt) —
+# OS-synthetic mouse never reaches a no-activation Unity window (HID/postToPid/activation REFUTED, #1466).
+QA_INPUT_PORT="$((PORT + 100))"
 
 # --- seed the pre-minted combat campaign (engine = sole writer) --------------
 # uv --directory cd's into servers/engine, so pass the seed by ABSOLUTE path (per its docstring).
@@ -209,9 +213,9 @@ PY
 
 # --- PLAYER MCP config: ONLY the NATIVE palette server (strict, no other tools). The palette treats
 # WORLDOS_NPT_RUNDIR as the RUN ROOT (bugs.ndjson + status.json there; screenshots/actions under player/).
-python3 - "$NPT_DIR" "$RUNDIR" "$OWNER" "$SDK_NM" "$PLAYER_CFG" <<'PY'
+python3 - "$NPT_DIR" "$RUNDIR" "$OWNER" "$SDK_NM" "$PLAYER_CFG" "$QA_INPUT_PORT" <<'PY'
 import json, sys
-npt_dir, rundir, owner, node_modules, out = sys.argv[1:6]
+npt_dir, rundir, owner, node_modules, out, qa_port = sys.argv[1:7]
 json.dump({"mcpServers": {"worldos-nativeplayer": {
     "command": "node",
     "args": [f"{npt_dir}/native_palette_server.js"],
@@ -220,6 +224,9 @@ json.dump({"mcpServers": {"worldos-nativeplayer": {
         "WORLDOS_NPT_PERSONA": "t3-native",
         "WORLDOS_NPT_WINDOW_OWNER": owner,
         "WORLDOS_NPT_NODE_MODULES": node_modules,
+        # #1466: route the palette's click tool through the player's QA input channel.
+        "WORLDOS_QA_INPUT": "1",
+        "WORLDOS_QA_INPUT_PORT": qa_port,
     },
 }}}, open(out, "w"))
 PY
@@ -280,10 +287,13 @@ PLAYER_WIN_ARGS=(); while IFS= read -r __a; do PLAYER_WIN_ARGS+=("$__a"); done <
 # #1463 W6.4: WORLDOS_ONBOARD=1 turns on the onboarding readability layer (whose-turn/name plates + the
 # affordance hint + walkability overlay ON for the first turn) for this player-session gate. Beauty captures
 # launch WITHOUT it (byte-identical), so onboarding is opt-in per the existing WORLDOS_PLAYTEST pattern.
-WORLDOS_ENGINE_BASE_URL="$BASE_URL" WORLDOS_CAMPAIGN_ID="$CID" WORLDOS_ONBOARD=1 "$PLAYER_BIN" "${PLAYER_WIN_ARGS[@]}" \
+# #1466/#1477: WORLDOS_QA_INPUT=1 opens the in-process HTTP QA channel (titlebar-immune viewport click
+# path) this T3 palette run drives instead of OS-synthetic mouse; port = engine port + 100.
+WORLDOS_ENGINE_BASE_URL="$BASE_URL" WORLDOS_CAMPAIGN_ID="$CID" WORLDOS_ONBOARD=1 \
+WORLDOS_QA_INPUT=1 WORLDOS_QA_INPUT_PORT="$QA_INPUT_PORT" "$PLAYER_BIN" "${PLAYER_WIN_ARGS[@]}" \
   > "$RUNDIR/player_app.log" 2>&1 &
 PLAYER_APP_PID=$!
-echo "[t3] player app launched WINDOWED (pid $PLAYER_APP_PID) — engine=$BASE_URL campaign=$CID args=${PLAYER_WIN_ARGS[*]}"
+echo "[t3] player app launched WINDOWED (pid $PLAYER_APP_PID) — engine=$BASE_URL campaign=$CID qa_input=:$QA_INPUT_PORT args=${PLAYER_WIN_ARGS[*]}"
 # Give the Unity build a beat to open its window + first combat-surface fetch before the agent looks.
 sleep 6
 


### PR DESCRIPTION
## Summary
- **Topology note:** #1477 ("QA input channel + run-in-background", squash `8a69798c`) merged into feature branch `w6/1466-pid-targeted-click`, not `main` — nobody opened the branch→main PR. Meanwhile #1484 merged straight to `main` (squash `ce810eb0`), touching the same area (activate-fallback default-on + `Application.runInBackground`). This PR lands #1477's content on `main`, discovered/fixed during #1484 shepherding.
- **What it carries:** the cell-based `/click {c,r}` HTTP QA input channel (env-gated `WORLDOS_QA_INPUT=1`, OFF by default = byte-identical player) — titlebar-immune, zero-activation, the PREFERRED deterministic T3/smoke click path. Routes through the same `HandleClickAt`/`HandleCell` rest-vs-combat + #1441 pre-validation + POST path a human click takes (not a shortcut).
- **Dedupe vs #1484:** `CombatSurfaceClient.Start()`'s `Application.runInBackground = true` was already landed by #1484/#1483 as a runtime backstop — kept that single line + its comment, dropped #1477's duplicate comment block (both explained the same one-line fix). `BuildMacOSPlayer.cs`'s baked `PlayerSettings.runInBackground = true` was NOT a duplicate (build-time bake vs runtime backstop) and is newly added here.
- **Composition with #1484's activate-fallback:** the cell channel is tried FIRST when the player exposes it (`QA_INPUT_PORT` set); the synthetic-click + activate-fallback path (default-on, authoritative env opt-out per #1483/#1484) remains the fallback when the channel isn't enabled. Both mechanisms now coexist in `player_smoke_driver.js`, `native_palette_server.js`, and `ui_playtest_player.sh` (which now launches with both `WORLDOS_ONBOARD=1` and `WORLDOS_QA_INPUT=1` set).
- Research register entry (`docs/research/2026-07-10-stage-tech-research.md`) kept `main`'s existing row, which already documents both mechanisms together and supersedes #1477's narrower version.

## Test plan
- [x] `uv run --directory servers/engine python -m pytest ../../qa/test_native_palette.py -q -p no:xdist` — 39 passed, 2 subtests passed
- [x] No merge-conflict markers remain in any touched file
- [x] Diff vs `origin/main` reviewed hunk-by-hunk; no duplicate `Application.runInBackground` lines