### PR TITLE
anim-pack: shared humanoid AnimatorController — real idle/walk/attack/hit/death for all humanoid actors (#1408)

### DIFF
--- a/data/asset-registry/registry.json
+++ b/data/asset-registry/registry.json
@@ -118,11 +118,13 @@
       "model_ref": "Assets/painterly/models/hero.fbx",
       "albedo_ref": "Assets/painterly/models/hero_albedo.png",
       "anim_ref": "Assets/painterly/models/hero@moveset.fbx",
-      "gen_recipe": "DEFAULT TEMPLATE: any character without a model resolves here.",
+      "gen_recipe": "DEFAULT TEMPLATE: any character without a model resolves here. #anim-pack (#1408): hero.fbx has a GENERIC (non-humanoid) rig — anim_pack_avatar_gate.cs re-imported it as Humanoid/CreateFromThisModel but auto-mapping could not produce a valid humanoid avatar (isHuman=false, isValid=true), so it CANNOT retarget the shared RPG-pack controller. It stays on the per-frame idle/donor graph fallback (its own embedded idle clip) and is flagged needs_remodel pending a proper humanoid rig.",
       "version": "1.0.0",
       "critic_score": 7.4,
       "default_used": false,
-      "is_template": true
+      "is_template": true,
+      "humanoid": false,
+      "needs_remodel": true
     },
     "template_demon": {
       "kind": "monster",
@@ -213,20 +215,22 @@
       "model_ref": "Assets/chars_v2/giant_spider/rigged.fbx",
       "albedo_ref": "Assets/chars_v2/giant_spider/albedo.jpg",
       "anim_ref": "Assets/chars_v2/giant_spider/anim_walk.fbx",
-      "gen_recipe": "tripo:text-to-model -> rig-check(octopod) -> rig(spec=tripo) -> retarget walk only (idle preset unsupported for octopod, non-fatal skip); rigged.fbx imported animationType=Generic (Tripo bone names do not auto-map to Unity Humanoid avatar); albedo from model.glb embedded PBR (wave-2 monster cast #1305). CAVEAT: bind-pose-vs-walk-pose curH mismatch inflated render scale (see qa/evidence/1305 render + PR notes) - follow-up recommended, not blocking.",
+      "gen_recipe": "tripo:text-to-model -> rig-check(octopod) -> rig(spec=tripo) -> retarget walk only (idle preset unsupported for octopod, non-fatal skip); rigged.fbx imported animationType=Generic (Tripo bone names do not auto-map to Unity Humanoid avatar); albedo from model.glb embedded PBR (wave-2 monster cast #1305). CAVEAT: bind-pose-vs-walk-pose curH mismatch inflated render scale (see qa/evidence/1305 render + PR notes) - follow-up recommended, not blocking. #anim-pack: NON-BIPED by design (octopod) -> keeps the per-frame graph fallback, never the humanoid RPG-pack controller.",
       "version": "1.0.0",
       "critic_score": 0.0,
-      "default_used": false
+      "default_used": false,
+      "humanoid": false
     },
     "dire_rat": {
       "kind": "monster",
       "model_ref": "Assets/chars_v2/dire_rat/rigged.fbx",
       "albedo_ref": "Assets/chars_v2/dire_rat/albedo.jpg",
       "anim_ref": "Assets/chars_v2/dire_rat/anim_walk.fbx",
-      "gen_recipe": "tripo:text-to-model -> rig-check(quadruped) -> rig(spec=tripo) -> retarget walk only (idle preset unsupported for quadruped, non-fatal skip); rigged.fbx imported animationType=Generic (Tripo bone names do not auto-map to Unity Humanoid avatar); albedo from model.glb embedded PBR (wave-2 monster cast #1305)",
+      "gen_recipe": "tripo:text-to-model -> rig-check(quadruped) -> rig(spec=tripo) -> retarget walk only (idle preset unsupported for quadruped, non-fatal skip); rigged.fbx imported animationType=Generic (Tripo bone names do not auto-map to Unity Humanoid avatar); albedo from model.glb embedded PBR (wave-2 monster cast #1305). #anim-pack: NON-BIPED by design (quadruped) -> keeps the per-frame graph fallback, never the humanoid RPG-pack controller.",
       "version": "1.0.0",
       "critic_score": 0.0,
-      "default_used": false
+      "default_used": false,
+      "humanoid": false
     }
   }
 }

--- a/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
+++ b/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
@@ -111,6 +111,20 @@ public static class BuildMacOSPlayer
                     }
                 }
             }
+            // #anim-pack: also bake the SHARED humanoid AnimatorController so the runtime can retarget it onto
+            // humanoid actors (CombatSurfaceClient.HumanoidController). BuildAssetBundles pulls its dependencies
+            // — the RPG-pack Idle/Walk/Run/Attack/Hit/Death clips + blend tree — in automatically, so only the
+            // .controller path is listed. Absent on disk (controller not yet built by
+            // build_worldos_humanoid_controller.cs) -> skipped, and the runtime falls back to the per-frame
+            // graph path (byte-identical). Keep this path in sync with CombatSurfaceClient.HumanoidControllerPath.
+            const string HumanoidCtrl = "Assets/Animations/WorldOSHumanoid.controller";
+            if (!string.IsNullOrEmpty(AssetDatabase.AssetPathToGUID(HumanoidCtrl)))
+            {
+                if (!names.Contains(HumanoidCtrl)) names.Add(HumanoidCtrl);
+                Debug.Log("[Package] +humanoid controller " + HumanoidCtrl);
+            }
+            else Debug.LogWarning("[Package] humanoid controller missing on disk, skipped: " + HumanoidCtrl);
+
             if (names.Count == 0) { Debug.LogWarning("[Package] no resolvable registry assets — bundle not built"); return; }
 
             // 3) build the bundle for StandaloneOSX to a temp dir, then copy the main bundle file into

