### PR TITLE
VFX-ANCHORS: animated campfire over the painted firepit (per-plate anchored effects)

### DIFF
--- a/extensions/renderers/unity/effects_registry.json
+++ b/extensions/renderers/unity/effects_registry.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "_comment": "VFX-ANCHORS effect registry: maps an ABSTRACT effect `type` (referenced by plates_manifest.json plate `effects` entries) to a prefab asset PATH baked into the worldos_actors AssetBundle (BuildMacOSPlayer.EnsurePackaged step 2b) and loaded at runtime by CombatSurfaceClient.LoadEffectsRegistry/SpawnPlateEffects. Paths point at OWNED packs on the box (Hovl Studio + the RPG VFX / FantasySpellsEffectsPack bundle); the repo vendors no Hovl files, so a path missing on disk is skipped at build time and simply never spawns (byte-identical). PIPELINE: the box renders Built-in RP, so Hovl Shader-Graph particle materials are re-pointed to Legacy Particles at runtime (RepointHovlMaterials, per PR #1515's FixHovlVFX). Prefer LOOPING, painterly-compatible flames (not one-shot hit flashes). The prefab paths below are BOX-FINALIZED in the deploy/verify phase against the actual owned pack folders — pick the flame that composites best over the painted firepit glow without washing it out.",
+  "effects": {
+    "fire_medium": { "prefab": "Assets/Hovl Studio/Realistic fire and explosions/Prefabs/Fire/Fire.prefab" },
+    "fire_small":  { "prefab": "Assets/Hovl Studio/Realistic fire and explosions/Prefabs/Fire/Small fire.prefab" },
+    "embers":      { "prefab": "Assets/Hovl Studio/Realistic fire and explosions/Prefabs/Sparks/Sparks.prefab" },
+    "fireflies":   { "prefab": "Assets/Hovl Studio/Magic circles/Prefabs/Loop version/Magic circle fire loop.prefab" }
+  }
+}

--- a/extensions/renderers/unity/effects_registry.json
+++ b/extensions/renderers/unity/effects_registry.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "_comment": "VFX-ANCHORS effect registry: maps an ABSTRACT effect `type` (referenced by plates_manifest.json plate `effects` entries) to a prefab asset PATH baked into the worldos_actors AssetBundle (BuildMacOSPlayer.EnsurePackaged step 2b) and loaded at runtime by CombatSurfaceClient.LoadEffectsRegistry/SpawnPlateEffects. Paths point at OWNED packs on the box (Hovl Studio + the RPG VFX / FantasySpellsEffectsPack bundle); the repo vendors no Hovl files, so a path missing on disk is skipped at build time and simply never spawns (byte-identical). PIPELINE: the box renders Built-in RP, so Hovl Shader-Graph particle materials are re-pointed to Legacy Particles at runtime (RepointHovlMaterials, per PR #1515's FixHovlVFX). Prefer LOOPING, painterly-compatible flames (not one-shot hit flashes). The prefab paths below are BOX-FINALIZED in the deploy/verify phase against the actual owned pack folders — pick the flame that composites best over the painted firepit glow without washing it out.",
+  "_comment": "VFX-ANCHORS effect registry: maps an ABSTRACT effect `type` (referenced by plates_manifest.json plate `effects` entries) to a prefab asset PATH baked into the worldos_actors AssetBundle (BuildMacOSPlayer.EnsurePackaged step 2b) and loaded at runtime by CombatSurfaceClient.LoadEffectsRegistry/SpawnPlateEffects. Paths point at OWNED packs on the box; the repo vendors no pack files, so a path missing on disk is skipped at build time and simply never spawns (byte-identical). All four map to Synty PolygonGeneric FX (shader Synty/Generic_ParticlesUnlit) — painterly-flat, render correctly under the box's Built-in RP with NO shader re-point, and match the painted plate aesthetic. PIPELINE: if a Hovl Shader-Graph effect is registered instead, RepointHovlMaterials re-points its HS_*/Shader Graphs/HS materials to Legacy Particles at runtime (per PR #1515 FixHovlVFX); GAPH/FantasySpells custom shaders and Synty unlit particles both render as-is. Box-verified 2026-07-11 (fire_medium=FX_Fire_01 composited over the camp firepit; the FantasySpells FlamePillar was rejected as a giant magical eruption that washed out the painterly plate).",
   "effects": {
-    "fire_medium": { "prefab": "Assets/Hovl Studio/Realistic fire and explosions/Prefabs/Fire/Fire.prefab" },
-    "fire_small":  { "prefab": "Assets/Hovl Studio/Realistic fire and explosions/Prefabs/Fire/Small fire.prefab" },
-    "embers":      { "prefab": "Assets/Hovl Studio/Realistic fire and explosions/Prefabs/Sparks/Sparks.prefab" },
-    "fireflies":   { "prefab": "Assets/Hovl Studio/Magic circles/Prefabs/Loop version/Magic circle fire loop.prefab" }
+    "fire_medium": { "prefab": "Assets/Synty/PolygonGeneric/Prefabs/FX/FX_Fire_01.prefab" },
+    "fire_small":  { "prefab": "Assets/Synty/PolygonGeneric/Prefabs/FX/FX_Fire_Card_Small_01.prefab" },
+    "embers":      { "prefab": "Assets/Synty/PolygonGeneric/Prefabs/FX/FX_Dust_Spots_01.prefab" },
+    "fireflies":   { "prefab": "Assets/Synty/PolygonGeneric/Prefabs/FX/FX_Flies_01.prefab" }
   }
 }

