### PR TITLE
fix(engine): stuck-cell — a mover's own cell must never block itself

### DIFF
--- a/servers/engine/combat_grid.py
+++ b/servers/engine/combat_grid.py
@@ -178,12 +178,19 @@ def reachable(
     an occupied cell, so `occupied` cells are dropped from the result (and the start
     itself is excluded — you stay put for free, it's not a "move to").
 
-    `occupied` should NOT include `start` (the mover doesn't block itself). `difficult`
-    empty (no terrain) => flat cost 1 (PR-1 behaviour, byte-for-byte). Returns a set of
-    (x, y) cells. Pure Dijkstra over per-step cost; deterministic.
+    `occupied` should NOT include `start` (the mover doesn't block itself) — and even if a
+    caller violates that (STUCK-CELL #1511: a stale/re-painted cell now overlaps where the
+    mover already stands), `start` is EXPLICITLY exempted below, so you can never be trapped
+    by your own square. `difficult` empty (no terrain) => flat cost 1 (PR-1 behaviour,
+    byte-for-byte). Returns a set of (x, y) cells. Pure Dijkstra over per-step cost;
+    deterministic.
     """
     if budget_cells <= 0:
         return set()
+    # STUCK-CELL (#1511): explicit source exemption (see shortest_path's matching comment) —
+    # `start` never blocks itself, whatever `occupied`/`impassable` the caller passes in.
+    occupied = set(occupied) - {start}
+    impassable = set(impassable) - {start}
     import heapq
 
     # Dijkstra: costs are 1 or 2, so a priority queue gives the minimal-cost distance to
@@ -242,6 +249,14 @@ def shortest_path(
         return None
     if goal in occupied or goal in impassable:
         return None
+    # STUCK-CELL (#1511): the SOURCE cell is EXEMPT from the blocked set — you can always step
+    # OFF wherever you're standing, even if it's (or became) occupied/impassable. The Dijkstra
+    # below already achieves this incidentally (it only tests NEIGHBOUR cells, never re-checks
+    # `cur`), but that's fragile: make the exemption explicit so it survives a future "skip an
+    # already-blocked cur" tweak. `goal` is unaffected — you still can't ROUTE INTO a blocked
+    # cell (checked above; the only exception is goal == start, already short-circuited).
+    occupied = set(occupied) - {start}
+    impassable = set(impassable) - {start}
     import heapq
 
     # Dijkstra over per-step cost (1, or 2 into difficult terrain). `seq` is a monotonic

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4644,7 +4644,11 @@ def rest_blocked_cells(
         ``scene_grid.impassable_cells`` — the same derivation a painted fight uses — and (2) rest
         OCCUPANCY: every character's ``stage_cell`` in this location PLUS any ``npc:<id>`` spawn
         anchors W1 writes into ``scene_grid.spawns`` (both are where PEOPLE stand at rest). The
-        mover's own ``exclude_id`` cell is removed (you never block yourself).
+        mover's own ``exclude_id`` cell is removed (you never block yourself) — STUCK-CELL
+        (#1511): this holds whether that cell is blocked via OCCUPANCY *or* TERRAIN (a wall/prop
+        the mover happens to be standing on, e.g. a post-re-paint obstacle that now overlaps an
+        already-staged party member) — the mover's cell is EXPLICITLY exempted below rather than
+        relying on it merely being absent from the occupancy side.
 
     Pure read of engine-owned state; no mutation, no I/O. If the location has no scene_grid, or a
     non-positive grid, returns ``(0, 0, set())`` (the caller treats that as "not walkable here" —
@@ -4656,6 +4660,15 @@ def rest_blocked_cells(
     height = int(grid.grid.rows)
     if width <= 0 or height <= 0:
         return 0, 0, set()
+
+    # STUCK-CELL (#1511): the mover's own CURRENT cell (if any) — needed below to exempt it from
+    # the TERRAIN half of the blocked set too, not just the occupancy half.
+    mover_cell: tuple[int, int] | None = None
+    if exclude_id:
+        mover_ch = c.characters.get(exclude_id)
+        sc = getattr(mover_ch, "stage_cell", None) if mover_ch is not None else None
+        if sc is not None:
+            mover_cell = (int(sc[0]), int(sc[1]))
 
     # (2) rest occupancy: where PEOPLE stand. Authoritative source is Character.stage_cell (this
     # PR's sole-writer field); the npc:<id> spawn anchors (W1 #1318) are folded in when present so
@@ -4685,12 +4698,51 @@ def rest_blocked_cells(
                     occupied.add((int(cell[0]), int(cell[1])))
 
     # (1) walls + prop footprints, minus any cell someone stands on (never trap a stander on a
-    # prop) — the SAME impassable_cells derivation a painted fight uses.
+    # prop) — the SAME impassable_cells derivation a painted fight uses. STUCK-CELL (#1511): widen
+    # the exemption set with the mover's OWN cell too (it's deliberately absent from `occupied`
+    # above, precisely so it doesn't count as an OCCUPANT blocking anyone else) — otherwise a
+    # mover standing on terrain the scene now paints impassable would stay stuck in the returned
+    # blocked set even though `occupied` correctly never counted them as an occupant.
+    terrain_exempt = occupied | {mover_cell} if mover_cell is not None else occupied
     impassable = {
         (x, y)
-        for x, y in scene_grid_mod.impassable_cells(grid, width, height, occupied=occupied)
+        for x, y in scene_grid_mod.impassable_cells(grid, width, height, occupied=terrain_exempt)
     }
-    return width, height, impassable | occupied
+    blocked = impassable | occupied
+    if mover_cell is not None:
+        blocked.discard(mover_cell)  # belt-and-suspenders: never block the mover's own cell
+    return width, height, blocked
+
+
+def _nearest_walkable_cell(
+    width: int, height: int, blocked: set[tuple[int, int]], cell: tuple[int, int]
+) -> "tuple[int, int] | None":
+    """STUCK-CELL (#1511) defense in depth: if `cell` is already walkable (in-bounds and not in
+    `blocked`), return it unchanged. Otherwise BFS outward over the 8-neighbourhood (rings of
+    increasing Chebyshev distance) for the nearest walkable cell — a deterministic fallback for
+    any rest-position WRITE that landed a character on a blocked cell (a grid-mismatched
+    combat-end write-back, a spawn that drifted onto a re-painted obstacle, ...). Returns None
+    only if the whole grid is blocked (nothing to relocate to). Pure; no mutation."""
+    if 0 <= cell[0] < width and 0 <= cell[1] < height and cell not in blocked:
+        return cell
+    from collections import deque
+
+    visited = {cell}
+    dq = deque([cell])
+    while dq:
+        cx, cy = dq.popleft()
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                if dx == 0 and dy == 0:
+                    continue
+                nxt = (cx + dx, cy + dy)
+                if nxt in visited or not (0 <= nxt[0] < width and 0 <= nxt[1] < height):
+                    continue
+                visited.add(nxt)
+                if nxt not in blocked:
+                    return nxt
+                dq.append(nxt)
+    return None  # no walkable cell anywhere in this room
 
 
 def _seed_stage_cells_on_arrival(c: "Campaign", dest: "Location") -> list[str]:
@@ -7428,13 +7480,30 @@ def end_combat(campaign_id: str, resolution: str = "") -> dict:
         # the grid) get a write-back; a zone/theater fight leaves x/y None ⇒ NO stage_cell write,
         # byte-for-byte today's behavior. The dead are skipped (a corpse has no rest position).
         # This IS the engine writing its own sole-writer field from its own combat state.
+        #
+        # STUCK-CELL (#1511) defense in depth: the combat grid's OWN geometry/impassable set is
+        # not guaranteed to track the location's REST scene_grid cell-for-cell (a plain #461
+        # `set_grid` fight, or a grid-mismatch degrade, has no obligation to match it) — so a
+        # combat-legal final cell could still land on a cell rest_blocked_cells treats as solid.
+        # Prefer the exact cell when it's rest-walkable; otherwise relocate to the nearest
+        # walkable cell rather than parking a survivor somewhere `walk_to` would refuse to route
+        # through. A location with no scene_grid (or an empty room) is untouched — write the
+        # combat cell exactly as before.
         for cb in c.combat.order:
             if cb.x is None or cb.y is None:
                 continue
             ch = c.characters.get(cb.character_id)
             if ch is None or ch.dead or ch.current_hp <= 0:
                 continue
-            ch.stage_cell = (int(cb.x), int(cb.y))
+            cell = (int(cb.x), int(cb.y))
+            loc = c.locations.get(ch.location_id) if ch.location_id else None
+            if loc is not None and getattr(loc, "scene_grid", None) is not None:
+                rw, rh, rest_blocked = rest_blocked_cells(c, loc, exclude_id=ch.id)
+                if rw > 0 and rh > 0 and cell in rest_blocked:
+                    relocated = _nearest_walkable_cell(rw, rh, rest_blocked, cell)
+                    if relocated is not None:
+                        cell = relocated
+            ch.stage_cell = cell
         c.combat = Combat()
         save_campaign(c)
         return result

--- a/servers/engine/tests/test_grid_walkability_p1.py
+++ b/servers/engine/tests/test_grid_walkability_p1.py
@@ -47,6 +47,32 @@ def test_open_floor_additive_unchanged():
     assert combat_grid.path_cost_cells((0, 0), (3, 3), p) == combat_grid.chebyshev_cells((0, 0), (3, 3)) == 3
 
 
+# ── STUCK-CELL (#1511): the SOURCE cell must be exempt from the blocked set ───────────
+# A mover standing on a cell that is (or becomes) impassable/occupied must always be able to
+# step OFF it — you can never be trapped by your own square. Pinned explicitly here (not just
+# incidentally true of the neighbour-only check) so a future "skip an already-blocked cur"
+# tweak can't silently reintroduce the trap.
+
+
+def test_shortest_path_escapes_when_start_is_impassable():
+    # start (2,2) is itself a wall cell; the open floor around it must still be reachable.
+    p = combat_grid.shortest_path((2, 2), (3, 2), occupied=set(), width=5, height=5,
+                                  impassable={(2, 2)})
+    assert p == [(3, 2)]
+
+
+def test_shortest_path_escapes_when_start_is_occupied():
+    # start (2,2) is itself in the combined blocked/occupied set (e.g. a stale stander cell).
+    p = combat_grid.shortest_path((2, 2), (3, 2), occupied={(2, 2)}, width=5, height=5)
+    assert p == [(3, 2)]
+
+
+def test_reachable_includes_neighbours_when_start_is_impassable():
+    r = combat_grid.reachable((2, 2), 4, occupied=set(), width=5, height=5, impassable={(2, 2)})
+    assert (3, 2) in r and (2, 3) in r
+    assert (2, 2) not in r  # start itself is never a "destination"
+
+
 # ── integration via the engine tools (set_grid obstacles + move_to_coords) ───
 
 

--- a/servers/engine/tests/test_living_stage.py
+++ b/servers/engine/tests/test_living_stage.py
@@ -143,6 +143,32 @@ def test_end_combat_skips_the_dead(staged):
     assert tuple(c.characters[ally].stage_cell) == (1, 0)
 
 
+def test_end_combat_relocates_write_back_off_a_blocked_cell(staged):
+    """STUCK-CELL (#1511) defense in depth: the NO-TELEPORT write-back copies a combatant's
+    final COMBAT-grid cell straight into rest stage_cell with no rest-walkability check. If a
+    fight's own grid_impassable doesn't happen to cover a cell the location's rest scene_grid
+    treats as blocked (a wall/prop), that combatant would land — and be written back — onto a
+    rest-impassable cell. Place Hero on the combat grid directly on (2, 1) (the wall-column's
+    rest-impassable cell, but NOT one of the combat's own obstacles, so the grid-mode move is
+    legal) — end_combat must relocate the write-back to the nearest WALKABLE rest cell, never
+    park a survivor on a cell rest_blocked_cells would refuse to route through."""
+    cid, hero, ally, goblin, loc_id = staged
+    # No seed_from_stage / no set_grid obstacles — an open 5x3 combat grid (a plain #461 grid
+    # fight) so placing Hero at (2, 1) — a WALL cell in the room's rest scene_grid — is a legal
+    # combat placement (the fight's own grid_impassable is empty; only rest treats it as solid).
+    server.start_combat(cid, [hero, ally, goblin])
+    server.set_grid(cid, 5, 3)
+    server.place_combatant_at_coords(cid, hero, 2, 1)
+    server.end_combat(cid, resolution="the goblin fled")
+    c = server._require(cid)
+    loc = c.locations[loc_id]
+    _w, _h, blocked = server.rest_blocked_cells(c, loc, exclude_id=hero)
+    hero_cell = tuple(c.characters[hero].stage_cell)
+    assert hero_cell not in blocked, (
+        f"end_combat parked Hero on a rest-blocked cell {hero_cell} instead of relocating"
+    )
+
+
 def test_full_loop_rest_to_combat_to_rest_continuity(staged):
     """The scripted NO-TELEPORT loop end to end: rest (walk) → combat (seed) → combat move →
     rest (write-back). Assert continuity at BOTH seams with no actor jump."""

--- a/servers/engine/tests/test_walk_to.py
+++ b/servers/engine/tests/test_walk_to.py
@@ -115,6 +115,37 @@ def test_rest_blocked_cells_reads_npc_spawns(room):
     assert (1, 1) not in blocked  # a positional "npcs" list is NOT treated as per-id occupancy
 
 
+def test_rest_blocked_cells_excludes_mover_even_on_impassable_terrain(room):
+    """STUCK-CELL (#1511): the "mover's own exclude_id cell is removed (you never block
+    yourself)" contract must hold whether the mover's cell is blocked via OCCUPANCY (already
+    covered by test_rest_blocked_cells_excludes_mover) or via TERRAIN (a wall/prop cell the
+    mover happens to be standing on, e.g. after a post-#1507-style obstacle re-paint lands a
+    crate under an already-staged party member). Move Hero directly onto the crate cell (4, 2)
+    and confirm rest_blocked_cells still fully exempts it for Hero."""
+    cid, hero, _ally, loc_id = room
+    c = server._require(cid)
+    c.characters[hero].stage_cell = (4, 2)  # the crate/prop cell — now Hero's OWN position
+    server.save_campaign(c)
+    c = server._require(cid)
+    loc = c.locations[loc_id]
+    _w, _h, blocked = server.rest_blocked_cells(c, loc, exclude_id=hero)
+    assert (4, 2) not in blocked, "a mover's own cell must never block itself, terrain or not"
+
+
+def test_walk_to_escapes_when_own_cell_is_impassable_terrain(room):
+    """STUCK-CELL (#1511) canonical repro: a character standing on a cell that IS/becomes
+    impassable terrain (a camp crate, post-#1507) must still be able to walk off it. Move Hero
+    directly onto the crate cell (4, 2), then confirm walk_to routes them to an adjacent open
+    cell instead of rejecting the move — the source cell can never trap you."""
+    cid, hero, _ally, _loc = room
+    c = server._require(cid)
+    c.characters[hero].stage_cell = (4, 2)  # standing ON the crate
+    server.save_campaign(c)
+    out = server.walk_to(cid, hero, 3, 2)  # step off onto the adjacent open floor
+    assert out["walked"] is True
+    assert out["to"] == [3, 2]
+
+
 def test_rest_blocked_cells_no_scene_grid_is_empty(tmp_path, monkeypatch):
     monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
     cid = server.create_campaign("no grid")["id"]


### PR DESCRIPTION
Fixes #1511

## Bug (owner hit it live, post-#1507 camp/crypt collision-coherence fix)

A character whose `Character.stage_cell` coincides with a cell that IS (or
becomes) impassable terrain — e.g. an older save that walked there under a
looser pre-#1507 footprint, or a combat-end write-back landing on one — was
at risk of reading as permanently blocked, because `rest_blocked_cells()`'s
own "the mover's own exclude_id cell is removed (you never block yourself)"
contract only held for the OCCUPANCY half of the blocked set, not the
TERRAIN half.

## Root cause
`servers/engine/server.py:4631` `rest_blocked_cells()` — the excluded mover's
own `stage_cell` is deliberately filtered out of `occupied` (so it doesn't
count as an occupant blocking anyone else), but that same filtering meant
`impassable_cells(..., occupied=occupied)` never saw that cell as "someone
stands here" and so never exempted it from the TERRAIN-impassable side —
leaving it in the final `impassable | occupied` union whenever it happened
to overlap a wall/prop cell.

Separately, `combat_grid.shortest_path`/`reachable` (`servers/engine/combat_grid.py`)
only *incidentally* avoid re-checking the `start` cell (the Dijkstra loop
tests neighbour cells only) — this happens to keep `walk_to` working today,
but it's an undocumented, unenforced side effect that a future "skip an
already-blocked `cur`" tweak could silently break.

`end_combat`'s NO-TELEPORT write-back (`ch.stage_cell = (cb.x, cb.y)`) also
copied a combatant's final combat-grid cell straight into rest `stage_cell`
with zero rest-walkability validation — a fight's own grid geometry isn't
guaranteed to track the room's rest scene_grid cell-for-cell.

## Fix
- `combat_grid.shortest_path`/`reachable`: explicitly exempt `start` from the
  occupied/impassable checks (defense in depth).
- `rest_blocked_cells`: fully exempt the excluded mover's own current cell
  from BOTH the terrain and occupancy components of the returned blocked set.
- `end_combat`: relocate a surviving combatant's stage_cell write-back to the
  nearest walkable rest cell (new `_nearest_walkable_cell` BFS helper) when
  their final combat position lands on a cell `rest_blocked_cells` would
  refuse to route through.

Additive; `gates-read-gauges` invariants untouched; no existing behavior
changes for open-floor / no-obstacle cases.

## Tests (red-first)
- `test_rest_blocked_cells_excludes_mover_even_on_impassable_terrain` and
  `test_end_combat_relocates_write_back_off_a_blocked_cell` reproduced the
  trap and FAILED before the fix; both pass after.
- `test_walk_to_escapes_when_own_cell_is_impassable_terrain` pins the
  canonical repro from the bug report (character standing on a crate cell
  must still be able to walk off it).
- `test_shortest_path_escapes_when_start_is_impassable/occupied` and
  `test_reachable_includes_neighbours_when_start_is_impassable` harden the
  combat_grid invariant explicitly.

Focused run: `uv run --directory servers/engine python -m pytest tests/test_grid_walkability_p1.py tests/test_walk_to.py tests/test_living_stage.py -q -p no:xdist` → 42 passed.
Full engine suite (`tests/`) → 3516 passed. Related `qa/` seed/gate tests → 14 passed, 2 skipped (pre-existing skips, unrelated).

## Test plan
- [x] Red-first failing tests added, confirmed failing pre-fix
- [x] Fix applied, focused suite green
- [x] Full `servers/engine/tests/` suite green (3516 passed)
- [x] `qa/` camp/crypt/plate-drift tests green