--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -171,6 +171,18 @@ public class CombatSurfaceClient : MonoBehaviour
     // evaluates every frame (a one-shot pose cannot hold a skinned pose — see PlayIdleGraph). Torn down by
     // KillIdleGraph on glide/attack start and on despawn.
     readonly System.Collections.Generic.Dictionary<string, UnityEngine.Playables.PlayableGraph> _idleGraphOf = new System.Collections.Generic.Dictionary<string, UnityEngine.Playables.PlayableGraph>();
+    // #anim-pack (RPG Character Mecanim pack — the PERMANENT #1408 T-pose/roster fix): the SHARED humanoid
+    // AnimatorController (idle/walk/run + attack/hit/death states, driven by a Speed float + Attack/Hit/Death
+    // triggers) retargeted onto any actor whose Animator has a VALID humanoid avatar. A REAL controller keeps
+    // the Animator evaluating every frame, so it REPLACES the per-frame idle/walk/attack PlayableGraph
+    // workaround for humanoids; the graph paths (PlayIdleGraph/MakeClipGraph/donor retarget) stay as the
+    // FALLBACK for non-humanoid / clipless / controller-absent rigs — byte-identical to pre-#anim-pack when the
+    // controller can't load or the avatar isn't humanoid. _ctrlDriven tracks who the controller currently
+    // drives (every glide/attack/hit/death/idle branch keys off it). Parameter names must match the controller
+    // built by build_worldos_humanoid_controller.cs.
+    const string HumanoidControllerPath = "Assets/Animations/WorldOSHumanoid.controller";
+    RuntimeAnimatorController _humanoidCtrl; bool _humanoidCtrlTried;
+    readonly System.Collections.Generic.HashSet<string> _ctrlDriven = new System.Collections.Generic.HashSet<string>();
     string _currentId = "";        // the isCurrent combatant this surface (active-turn ring-pulse anchor)
     string _pulsePrev = "";        // last-pulsed ring, reset to rest when the turn moves on
 
@@ -754,7 +766,13 @@ public class CombatSurfaceClient : MonoBehaviour
                 if (tgt != null)
                 {
                     FloatDamage(tgt.position, "-" + (prevHp - newHp), new Color(1f, 0.95f, 0.45f, 1f));
-                    if (newHp > 0) StartCoroutine(FlinchCo(tgt, attacker != null ? attacker.position : tgt.position - tgt.forward));
+                    if (newHp > 0)
+                    {
+                        // #anim-pack: fire the controller's Hit reaction (the transform knockback flinch still
+                        // runs on top for any rig). Controller-absent actors just flinch, as before.
+                        if (_ctrlDriven.Contains(t.id)) { var han = tgt.GetComponentInChildren<Animator>(); if (han != null) han.SetTrigger("Hit"); }
+                        StartCoroutine(FlinchCo(tgt, attacker != null ? attacker.position : tgt.position - tgt.forward));
+                    }
                     if (attacker != null && attacker != tgt) StartCoroutine(LungeCo(attacker, _currentId, tgt.position));
                 }
             }
@@ -1020,6 +1038,18 @@ public class CombatSurfaceClient : MonoBehaviour
         return b.LoadAsset<T>(assetPath);
     }
 
+    // #anim-pack: the shared humanoid controller, loaded ONCE from the actor bundle by HumanoidControllerPath.
+    // Baked into worldos_actors (with its pack clip dependencies) by BuildMacOSPlayer.EnsurePackaged. Absent
+    // (an un-repackaged/old bundle) -> null -> every actor uses the per-frame graph fallback (byte-identical).
+    RuntimeAnimatorController HumanoidController()
+    {
+        if (_humanoidCtrlTried) return _humanoidCtrl;
+        _humanoidCtrlTried = true;
+        _humanoidCtrl = LoadAsset<RuntimeAnimatorController>(HumanoidControllerPath);
+        Debug.Log("[CSC] humanoid controller " + (_humanoidCtrl != null ? "loaded" : "absent") + " @" + HumanoidControllerPath);
+        return _humanoidCtrl;
+    }
+
     // Parse StreamingAssets/registry.json into the same assets/defaults/aliases maps paint_combat_v1
     // reads. Uses a self-contained parser (MiniJson lives in the editor-only assembly and is not
     // available to this runtime MonoBehaviour). Absent/corrupt -> null maps -> resolve falls to the
@@ -1196,12 +1226,25 @@ public class CombatSurfaceClient : MonoBehaviour
         float height = foe ? ActorHeightFoe : ActorHeightChar;   // #1441: named, single-source heights
         float sc = height / curH; go.transform.localScale = go.transform.localScale * sc;
 