--- a/extensions/renderers/unity/plates_manifest.json
+++ b/extensions/renderers/unity/plates_manifest.json
@@ -6,7 +6,11 @@
       "plate": "plates/crypt_armb_iter3_v1.png"
     },
     "camp_clearing_night": {
-      "plate": "plates/camp_clearing_night_truegrey_v1.png"
+      "plate": "plates/camp_clearing_night_truegrey_v1.png",
+      "_effects_comment": "VFX-ANCHORS: an animated fire over the painted firepit. Cell is the campfire_pit footprint from qa/room_manifests/camp_truegrey.cells.json (props[campfire].footprint = [[4,8],[5,8]]); the flame anchors on the left pit cell. `type` resolves through effects_registry.json; cell=[c,r], y=ground offset, scale=1.0. Cell/y/scale are BOX-TUNED against the paint so the flame sits in the pit and does not wash out the painted glow (the plate is the star).",
+      "effects": [
+        { "type": "fire_medium", "cell": [4, 8], "scale": 1.0, "y": 0.0 }
+      ]
     }
   }
 }

--- a/extensions/renderers/unity/plates_manifest.json
+++ b/extensions/renderers/unity/plates_manifest.json
@@ -7,9 +7,9 @@
     },
     "camp_clearing_night": {
       "plate": "plates/camp_clearing_night_truegrey_v1.png",
-      "_effects_comment": "VFX-ANCHORS: an animated fire over the painted firepit. Cell is the campfire_pit footprint from qa/room_manifests/camp_truegrey.cells.json (props[campfire].footprint = [[4,8],[5,8]]); the flame anchors on the left pit cell. `type` resolves through effects_registry.json; cell=[c,r], y=ground offset, scale=1.0. Cell/y/scale are BOX-TUNED against the paint so the flame sits in the pit and does not wash out the painted glow (the plate is the star).",
+      "_effects_comment": "VFX-ANCHORS: an animated fire over the painted firepit. The campfire_pit footprint is [[4,8],[5,8]] (qa/room_manifests/camp_truegrey.cells.json props[campfire]); cell [5,8] BOX-TUNED 2026-07-11 as the flame anchor that seats in the painted pit on camp_clearing_night_truegrey_v1.png, scale 1.5 filling the pit without washing out the painted glow (the plate is the star). `type` resolves through effects_registry.json; cell=[c,r], y=ground offset. Embers/fireflies types are registered and one-line-addable here later.",
       "effects": [
-        { "type": "fire_medium", "cell": [4, 8], "scale": 1.0, "y": 0.0 }
+        { "type": "fire_medium", "cell": [5, 8], "scale": 1.5, "y": 0.0 }
       ]
     }
   }