-        // Pose to a neutral idle for the VISUAL now that scale is locked. #idle-persist: start a PERSISTENT
-        // idle graph (Update evaluates it each frame) — a one-shot Evaluate cannot hold a SKINNED pose (a
-        // disabled Animator freezes GPU skinning at bind; an enabled controllerless Animator reverts to bind),
-        // so the idle must be a live graph like the walk glide. Resolve the clip: own idle (model OR moveset),
-        // else the model's first clip, else the goblin donor idle retargeted onto a clipless humanoid rig.
-        PlayIdleGraph(go, id, ResolveIdleClip(id, fbx, go));
+        // #anim-pack: a VALID humanoid avatar retargets the shared RPG-pack controller (idle/walk/run +
+        // attack/hit/death, driven by Speed + triggers). A real controller keeps the Animator evaluating every
+        // frame, so the bind-pose revert the per-frame idle graph worked around (#1408/#idle-persist) cannot
+        // happen — this is the permanent T-pose fix. Assigned AFTER the bind-pose scale lock so the controller's
+        // idle first frame can't inflate the height; animC.Update(0f) settles that idle before the grounding
+        // Measure below. Non-humanoid / clipless / controller-absent actors fall through to the persistent idle
+        // graph (byte-identical to pre-#anim-pack).
+        bool ctrlDriven = false;
+        if (animC != null && animC.avatar != null && animC.avatar.isHuman)
+        {
+            var hc = HumanoidController();
+            if (hc != null) { animC.runtimeAnimatorController = hc; animC.applyRootMotion = false; animC.Update(0f); ctrlDriven = true; _ctrlDriven.Add(id); }
+        }
+        // Pose to a neutral idle for the VISUAL now that scale is locked (fallback path). #idle-persist: start a
+        // PERSISTENT idle graph (Update evaluates it each frame) — a one-shot Evaluate cannot hold a SKINNED
+        // pose (a disabled Animator freezes GPU skinning at bind; an enabled controllerless Animator reverts to
+        // bind), so the idle must be a live graph like the walk glide. Resolve the clip: own idle (model OR
+        // moveset), else the model's first clip, else the goblin donor idle retargeted onto a clipless rig.
+        if (!ctrlDriven) PlayIdleGraph(go, id, ResolveIdleClip(id, fbx, go));
 
         // Ground + center on the cell: feet to FloorY, bounds-center X/Z to the cell.
         Vector3 p = CellToWorld(cx, cy); go.transform.position = p; bb = Measure(go, rends); Vector3 ctr = bb.center;
@@ -1263,6 +1306,7 @@ public class CombatSurfaceClient : MonoBehaviour
         _glide.Remove(id); _cellOf.Remove(id); _fbxOf.Remove(id);
         _animOf.Remove(id); _topOf.Remove(id); RemoveHpBar(id);   // #anim-combat: clear combat/anim state
         _downed.Remove(id); _downRunning.Remove(id); _reviveWanted.Remove(id); _downPose.Remove(id);
+        _ctrlDriven.Remove(id);   // #anim-pack: forget controller-driven state so a re-spawn re-resolves the avatar
         Debug.Log("[CSC] despawned Actor_" + id);
     }
 
@@ -1468,15 +1512,27 @@ public class CombatSurfaceClient : MonoBehaviour
         // generic clips correctly in builds. So: pick the walk clip (own model/moveset, else a humanoid donor
         // for a clipless humanoid rig) and drive it through the graph whenever the actor has an Animator+avatar;
         // SampleAnimation stays only as the legacy/no-Animator fallback.
-        AnimationClip walkClip = FindOwnClip(id, "walk", "run");
         var walkAnim = go.GetComponentInChildren<Animator>();
-        if (walkClip == null && walkAnim != null && walkAnim.avatar != null && walkAnim.avatar.isHuman) walkClip = DonorWalk();
-        KillIdleGraph(id);   // #idle-persist: stop the idle graph so it doesn't fight the walk graph over the Animator
+        bool cd = _ctrlDriven.Contains(id);   // #anim-pack: controller-driven -> drive Speed, not a walk graph
+        AnimationClip walkClip = null;
         UnityEngine.Playables.PlayableGraph walkGraph = default; bool haveGraph = false; bool sampleWalk = false;
-        if (walkClip != null)
+        if (cd)
         {
-            if (walkAnim != null && walkAnim.avatar != null) { walkGraph = MakeClipGraph(walkAnim, walkClip, "Walk_" + a.name); haveGraph = true; _walkGraphOf[id] = walkGraph; }
-            else sampleWalk = true;   // no Animator/avatar -> legacy rig -> direct curve sample is the only path
+            // #anim-pack: the shared controller's Locomotion blend plays walk/run off the Speed float; the
+            // Animator self-updates in the player loop, so there is NO per-frame graph Evaluate here. Speed is
+            // set to the glide's planar rate so the blend picks a stride matching the cell->cell tween.
+            if (walkAnim != null) walkAnim.SetFloat("Speed", GlideSpeed);
+        }
+        else
+        {
+            walkClip = FindOwnClip(id, "walk", "run");
+            if (walkClip == null && walkAnim != null && walkAnim.avatar != null && walkAnim.avatar.isHuman) walkClip = DonorWalk();
+            KillIdleGraph(id);   // #idle-persist: stop the idle graph so it doesn't fight the walk graph over the Animator
+            if (walkClip != null)
+            {
+                if (walkAnim != null && walkAnim.avatar != null) { walkGraph = MakeClipGraph(walkAnim, walkClip, "Walk_" + a.name); haveGraph = true; _walkGraphOf[id] = walkGraph; }
+                else sampleWalk = true;   // no Animator/avatar -> legacy rig -> direct curve sample is the only path
+            }
         }
 
         // total planar length for even-speed sampling across the (possibly multi-segment) route.