--- a/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
+++ b/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
@@ -93,6 +93,13 @@ public static class BuildMacOSPlayer
                 else Debug.LogWarning("[Package] plates_manifest.json present but no plates/ dir at " + platesSrcDir);
             }
 
+            // 1d) VFX-ANCHORS OPTIONAL effects registry -> StreamingAssets (verbatim). Present => the built
+            //     player resolves per-plate `effects` types to prefabs (CombatSurfaceClient.LoadEffectsRegistry
+            //     / SpawnPlateEffects); the referenced prefabs ride in the actor bundle (collected in step 2b).
+            //     ABSENT => not copied, the runtime finds no registry => no anchored VFX spawn. Not fatal.
+            string effectsRegSrc = Path.Combine(projectRoot, "effects_registry.json");
+            if (File.Exists(effectsRegSrc)) { File.Copy(effectsRegSrc, Path.Combine(saDir, "effects_registry.json"), true); Debug.Log("[Package] effects_registry.json -> StreamingAssets (VFX-ANCHORS)"); }
+
             // 2) collect every registry-referenced asset path (model/albedo/anim) that actually exists.
             var names = new List<string>();
             var root = MiniJson.Parse(File.ReadAllText(regSrc)) as Dictionary<string, object>;
@@ -124,6 +131,26 @@ public static class BuildMacOSPlayer
                 Debug.Log("[Package] +humanoid controller " + HumanoidCtrl);
             }
             else Debug.LogWarning("[Package] humanoid controller missing on disk, skipped: " + HumanoidCtrl);
+
+            // 2b) VFX-ANCHORS: bake the effect prefabs (effects_registry.json type->prefab) into the SAME
+            //     bundle so the runtime can LoadAsset them by their exact asset path. Dependencies (Hovl
+            //     materials/textures) are pulled in automatically. A path missing on disk (repo-only build, no
+            //     Hovl vendored) is skipped -> that effect type simply won't spawn (byte-identical). Keep the
+            //     paths in sync with the CombatSurfaceClient runtime resolver (both read effects_registry.json).
+            if (File.Exists(effectsRegSrc))
+            {
+                var fxRoot = MiniJson.Parse(File.ReadAllText(effectsRegSrc)) as Dictionary<string, object>;
+                var fxMap = (fxRoot != null && fxRoot.ContainsKey("effects")) ? fxRoot["effects"] as Dictionary<string, object> : null;
+                if (fxMap != null)
+                    foreach (var kv in fxMap)
+                    {
+                        var row = kv.Value as Dictionary<string, object>; if (row == null) continue;
+                        string path = row.ContainsKey("prefab") ? row["prefab"] as string : null;
+                        if (string.IsNullOrEmpty(path)) continue;
+                        if (string.IsNullOrEmpty(AssetDatabase.AssetPathToGUID(path))) { Debug.LogWarning("[Package] effect prefab missing on disk, skipped: " + path + " (type " + kv.Key + ")"); continue; }
+                        if (!names.Contains(path)) { names.Add(path); Debug.Log("[Package] +effect prefab " + path + " (type " + kv.Key + ")"); }
+                    }
+            }
 
             if (names.Count == 0) { Debug.LogWarning("[Package] no resolvable registry assets — bundle not built"); return; }
 

--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -291,8 +291,18 @@ public class CombatSurfaceClient : MonoBehaviour
     // Walkable/impassable/occluder truth stays ENGINE-side (already on the surface); the manifest is pure
     // presentation. ABSENT manifest / unknown location => no swap (byte-identical single-plate behavior).
     // (#W5e item 6; optional StreamingAssets/plates_manifest.json)
-    class PlateEntry { public string plate; public float[] planeSize; public float ortho = -1f, pitch = float.NaN, yaw = float.NaN; }
+    // VFX-ANCHORS: an OPTIONAL per-plate "effects" array anchors animated presentation VFX (an animated
+    // campfire over the painted firepit; embers/fireflies later) to grid cells. Each spec is {type, cell:[c,r],
+    // scale?, y?}; `type` resolves through effects_registry.json (type -> prefab asset path in the actor
+    // bundle) so content authors reference abstract types, not asset paths. Pure presentation — no engine/
+    // gameplay contact; ABSENT effects (or absent registry / bundle) => nothing spawns (byte-identical).
+    class EffectSpec { public string type; public int[] cell; public float scale = 1f; public float y = 0f; }
+    class PlateEntry { public string plate; public float[] planeSize; public float ortho = -1f, pitch = float.NaN, yaw = float.NaN;
+                       public System.Collections.Generic.List<EffectSpec> effects; }
     System.Collections.Generic.Dictionary<string, PlateEntry> _plateManifest;
+    System.Collections.Generic.Dictionary<string, string> _effectRegistry;   // type -> prefab asset path (effects_registry.json)
+    System.Collections.Generic.List<GameObject> _effectInstances;            // live spawned effect instances (despawned on plate swap)
+    GameObject _effectsRoot;                                                  // parent of the spawned effect instances (one-call teardown)
     string _locId = "";          // the surface's current location.id (parsed every ParseSurfaceExtras)
     string _plateLocId = "\0";   // the location the CURRENT backdrop plate was applied for (sentinel => unset)
     bool _plateSwapping = false; // guards against a re-entrant swap while a fade is mid-flight
@@ -357,6 +367,9 @@ public class CombatSurfaceClient : MonoBehaviour
         // WALKABLE-SLICE-V1 (item 6): load the OPTIONAL plate registry (per-location backdrop swap). Absent
         // -> no swap, the scene's baked plate stands (byte-identical to pre-W5e).
         LoadPlateManifest();
+        // VFX-ANCHORS: load the OPTIONAL effects registry (type -> prefab asset path). Absent -> no effects
+        // resolve -> nothing spawns (byte-identical). Paired with the per-plate `effects` array above.
+        LoadEffectsRegistry();
         // Option A (item 3): hide the scene's baked mannequins — the client now renders its own cast in rest
         // AND combat, so a baked actor would double-render / linger T-posed beside the live cast.
         HideBakedCast();
@@ -2824,6 +2837,22 @@ public class CombatSurfaceClient : MonoBehaviour
                     if (cp.ContainsKey("pitch")) pe.pitch = System.Convert.ToSingle(cp["pitch"]);
                     if (cp.ContainsKey("yaw")) pe.yaw = System.Convert.ToSingle(cp["yaw"]);
                 }
+                // VFX-ANCHORS: OPTIONAL `effects`:[{type, cell:[c,r], scale?, y?}] anchored VFX for this plate.
+                if (row.ContainsKey("effects") && row["effects"] is System.Collections.Generic.List<object> fx)
+                {
+                    pe.effects = new System.Collections.Generic.List<EffectSpec>();
+                    foreach (var fe in fx)
+                    {
+                        var er = fe as System.Collections.Generic.Dictionary<string, object>; if (er == null) continue;
+                        var es = new EffectSpec();
+                        es.type = er.ContainsKey("type") ? er["type"] as string : null;
+                        if (er.ContainsKey("cell") && er["cell"] is System.Collections.Generic.List<object> cl && cl.Count >= 2)
+                            es.cell = new[] { System.Convert.ToInt32(cl[0]), System.Convert.ToInt32(cl[1]) };
+                        if (er.ContainsKey("scale")) es.scale = System.Convert.ToSingle(er["scale"]);
+                        if (er.ContainsKey("y")) es.y = System.Convert.ToSingle(er["y"]);
+                        if (!string.IsNullOrEmpty(es.type) && es.cell != null) pe.effects.Add(es);
+                    }
+                }
                 _plateManifest[kv.Key] = pe;
             }
             Debug.Log("[CSC] plates_manifest.json loaded: " + _plateManifest.Count + " plate(s)");