@@ -1505,7 +1561,8 @@ public class CombatSurfaceClient : MonoBehaviour
         // arrive: snap exact, tear down walk, return to a grounded idle facing the camera.
         MoveActorAndShadows(a, endPos);
         if (haveGraph) KillWalkGraph(id);   // registry-tracked destroy (#1451-review P2)
-        PoseIdle(go);
+        if (cd) { if (walkAnim != null) walkAnim.SetFloat("Speed", 0f); }   // #anim-pack: Speed 0 -> controller's Idle
+        else PoseIdle(go);
         var cam = Camera.main; float camYaw = cam != null ? cam.transform.eulerAngles.y : 45f;
         a.rotation = Quaternion.Euler(pitchX, camYaw + 180f, 0f);
         MoveActorAndShadows(a, GroundedPivot(a, cx, cy));   // re-ground the final idle pose (idempotent)
@@ -1520,6 +1577,16 @@ public class CombatSurfaceClient : MonoBehaviour
         if (go == null) return;
         string nm = go.name;
         string id = nm.StartsWith("Actor_") ? nm.Substring(6) : nm;
+        // #anim-pack: a controller-driven humanoid returns to Idle via the controller — Rebind clears any
+        // terminal Death / one-shot state (this is the revive path's stand-up), Update(0f) settles the pose,
+        // and Speed 0 selects Idle in the Locomotion blend. The glide/attack arrival paths set Speed directly
+        // (no Rebind), so this heavier reset only runs on first-sight/settle/revive.
+        if (_ctrlDriven.Contains(id))
+        {
+            var an = go.GetComponentInChildren<Animator>();
+            if (an != null) { an.Rebind(); an.Update(0f); an.SetFloat("Speed", 0f); }
+            return;
+        }
         string fbx; _fbxOf.TryGetValue(id, out fbx);
         PlayIdleGraph(go, id, ResolveIdleClip(id, fbx, go));
     }
@@ -2325,11 +2392,16 @@ public class CombatSurfaceClient : MonoBehaviour
         dir = dir.normalized;
         float pitchX = go.GetComponentInChildren<SkinnedMeshRenderer>() != null ? 0f : -90f;
         a.rotation = Quaternion.Euler(pitchX, Mathf.Atan2(dir.x, dir.z) * Mathf.Rad2Deg, 0f);
-        AnimationClip atk = FindOwnClip(id, "attack", "swing");
         var anim = go.GetComponentInChildren<Animator>();
-        KillIdleGraph(id);   // #idle-persist: stop the idle graph while the attack clip drives the Animator
+        bool cd = _ctrlDriven.Contains(id);   // #anim-pack: controller plays the Attack state, then auto-returns
         UnityEngine.Playables.PlayableGraph g = default; bool hg = false;