@@ -2919,9 +2948,115 @@ public class CombatSurfaceClient : MonoBehaviour
         var ls = bd.transform.localScale;
         bd.transform.localScale = new Vector3(ow, oh, ls.z == 0f ? 1f : ls.z);
         Debug.Log("[CSC] plate swapped -> " + entry.plate + " (" + tex.width + "x" + tex.height + ", loc=" + _locId + ")");
+        // VFX-ANCHORS: despawn the prior plate's effect instances and spawn this plate's anchored VFX (an
+        // animated fire over the painted firepit, etc.). No `effects` / no registry / no bundle => a clean
+        // despawn + nothing spawned (byte-identical to the pre-VFX plate).
+        SpawnPlateEffects(entry);
         // #idle-fix: the location just changed — settle the whole cast to a grounded idle on the new plate so
         // no actor renders a bind (T) pose or floats after the cross-room reposition (the taste-pass defect).
         SettleCastIdleGrounded();
         return true;
+    }
+
+    // ---- VFX-ANCHORS: per-plate anchored presentation effects (fire / embers / fireflies) ----------------
+
+    // Parse the OPTIONAL StreamingAssets/effects_registry.json ({version, effects:{<type>:{prefab}}}) into a
+    // flat type -> prefab-asset-path map. The prefab paths key into the SAME worldos_actors AssetBundle the
+    // build bakes them into (BuildMacOSPlayer.EnsurePackaged). Absent/corrupt -> _effectRegistry null -> no
+    // effect ever resolves (byte-identical). Same runtime Json parser registry.json/stage.json use.
+    void LoadEffectsRegistry()
+    {
+        try
+        {
+            string p = System.IO.Path.Combine(Application.streamingAssetsPath, "effects_registry.json");
+            if (!System.IO.File.Exists(p)) { Debug.Log("[CSC] no effects_registry.json (no anchored VFX)"); return; }
+            var root = Json.Parse(System.IO.File.ReadAllText(p)) as System.Collections.Generic.Dictionary<string, object>;
+            var eff = (root != null && root.ContainsKey("effects")) ? root["effects"] as System.Collections.Generic.Dictionary<string, object> : null;
+            if (eff == null) { Debug.LogWarning("[CSC] effects_registry.json has no `effects` map"); return; }
+            _effectRegistry = new System.Collections.Generic.Dictionary<string, string>();
+            foreach (var kv in eff)
+            {
+                var row = kv.Value as System.Collections.Generic.Dictionary<string, object>; if (row == null) continue;
+                string prefab = row.ContainsKey("prefab") ? row["prefab"] as string : null;
+                if (!string.IsNullOrEmpty(prefab)) _effectRegistry[kv.Key] = prefab;
+            }
+            Debug.Log("[CSC] effects_registry.json loaded: " + _effectRegistry.Count + " effect type(s)");
+        }
+        catch (System.Exception e) { Debug.LogWarning("[CSC] effects_registry parse: " + e.Message); }
+    }
+
+    // Despawn the prior plate's effect instances and spawn this plate's `effects` anchored at each cell's
+    // CellToWorld position (+ y). Each spec's `type` resolves through the registry to a prefab loaded from
+    // the actor bundle; a missing type / prefab / bundle is a logged skip (never a broken frame). Hovl SG
+    // materials are re-pointed to Legacy Particles so they render under the box's Built-in RP (see #1515).
+    void SpawnPlateEffects(PlateEntry entry)
+    {
+        // despawn prior instances first (unconditional — a plate with no effects clears the old ones).
+        if (_effectInstances != null)
+        {
+            foreach (var go in _effectInstances) if (go != null) Object.Destroy(go);
+            _effectInstances.Clear();
+        }
+        if (entry == null || entry.effects == null || entry.effects.Count == 0) return;
+        if (_effectRegistry == null) { Debug.LogWarning("[CSC] plate has effects but no effects_registry.json — skipped"); return; }
+        if (_effectsRoot == null) { _effectsRoot = new GameObject("_EffectsRoot"); }
+        if (_effectInstances == null) _effectInstances = new System.Collections.Generic.List<GameObject>();
+
+        foreach (var es in entry.effects)
+        {
+            if (es == null || string.IsNullOrEmpty(es.type) || es.cell == null || es.cell.Length < 2) continue;
+            if (!_effectRegistry.TryGetValue(es.type, out var prefabPath) || string.IsNullOrEmpty(prefabPath))
+            { Debug.LogWarning("[CSC] effect type '" + es.type + "' not in registry — skipped"); continue; }
+            var prefab = LoadAsset<GameObject>(prefabPath);
+            if (prefab == null) { Debug.LogWarning("[CSC] effect prefab missing in bundle: " + prefabPath + " (type " + es.type + ")"); continue; }
+            var inst = (GameObject)Object.Instantiate(prefab);
+            inst.name = "_FX_" + es.type + "_" + es.cell[0] + "_" + es.cell[1];
+            inst.transform.SetParent(_effectsRoot.transform, false);
+            inst.transform.position = CellToWorld(es.cell[0], es.cell[1]) + new Vector3(0f, es.y, 0f);
+            if (es.scale > 0f && System.Math.Abs(es.scale - 1f) > 1e-4f) inst.transform.localScale *= es.scale;
+            RepointHovlMaterials(inst);
+            WarmParticleSystems(inst);
+            _effectInstances.Add(inst);
+            Debug.Log("[CSC] spawned effect '" + es.type + "' @cell[" + es.cell[0] + "," + es.cell[1] + "] y=" + es.y + " scale=" + es.scale);
+        }
+    }
+
+    // Runtime port of M15SpendGateProbe.FixHovlVFX (#1515) Built-in-RP branch: the box renders under Built-in
+    // RP, where Hovl's Shader-Graph particle materials (Shader Graphs/HS_*, HS_*) draw 0 px. Re-point them to
+    // Unity's Legacy Particles shader (Additive for fire/energy; Alpha Blended for distortion), preserving the
+    // emissive texture + tint. No-op under URP/HDRP (the SG shaders render there) and for non-Hovl materials.
+    static void RepointHovlMaterials(GameObject inst)
+    {
+        if (UnityEngine.Rendering.GraphicsSettings.currentRenderPipeline != null) return;   // URP/HDRP: SG renders
+        var addBlend = Shader.Find("Legacy Shaders/Particles/Additive");
+        var alphaBlend = Shader.Find("Legacy Shaders/Particles/Alpha Blended");
+        if (addBlend == null) { Debug.LogWarning("[CSC] Legacy Shaders/Particles/Additive not found — Hovl VFX may render 0px"); return; }
+        int fixedN = 0;
+        foreach (var r in inst.GetComponentsInChildren<Renderer>(true))
+        {
+            var src = r.sharedMaterial; if (src == null || src.shader == null) continue;
+            string sn = src.shader.name;
+            if (!(sn.Contains("HS_") || sn.StartsWith("Shader Graphs/HS") || sn.StartsWith("Hovl"))) continue;
+            bool distort = sn.Contains("Distort");
+            var tgt = new Material(distort && alphaBlend != null ? alphaBlend : addBlend);
+            Texture tex = null;
+            foreach (var pn in new[] { "_MainTex", "_BaseMap", "_BaseColorMap" }) if (src.HasProperty(pn) && src.GetTexture(pn) != null) { tex = src.GetTexture(pn); break; }
+            if (tex != null) tgt.mainTexture = tex;
+            foreach (var pn in new[] { "_TintColor", "_BaseColor", "_Color" }) if (src.HasProperty(pn)) { tgt.color = src.GetColor(pn); break; }
+            r.material = tgt;   // per-instance material — never edits the shared bundle asset
+            fixedN++;
+        }
+        if (fixedN > 0) Debug.Log("[CSC] Built-in RP: re-pointed " + fixedN + " Hovl SG material(s) -> Legacy Particles");
+    }
+
+    // Tick freshly-instantiated ParticleSystems forward so a persistent VFX (a looping campfire) shows flame
+    // in the first captured frame instead of its empty t=0 bind state (mirrors M15SpendGateProbe's warm-up).
+    static void WarmParticleSystems(GameObject inst)
+    {
+        foreach (var ps in inst.GetComponentsInChildren<ParticleSystem>(true))
+        {
+            ps.Simulate(2f, true, true);
+            ps.Play(true);
+        }
     }
 }


### PR DESCRIPTION
## What
Adds an **additive, presentation-only** per-plate VFX-anchor layer to the Unity combat-surface renderer. `plates_manifest.json` plate entries gain an OPTIONAL `effects` array; on plate load/swap `CombatSurfaceClient` despawns prior effect instances and spawns each entry's mapped prefab at the cell's world position. The owner's #1 polish ask — an **animated fire over the painted camp firepit** — plus the reusable mechanism for embers/fireflies later.

## Design (additive; byte-identical when absent)
- **Schema:** `effects: [{ "type", "cell":[c,r], "scale"?, "y"? }]` on each plate entry.
- **Registry:** new optional `effects_registry.json` maps abstract `type` -> prefab asset path (single source of truth, read by both the runtime resolver and the build).
- **Spawner:** `CombatSurfaceClient.SpawnPlateEffects` (called from `ApplyPlate`) despawns prior instances, instantiates each mapped prefab at `CellToWorld(cell)+y`, scales, warms its ParticleSystems, and parents under `_EffectsRoot`. Pure presentation — no engine/gameplay contact.
- **Pipeline:** the box renders **Built-in RP**; `RepointHovlMaterials` re-points Hovl Shader-Graph particle materials to Legacy Particles at runtime (reuses PR #1515 `FixHovlVFX`). No-op for Synty/GAPH shaders.
- **Build:** `BuildMacOSPlayer.EnsurePackaged` copies `effects_registry.json` into StreamingAssets and bakes each registered prefab into the `worldos_actors` AssetBundle.
- **Content:** `camp_clearing_night` gets `fire_medium` at the firepit cell `[5,8]`, scale 1.5 (box-tuned).

**Absent `effects` / registry / bundle prefab => nothing spawns (byte-identical to the pre-VFX plate).**

## Box verification (GEX44, 2026-07-11)
`fire_medium` = Synty `FX_Fire_01` (painterly-flat `Synty/Generic_ParticlesUnlit`), composited over the painted camp firepit on `camp_clearing_night_truegrey_v1.png`:
- Hero night frame — animated fire seated in the pit, no wash-out of the painted glow.
- 3-frame motion series (distinct flame shapes) — animation confirmed.
- Boosted-lighting variant — self-lit additive VFX reads regardless of scene lighting.
- No z-fighting (fire bounds ~90 units from the backdrop plane).
- Rejected the FantasySpells FlamePillar (a giant magical eruption that washed out the painterly plate).

Evidence frames pulled to `qa/evidence/vfx-anchors/` on the box capture host (not committed — large PNGs).