-        if (atk != null && anim != null && anim.avatar != null) { g = MakeClipGraph(anim, atk, "Atk_" + a.name); hg = true; }
+        if (cd) { if (anim != null) anim.SetTrigger("Attack"); }
+        else
+        {
+            AnimationClip atk = FindOwnClip(id, "attack", "swing");
+            KillIdleGraph(id);   // #idle-persist: stop the idle graph while the attack clip drives the Animator
+            if (atk != null && anim != null && anim.avatar != null) { g = MakeClipGraph(anim, atk, "Atk_" + a.name); hg = true; }
+        }
         float dur = 0.42f, t = 0f;
         while (t < dur && a != null)
         {
@@ -2343,7 +2415,7 @@ public class CombatSurfaceClient : MonoBehaviour
         if (hg && g.IsValid()) g.Destroy();
         if (a != null)
         {
-            PoseIdle(go);
+            if (!cd) PoseIdle(go);   // #anim-pack: the controller returns to Locomotion via the Attack->exit transition
             var cam = Camera.main; float camYaw = cam != null ? cam.transform.eulerAngles.y : 45f;
             a.rotation = Quaternion.Euler(pitchX, camYaw + 180f, 0f);
             MoveActorAndShadows(a, home);
@@ -2369,16 +2441,21 @@ public class CombatSurfaceClient : MonoBehaviour
         var go = a.gameObject;
         Vector3 home = a.position; Quaternion startRot = a.rotation;
         _downPose[id] = new DownPose { scale = a.localScale, rot = startRot };
-        AnimationClip death = FindOwnClip(id, "death", "dead", "die");
         var anim = go.GetComponentInChildren<Animator>();
+        bool cd = _ctrlDriven.Contains(id);   // #anim-pack: controller plays the Death state (terminal)
         UnityEngine.Playables.PlayableGraph g = default; bool hg = false;
-        if (death != null && anim != null && anim.avatar != null) { g = MakeClipGraph(anim, death, "Down_" + a.name); hg = true; }
+        if (cd) { if (anim != null) anim.SetTrigger("Death"); }
+        else
+        {
+            AnimationClip death = FindOwnClip(id, "death", "dead", "die");
+            if (death != null && anim != null && anim.avatar != null) { g = MakeClipGraph(anim, death, "Down_" + a.name); hg = true; }
+        }
         float dur = 0.85f, t = 0f;
         while (t < dur && a != null && !_reviveWanted.Contains(id))
         {
             t += Time.deltaTime; float u = t / dur;
             if (hg) g.Evaluate(Time.deltaTime);
-            else a.rotation = startRot * Quaternion.Euler(0f, 0f, Mathf.Lerp(0f, 85f, u));   // topple when no clip
+            else if (!cd) a.rotation = startRot * Quaternion.Euler(0f, 0f, Mathf.Lerp(0f, 85f, u));   // topple when no clip (controller plays Death)
             MoveActorAndShadows(a, home + new Vector3(0f, -0.25f * u, 0f));
             float dim = Mathf.Lerp(1f, 0.35f, u);
             FadeSibling(a.name, "_Ring", dim); FadeSibling(a.name, "_AO", dim);

--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -1234,7 +1234,11 @@ public class CombatSurfaceClient : MonoBehaviour
         // Measure below. Non-humanoid / clipless / controller-absent actors fall through to the persistent idle
         // graph (byte-identical to pre-#anim-pack).
         bool ctrlDriven = false;
-        if (animC != null && animC.avatar != null && animC.avatar.isHuman)
+        // #anim-pack: require isHuman AND isValid — an avatar flagged humanoid but INVALID (a broken bone
+        // map) cannot retarget the humanoid clips and would silently T-pose (the exact #1408 failure). This
+        // mirrors anim_pack_avatar_gate.cs's (isHuman && isValid) accept criterion; an invalid rig falls
+        // through to the per-frame graph fallback below.
+        if (animC != null && animC.avatar != null && animC.avatar.isHuman && animC.avatar.isValid)
         {
             var hc = HumanoidController();
             if (hc != null) { animC.runtimeAnimatorController = hc; animC.applyRootMotion = false; animC.Update(0f); ctrlDriven = true; _ctrlDriven.Add(id); }

--- a/extensions/renderers/unity/scripts/anim_pack_avatar_gate.cs
+++ b/extensions/renderers/unity/scripts/anim_pack_avatar_gate.cs
@@ -1,0 +1,65 @@
+// anim_pack_avatar_gate.cs — #1408 avatar gate. For every registry character/monster MODEL fbx, test
+// whether its avatar is a VALID humanoid (the precondition for the RPG-pack controller to retarget). A
+// broken/generic avatar is re-imported as Humanoid with auto-mapping (CreateFromThisModel) and re-tested.
+// Genuinely-unfixable rigs (auto-map can't resolve the required bones) are reported NEEDS_REMODEL — the
+// runtime keeps them on the per-frame graph fallback and the registry marks them needs_remodel (no hand-rig).
+//
+// Run on the GEX44 box:  unity-mcp code execute --no-safety-checks -f anim_pack_avatar_gate.cs
+// NO top-level `using`; no LINQ. Prints one MODEL line per model for the caller to fold into registry.json.
+var sb = new System.Text.StringBuilder();
+
+// Quadrupeds/vermin are non-humanoid BY DESIGN — never force them to Humanoid (they keep the fallback).
+var skipBiped = new System.Collections.Generic.HashSet<string>();
+skipBiped.Add("giant_spider"); skipBiped.Add("dire_rat");
+
+// Read the project-root registry.json (the copy EnsurePackaged reads) and collect character/monster models.
+string projRoot = System.IO.Directory.GetParent(UnityEngine.Application.dataPath).FullName;
+string regPath = System.IO.Path.Combine(projRoot, "registry.json");
+if (!System.IO.File.Exists(regPath)) { return "NO registry.json at " + regPath; }
+var root = MiniJson.Parse(System.IO.File.ReadAllText(regPath)) as System.Collections.Generic.Dictionary<string, object>;
+var assets = (root != null && root.ContainsKey("assets")) ? root["assets"] as System.Collections.Generic.Dictionary<string, object> : null;
+if (assets == null) { return "NO assets block in registry.json"; }
+
+// Load an FBX's embedded Avatar sub-asset (null if none).
+System.Func<string, UnityEngine.Avatar> avatarOf = (path) => {
+    var all = UnityEditor.AssetDatabase.LoadAllAssetsAtPath(path);
+    for (int i = 0; i < all.Length; i++) { var av = all[i] as UnityEngine.Avatar; if (av != null) return av; }
+    return null;
+};
+
+var seen = new System.Collections.Generic.HashSet<string>();
+foreach (var kv in assets) {
+    var row = kv.Value as System.Collections.Generic.Dictionary<string, object>; if (row == null) continue;
+    string kind = row.ContainsKey("kind") ? row["kind"] as string : "";
+    if (kind != "character" && kind != "monster") continue;
+    string model = row.ContainsKey("model_ref") ? row["model_ref"] as string : null;
+    if (string.IsNullOrEmpty(model) || !model.ToLower().EndsWith(".fbx")) continue;
+    if (seen.Contains(model)) continue; seen.Add(model);
+    string slug = kv.Key;
+
+    if (string.IsNullOrEmpty(UnityEditor.AssetDatabase.AssetPathToGUID(model))) { sb.AppendLine("MODEL " + slug + " " + model + " -> MISSING_ON_DISK"); continue; }
+    if (skipBiped.Contains(slug)) { sb.AppendLine("MODEL " + slug + " " + model + " -> SKIP_NONBIPED"); continue; }
+
+    var imp = UnityEditor.AssetImporter.GetAtPath(model) as UnityEditor.ModelImporter;
+    if (imp == null) { sb.AppendLine("MODEL " + slug + " " + model + " -> NO_MODEL_IMPORTER"); continue; }
+
+    var av0 = avatarOf(model);
+    bool h0 = av0 != null && av0.isHuman; bool v0 = av0 != null && av0.isValid;
+    string before = "H" + (h0 ? "1" : "0") + "V" + (v0 ? "1" : "0");
+
+    if (h0 && v0) { sb.AppendLine("MODEL " + slug + " " + model + " before=" + before + " -> ALREADY_HUMANOID"); continue; }
+
+    // Attempt the fix: re-import as Humanoid with auto-mapping from this model's own skeleton.
+    imp.animationType = UnityEditor.ModelImporterAnimationType.Human;
+    imp.avatarSetup = UnityEditor.ModelImporterAvatarSetup.CreateFromThisModel;
+    imp.SaveAndReimport();
+    UnityEditor.AssetDatabase.ImportAsset(model, UnityEditor.ImportAssetOptions.ForceUpdate);
+
+    var av1 = avatarOf(model);
+    bool h1 = av1 != null && av1.isHuman; bool v1 = av1 != null && av1.isValid;
+    string after = "H" + (h1 ? "1" : "0") + "V" + (v1 ? "1" : "0");
+    string verdict = (h1 && v1) ? "FIXED" : "NEEDS_REMODEL";
+    sb.AppendLine("MODEL " + slug + " " + model + " before=" + before + " after=" + after + " -> " + verdict);
+}
+UnityEditor.AssetDatabase.SaveAssets();
+return sb.ToString();

--- a/extensions/renderers/unity/scripts/anim_pack_avatar_gate.cs
+++ b/extensions/renderers/unity/scripts/anim_pack_avatar_gate.cs
@@ -49,7 +49,11 @@ foreach (var kv in assets) {
 
     if (h0 && v0) { sb.AppendLine("MODEL " + slug + " " + model + " before=" + before + " -> ALREADY_HUMANOID"); continue; }
 
-    // Attempt the fix: re-import as Humanoid with auto-mapping from this model's own skeleton.
+    // Attempt the fix: re-import as Humanoid with auto-mapping from this model's own skeleton. Capture the
+    // original importer settings first so a FAILED fix restores them (never leave a half-changed import that
+    // couldn't become a valid humanoid — the runtime keeps such a rig on the per-frame fallback either way).
+    var origType = imp.animationType;
+    var origSetup = imp.avatarSetup;
     imp.animationType = UnityEditor.ModelImporterAnimationType.Human;
     imp.avatarSetup = UnityEditor.ModelImporterAvatarSetup.CreateFromThisModel;
     imp.SaveAndReimport();
@@ -58,7 +62,16 @@ foreach (var kv in assets) {
     var av1 = avatarOf(model);
     bool h1 = av1 != null && av1.isHuman; bool v1 = av1 != null && av1.isValid;
     string after = "H" + (h1 ? "1" : "0") + "V" + (v1 ? "1" : "0");
-    string verdict = (h1 && v1) ? "FIXED" : "NEEDS_REMODEL";
+    bool fixedOk = h1 && v1;
+    if (!fixedOk)
+    {
+        // restore the original import settings so a needs-remodel rig is left exactly as it was found.
+        imp.animationType = origType;
+        imp.avatarSetup = origSetup;
+        imp.SaveAndReimport();
+        UnityEditor.AssetDatabase.ImportAsset(model, UnityEditor.ImportAssetOptions.ForceUpdate);
+    }
+    string verdict = fixedOk ? "FIXED" : "NEEDS_REMODEL";
     sb.AppendLine("MODEL " + slug + " " + model + " before=" + before + " after=" + after + " -> " + verdict);
 }
 UnityEditor.AssetDatabase.SaveAssets();

--- a/extensions/renderers/unity/scripts/build_worldos_humanoid_controller.cs
+++ b/extensions/renderers/unity/scripts/build_worldos_humanoid_controller.cs
@@ -1,0 +1,116 @@
+// build_worldos_humanoid_controller.cs — build the SHARED humanoid AnimatorController from the
+// Explosive LLC "RPG Character Mecanim Animation Pack" (all clips are Humanoid -> retarget onto ANY
+// valid humanoid avatar). This is the #1408 permanent T-pose fix: CombatSurfaceClient assigns this
+// controller to every actor whose Animator has a valid humanoid avatar and drives it with a Speed
+// float (Locomotion blend: idle/walk/run) + Attack/Hit/Death triggers.
+//
+// Run on the GEX44 box:  unity-mcp code execute --no-safety-checks -f build_worldos_humanoid_controller.cs
+// NO top-level `using` — `code execute` wraps the snippet in a method body where `using` is illegal
+// (mirrors the proven build_combat_animator.cs / paint_3d_spike.cs). No LINQ either. Idempotent: the
+// controller is cleared + rebuilt clean every run, so re-running never duplicates states/params.
+//
+// PARAMETER NAMES ARE A CONTRACT with CombatSurfaceClient.cs: Speed (Float), Attack/Hit/Death (Trigger).
+var sb = new System.Text.StringBuilder();
+string CTRL = "Assets/Animations/WorldOSHumanoid.controller";
+
+// The pack clips (by their FBX filename, sans .FBX). Located via FindAssets so the exact subfolder
+// (Unarmed / Relax) doesn't matter. Run-Forward is the natural cell->cell stride at glide speed; the
+// Unarmed set has no plain walk, so Relax-Walk-Forward is the slow-walk blend point.
+string IDLE = "RPG-Character@Unarmed-Idle";
+string WALK = "RPG-Character@Relax-Walk-Forward";
+string RUN  = "RPG-Character@Unarmed-Run-Forward";
+string ATK  = "RPG-Character@Unarmed-Attack-R1";
+string HIT  = "RPG-Character@Unarmed-GetHit-F1";
+string DIE  = "RPG-Character@Unarmed-Death1";
+
+UnityEditor.AssetDatabase.Refresh();
+
+// Resolve an AnimationClip sub-asset by its owning FBX filename (FindAssets on the file, then scan its
+// sub-assets for the first non-"__" AnimationClip). Robust to which pack subfolder the clip lives in.
+System.Func<string, UnityEngine.AnimationClip> clipByName = (fname) => {
+    var guids = UnityEditor.AssetDatabase.FindAssets(fname);
+    for (int gi = 0; gi < guids.Length; gi++) {
+        string p = UnityEditor.AssetDatabase.GUIDToAssetPath(guids[gi]);
+        if (string.IsNullOrEmpty(p)) continue;
+        // require an exact filename match (FindAssets is a fuzzy contains-match)
+        string leaf = System.IO.Path.GetFileNameWithoutExtension(p);
+        if (leaf != fname) continue;
+        var imp = UnityEditor.AssetImporter.GetAtPath(p) as UnityEditor.ModelImporter;
+        if (imp != null && imp.animationType != UnityEditor.ModelImporterAnimationType.Human)
+            sb.AppendLine("WARN " + fname + " importer is " + imp.animationType + " not Humanoid (retarget may fail)");
+        var assets = UnityEditor.AssetDatabase.LoadAllAssetsAtPath(p);
+        for (int ai = 0; ai < assets.Length; ai++) {
+            var ac = assets[ai] as UnityEngine.AnimationClip;
+            if (ac != null && !ac.name.StartsWith("__")) return ac;
+        }
+    }
+    return null;
+};
+
+var idleC = clipByName(IDLE); var walkC = clipByName(WALK); var runC = clipByName(RUN);
+var atkC  = clipByName(ATK);  var hitC  = clipByName(HIT);  var dieC = clipByName(DIE);
+if (idleC == null) sb.AppendLine("MISSING clip " + IDLE);
+if (walkC == null) { sb.AppendLine("MISSING clip " + WALK + " -> using RUN for the walk blend point"); walkC = runC; }
+if (runC  == null) sb.AppendLine("MISSING clip " + RUN);
+if (atkC  == null) sb.AppendLine("MISSING clip " + ATK);
+if (hitC  == null) sb.AppendLine("MISSING clip " + HIT);
+if (dieC  == null) sb.AppendLine("MISSING clip " + DIE);
+
+// (Re)create the controller, cleared to a blank slate (idempotent rebuild).
+System.IO.Directory.CreateDirectory("Assets/Animations");
+var ctrl = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEditor.Animations.AnimatorController>(CTRL);
+if (ctrl == null) ctrl = UnityEditor.Animations.AnimatorController.CreateAnimatorControllerAtPath(CTRL);
+var pcopy = ctrl.parameters;
+foreach (var p in pcopy) ctrl.RemoveParameter(p);
+var sm = ctrl.layers[0].stateMachine;
+var scopy = sm.states;
+foreach (var cs in scopy) sm.RemoveState(cs.state);
+
+// Parameters (the CombatSurfaceClient contract).
+ctrl.AddParameter("Speed",  UnityEngine.AnimatorControllerParameterType.Float);
+ctrl.AddParameter("Attack", UnityEngine.AnimatorControllerParameterType.Trigger);
+ctrl.AddParameter("Hit",    UnityEngine.AnimatorControllerParameterType.Trigger);
+ctrl.AddParameter("Death",  UnityEngine.AnimatorControllerParameterType.Trigger);
+
+// Locomotion: a 1D blend on Speed (idle@0 / walk@1.5 / run@5). CreateBlendTreeInController adds the
+// state + tree to layer 0; it auto-adds a "Blend" float param which we repoint to "Speed" and drop.
+UnityEditor.Animations.BlendTree tree;
+var loco = ctrl.CreateBlendTreeInController("Locomotion", out tree, 0);
+tree.blendType = UnityEditor.Animations.BlendTreeType.Simple1D;
+tree.blendParameter = "Speed";
+tree.useAutomaticThresholds = false;
+if (idleC != null) tree.AddChild(idleC, 0f);
+if (walkC != null) tree.AddChild(walkC, 1.5f);
+if (runC  != null) tree.AddChild(runC, 5f);
+// drop the auto-added "Blend" param if CreateBlendTreeInController introduced one.
+var pcopy2 = ctrl.parameters;
+foreach (var p in pcopy2) if (p.name == "Blend") ctrl.RemoveParameter(p);
+sm.defaultState = loco;
+
+// One-shot verb states (Any-State triggered). Attack/Hit return to Locomotion after (near-)full play;
+// Death is terminal (holds prone — CombatSurfaceClient's DownCo owns the sink/dim, revive rebinds out).
+System.Func<string, UnityEngine.AnimationClip, UnityEditor.Animations.AnimatorState> verb = (nm, clip) => {
+    var st = sm.AddState(nm); st.motion = clip;
+    var anyT = sm.AddAnyStateTransition(st);
+    anyT.AddCondition(UnityEditor.Animations.AnimatorConditionMode.If, 0f, nm);
+    anyT.duration = 0.08f; anyT.hasExitTime = false; anyT.canTransitionToSelf = false;
+    return st;
+};
+var atkS = verb("Attack", atkC);
+var hitS = verb("Hit",    hitC);
+var dieS = verb("Death",  dieC);
+foreach (var st in new UnityEditor.Animations.AnimatorState[] { atkS, hitS }) {
+    var back = st.AddTransition(loco);
+    back.hasExitTime = true; back.exitTime = 0.85f; back.duration = 0.15f;
+}
+// Death: no back-transition (terminal); the revive path rebinds the Animator to the default state.
+
+UnityEditor.EditorUtility.SetDirty(ctrl);
+UnityEditor.AssetDatabase.SaveAssets();
+UnityEditor.AssetDatabase.Refresh();
+sb.AppendLine("WorldOSHumanoid.controller: states=" + sm.states.Length + " params=" + ctrl.parameters.Length
+    + " loco-children=" + tree.children.Length
+    + " clips[idle/walk/run/atk/hit/die]="
+    + (idleC != null ? "1" : "0") + (walkC != null ? "1" : "0") + (runC != null ? "1" : "0")
+    + (atkC != null ? "1" : "0") + (hitC != null ? "1" : "0") + (dieC != null ? "1" : "0"));
+return sb.ToString();


### PR DESCRIPTION
## ANIM-PACK — real humanoid animations for ALL humanoid actors (permanent #1408 T-pose/roster fix)

Integrates the owner-purchased **Explosive LLC "RPG Character Mecanim Animation Pack"** (1200+ Humanoid clips, imported on the GEX44 box) so every humanoid actor plays real idle / walk-run / attack / hit / death — killing the T-pose/roster class (#1408) permanently.

### Design — ONE shared runtime approach
A single **`Assets/Animations/WorldOSHumanoid.controller`** built from the pack's Humanoid clips: a `Speed`-float **Locomotion 1D blend** (idle→`Unarmed-Idle` / walk→`Relax-Walk-Forward` / run→`Unarmed-Run-Forward`) plus **Attack / Hit / Death** trigger states. Because pack clips are Humanoid they retarget onto ANY valid humanoid avatar. `CombatSurfaceClient` assigns the controller at spawn to any actor whose `Animator.avatar.isHuman`, then drives `Speed` during glide and `Attack`/`Hit`/`Death` triggers in the combat verbs — a **real controller keeps the Animator evaluating every frame**, so the bind-pose revert the per-frame idle graph worked around (#1408/#idle-persist) cannot happen. The per-frame idle/walk/attack graphs + goblin-donor retarget remain the **fallback** for non-humanoid / clipless / controller-absent rigs. Fully additive: controller absent OR avatar non-humanoid ⇒ byte-identical to prior behavior.

### Avatar gate (`anim_pack_avatar_gate.cs`, box-run) — #1408 root fix
| result | models |
|--------|--------|
| valid humanoid, retarget-ready (12) | fighter, mage, goblin, skeleton_archer\*, cultist\*, ghoul\*, innkeeper, patron_commoner, zombie, bandit, cult_leader, animated_armor |
| **needs_remodel** (1) | template_human / hero.fbx — generic rig, auto-map can't yield a valid humanoid avatar → per-frame fallback, no hand-rig |
| non-biped by design (2) | giant_spider (octopod), dire_rat (quadruped) → `humanoid:false`, fallback kept |

\* skeleton_archer/cultist/ghoul had BROKEN humanoid avatars — re-imported Humanoid (`CreateFromThisModel`) and now retarget.

### Per-model animation matrix (box, editor drive) — **12/12 PASS**
Every humanoid model: `idle=1 walk=1 atk=1 hit=1 death=1` (idle live/no-T-pose, locomotion animates, all verb states reached).

### Validation frames (box `Captures/`)
`animpack_01_idle.png`, `animpack_02_walk.png` (mid-stride), `animpack_03_attack.png` (mid-swing), `animpack_04_death.png` — grid of all 12 humanoid models; clearly distinct poses, zero T-poses.

### Step 0 — box compile fix (absorbed prereq)
The owner's concurrent A\*/DOTween/ExplosiveLLC/Hovl imports left the editor compile-broken: `HS_DemoShooting.cs(162)` CS0619 (obsolete `GetInstanceID()` as error) broke Assembly-CSharp (no asmdef). **Quarantined** `Assets/Hovl Studio/HSFiles/Scripts/For demo scenes/` (demo-scene glue; kept the real Hovl VFX runtime scripts) → editor compiles clean (Assembly-CSharp compiled=True). Tessera is isolated by its own asmdefs (left as-is); ExplosiveLLC demo Code compiles (warnings only). Manifest: `/home/unity/anim-pack-quarantine/`.

### Player build + packaging
- `BuildMacOSPlayer.EnsurePackaged` now bakes the controller (+ its pack-clip deps) into the `worldos_actors` bundle (`[Package] +humanoid controller`, `assets=45`).
- Full player rebuild: **result=Succeeded, 0 errors, 1 warning**, 401MB, universal (x64ARM64).
- Runtime smoke: the controller **loads from the shipped `.app` bundle by the exact runtime key** + models resolve.
- Refreshed `/home/unity/WorldOSPlayer.app.zip` (307MB) + `BuildOutput/` + `INSTALL.md` (what's-new note).

### Files
- `extensions/renderers/unity/scripts/CombatSurfaceClient.cs` — controller assign + Speed/trigger drive + `_ctrlDriven` fallback gating
- `extensions/renderers/unity/scripts/BuildMacOSPlayer.cs` — bake controller into bundle
- `extensions/renderers/unity/scripts/build_worldos_humanoid_controller.cs` — box-run controller builder
- `extensions/renderers/unity/scripts/anim_pack_avatar_gate.cs` — box-run avatar gate
- `data/asset-registry/registry.json` — `needs_remodel`/`humanoid` flags from the gate
- (user-level) `unity-asset-stack` skill registry: A\*/DOTween marked imported; RPG Mecanim + Tessera Pro + DunGen added owned+imported

Closes #1408.
