### PR TITLE
docs: consolidate room pipeline + process changes (docs only)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -69,12 +69,16 @@ plate / VFX / UX / animation changes:
   JPEG fine for painterly plates) — local paths (`~/worldos-session-notes/...`) are INVISIBLE to
   reviewers, repo paths only.
 - **Embed each frame with markdown image syntax pointed at the RAW bytes, so it renders inline in
-  the PR view** — `![caption](https://raw.githubusercontent.com/electricsheephq/WorldOS/<branch-or-sha>/qa/evidence/<number>/frame.jpg)`,
-  or the `/blob/...` GitHub URL with `?raw=true` appended. **A plain `/blob/...` URL (GitHub's HTML
-  file viewer) will NOT render inline** — it links to a page, not the image bytes; that silently
-  fails the exact case this section exists for. A bare path or a "see qa/evidence/123/" pointer
-  doesn't satisfy this either — if the owner has to click through to a file listing to see a pixel,
-  the section is incomplete.
+  the PR view** — `![caption](.../blob/<commit-sha>/qa/evidence/<number>/frame.jpg?raw=true)` using
+  **your own PR-head repo and an immutable commit SHA on this branch** (not a hardcoded upstream
+  `owner/repo`, which 404s the moment this is opened from a fork), or a plain `/blob/...` URL with
+  `?raw=true` appended. **A plain `/blob/...` URL with no `?raw=true` (GitHub's HTML file viewer)
+  will NOT render inline** — it links to a page, not the image bytes; that silently fails the exact
+  case this section exists for. Simplest and most robust for most contributors: drag-and-drop the
+  image directly into the PR description text box — GitHub uploads it to its own CDN and inserts a
+  working inline `![...]` link automatically, with no fork/SHA/URL bookkeeping at all. A bare path
+  or a "see qa/evidence/123/" pointer doesn't satisfy this either — if the owner has to click
+  through to a file listing to see a pixel, the section is incomplete.
 - Motion: a numbered frame series (2-6 stills) is primary and each still gets its own embedded image
   (agents read stills reliably); a GIF is optional, for humans, in addition to the stills.
 - Include the deterministic pre-gate output (`qa/visual_pregate.py`) when the change touches

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -68,10 +68,13 @@ plate / VFX / UX / animation changes:
 - Commit 1-6 BEFORE/AFTER still frames to `qa/evidence/<number>/` **on this branch** (≤400KB each;
   JPEG fine for painterly plates) — local paths (`~/worldos-session-notes/...`) are INVISIBLE to
   reviewers, repo paths only.
-- **Embed each frame with markdown image syntax so it renders inline in the PR view** —
-  `![caption](../blob/<branch>/qa/evidence/<number>/frame.jpg)` or the repo-relative form GitHub
-  resolves on this PR's branch. A bare path or a "see qa/evidence/123/" pointer does not satisfy this
-  — if the owner has to click through to a file listing to see a pixel, the section is incomplete.
+- **Embed each frame with markdown image syntax pointed at the RAW bytes, so it renders inline in
+  the PR view** — `![caption](https://raw.githubusercontent.com/electricsheephq/WorldOS/<branch-or-sha>/qa/evidence/<number>/frame.jpg)`,
+  or the `/blob/...` GitHub URL with `?raw=true` appended. **A plain `/blob/...` URL (GitHub's HTML
+  file viewer) will NOT render inline** — it links to a page, not the image bytes; that silently
+  fails the exact case this section exists for. A bare path or a "see qa/evidence/123/" pointer
+  doesn't satisfy this either — if the owner has to click through to a file listing to see a pixel,
+  the section is incomplete.
 - Motion: a numbered frame series (2-6 stills) is primary and each still gets its own embedded image
   (agents read stills reliably); a GIF is optional, for humans, in addition to the stills.
 - Include the deterministic pre-gate output (`qa/visual_pregate.py`) when the change touches

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -62,13 +62,22 @@ List the checks you ran.
 - Exact next action:
 
 
-## Evidence (required for anything visual)
-For renderer / viewer / UX / animation changes: commit 1-6 BEFORE/AFTER still frames to
-`qa/evidence/<number>/` **on this branch** (≤400KB each; JPEG fine for painterly plates) and
-reference them here. Local paths (`~/worldos-session-notes/...`) are INVISIBLE to reviewers — repo
-paths only. Motion: a numbered frame series (2-6 stills) is primary; a GIF is optional for humans
-(agents read stills). Include the deterministic pre-gate output (qa/visual_pregate.py) when the
-change touches placement/pose/scale. Engine-only changes: test names + fast_gate line instead.
+## Visual Evidence (required for any renderer / plate / QA-visual change)
+**The owner browses PRs — frames must render INLINE, not just be linked.** For renderer / viewer /
+plate / VFX / UX / animation changes:
+- Commit 1-6 BEFORE/AFTER still frames to `qa/evidence/<number>/` **on this branch** (≤400KB each;
+  JPEG fine for painterly plates) — local paths (`~/worldos-session-notes/...`) are INVISIBLE to
+  reviewers, repo paths only.
+- **Embed each frame with markdown image syntax so it renders inline in the PR view** —
+  `![caption](../blob/<branch>/qa/evidence/<number>/frame.jpg)` or the repo-relative form GitHub
+  resolves on this PR's branch. A bare path or a "see qa/evidence/123/" pointer does not satisfy this
+  — if the owner has to click through to a file listing to see a pixel, the section is incomplete.
+- Motion: a numbered frame series (2-6 stills) is primary and each still gets its own embedded image
+  (agents read stills reliably); a GIF is optional, for humans, in addition to the stills.
+- Include the deterministic pre-gate output (`qa/visual_pregate.py`) when the change touches
+  placement/pose/scale, and the coherence-gate result (`qa/check_grid_paint_coherence.py`) when the
+  change touches a room's authored geometry or manifest.
+- Engine-only changes with no visual surface: test names + fast_gate line instead of this section.
 
 ---
 _Merging note: required checks stuck at "expected/pending" with mergeState BLOCKED is the known repo-wide auto-merge hang (#1389), NOT a CI failure. Procedure: real checks green + threads resolved → `gh pr merge <n> --admin --squash` (docs/OPERATIONS.md "Merging")._

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -146,7 +146,9 @@ reviewers: drag-dropped into the issue, or committed to `qa/evidence/<number>/` 
 read them. Motion defects: a numbered still series is the primary artifact (agents read stills
 reliably; GIFs are optional, for humans). Pair frames with qa/visual_pregate.py output when the
 change touches placement/pose/scale. Use the `graphics-defect` issue template; the PR template's
-Evidence section applies to every visual-affecting PR. See qa/evidence/README.md.
+Visual Evidence section applies to every visual-affecting PR and requires frames to be **embedded
+inline** (markdown image syntax), not just linked — the owner browses PRs and should never have to
+click through to a file listing to see a pixel. See qa/evidence/README.md.
 
 ## The Universal Run Contract (owner-ratified 2026-07-08 — every run type, no exceptions)
 Every run — engine test, probe, sprint, duo, sweep, playtest, render, panel, generation, extraction,
@@ -167,3 +169,84 @@ promotion, rollup — closes with the SAME five steps. A run that skips a step d
 evidence, scores surface, owning skill/runbook, last-verified). Adding a NEW run type = adding a
 row + wiring the five steps. Changing a runner = updating its row. Dispatch packets for any run
 MUST name the run type's row so the executing agent inherits the contract.
+
+## Worktree discipline (owner-ratified after #1516 — three lanes' live worktrees deleted mid-session)
+
+**A lane may remove ONLY the worktree it created, by its exact path.** #1516 measured three
+concurrent lanes (probe-placement, an owner-play session, true-greybox) losing their
+`~/WorldOS-worktrees/*` directories mid-run to a sibling process's cleanup step — suspected cause: a
+broad `git worktree remove --force` with a glob/wrong var, or an `rm -rf` sweep, instead of a
+single named-path removal. Recoveries succeeded only because of commit-early discipline; each still
+cost a rebuild/regeneration round, and one recovery briefly killed the owner's live session.
+
+- **Broad prunes are forbidden mid-session.** Never `git worktree prune`, never glob-remove
+  `~/WorldOS-worktrees/*` or `~/worldos-worktrees/*`, never a bare `rm -rf` over the worktrees
+  parent dir. Remove exactly the one path you created, when you created it, and nothing else.
+  This applies even when you're "just cleaning up" — a stray worktree from a lane you don't
+  recognize is not yours to delete.
+- **`.worldos-keep` marker = never touch, full stop.** Long-lived shared worktrees (e.g.
+  `wt-owner-play`) carry a `.worldos-keep` file at their root. Any cleanup script or dev-loop
+  finish step MUST skip any tree containing that marker — check for it before any remove, even a
+  single-path one you believe is safe.
+- **Commit-and-push-early stays the recovery guarantee.** A worktree that gets swept mid-session is
+  only a lost *regeneration round*, never lost work, if you've been committing and pushing as you
+  go (per the `worldos-dev` dev-loop) rather than accumulating uncommitted state.
+
+## The orchestrator-eyeball rule (owner-bound visuals get a human look before shipping)
+
+Any visual artifact the owner is directly bound to — a rest-scene demo, a shipped room plate, a
+player-build screenshot posted as release evidence, anything framed as "look at this" rather than
+"here's a gate result" — gets a **personal orchestrator review of the actual frames** before it
+ships or is reported as done. A green pre-gate and an in-band panel median are necessary but not
+sufficient: they measure against an instrument, not against the owner's actual reaction. Eyeball
+the frames yourself (0-for-5, per the visual-critic panel discipline) before trusting a panel
+verdict enough to post it as "ready." This is the same discipline the felt-rest panel protocol
+already states for panel composition (`qa/felt_rest_panel.md`) — restated here as a general
+operating rule for anything visual and owner-bound, not just that one panel type.
+
+## Box claim-queue etiquette (single-tenant GEX44)
+
+The GEX44 Unity box is **single-tenant** — one lane's box op at a time. The live pattern (see the
+active sprint charter, e.g. #1386 "Rules of engagement"): **claim by commenting on the owning
+tracker issue before any box op; release (comment) when done.** Concretely:
+- **Poll boundedly, repo-side-first.** Do repo-side work (author geometry, derive manifests, write
+  the plate-loop config, stage panels) BEFORE requesting the box, so the box session is
+  near-mechanical when it starts (see `qa/evidence/dungen-spike/BOX-DRIVE-RECIPE.md` for the
+  pattern: "repo-side is DONE + green; this is the ready-to-run box phase"). Don't idle-poll for
+  the box to free up — do the next repo-side unit of work instead, and check back when you need it.
+- **Claim, do the bounded op, restore, release.** On the box: `chown -R unity:unity` any files you
+  touched, `ctrl+r` (refresh Unity), restore the scene you found, THEN comment release on the
+  claiming issue. Restoring state is part of the op, not optional cleanup.
+- **The Built-in-RP note:** the box's Unity project is **Built-in Render Pipeline, not URP.**
+  Shader/material work that assumes URP (Shader Graph particle materials, certain post-effects)
+  needs a repoint step for this box (e.g. `RepointHovlMaterials`, PR #1515/#1525) — check the
+  pipeline before importing or wiring any new asset pack; the `unity-asset-stack` skill states this
+  per-pack.
+
+## Journey-eval + the coherence gate — standing instruments (not one-off checks)
+
+Two instruments run standing (not just once) against any shipped room, and neither substitutes for
+the other:
+
+- **`qa/check_grid_paint_coherence.py`** — the ABSOLUTE grid↔paint coherence gate (#1462/#1491).
+  Run it against every registered plate candidate BEFORE the panel (step 5 of
+  `docs/ROOM-PIPELINE-RUNBOOK.md`) — it is what would have caught the sarcophagus incident
+  (engine-legal cell, paint ~3/4 cell off the authored footprint).
+- **`qa/journey_eval.py`** — walks a scripted playable path (prop approaches + parley + door-cross +
+  combat-entry), captures frames, and asks factual VQA questions per frame (on_prop, t_pose,
+  floating, missing/cloned actor, backdrop-transition-changed). This is the eval-blindness
+  instrument: aesthetic panels measure beauty-vs-bar and can score highly around a T-posing actor or
+  a character standing inside a painted prop.
+  - **★ v1 has a known structural blind spot (#1523, "the legal-path blind spot"):** the run only
+    walks cells the ENGINE considers legal, so it structurally cannot catch a missing-footprint prop
+    (standing on a painted object that the engine never flagged impassable) — exactly the defect
+    class the owner's playtest #7 found by hand (woodpile, crate stack, hut/shelter, top-right
+    trees). The first live run (PR #1520) scored 0/4 recall against that punch list for precisely
+    this reason — see `qa/evidence/journey-eval-first-run/RECALL.md` for the full comparison.
+  - **v2 (tracked, #1523)** adds an adversarial phase: click every painted-prop candidate region
+    (from the manifest's footprint+occlusion sets, plus a coarse grid sweep of high-texture regions)
+    and flag whenever the engine ACCEPTS the move — closing the exact gap v1 has.
+  - Until v2 lands, **do not treat a clean journey-eval v1 run as proof a room has no
+    missing-footprint defects** — it answers a different question (does the legal path look right)
+    than the coherence gate (does the paint sit on its authored cells) or a human playtest (does
+    something painted-but-uncollided exist at all).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -190,7 +190,14 @@ cost a rebuild/regeneration round, and one recovery briefly killed the owner's l
   single-path one you believe is safe.
 - **Commit-and-push-early stays the recovery guarantee.** A worktree that gets swept mid-session is
   only a lost *regeneration round*, never lost work, if you've been committing and pushing as you
-  go (per the `worldos-dev` dev-loop) rather than accumulating uncommitted state.
+  go (per the `worldos-dev` dev-loop) rather than accumulating uncommitted state. **Confirmed again
+  independently after #1516 landed** (NEW-ROOM-TAVERN, PR #1531, 2026-07-11): "a parallel
+  worktree-prune destroyed the first uncommitted run; rebuilt byte-faithfully — deterministic
+  numbers reproduced exactly." The sweeping behavior is still live somewhere in this environment —
+  a `.worldos-keep` marker is not yet a proven full mitigation (an unrelated worktree carrying one
+  was still removed mid-session during this very docs-consolidate lane, 2026-07-11) — so treat the
+  commit/push discipline above as load-bearing, not optional, until the sweeper itself is found and
+  fixed.
 
 ## The orchestrator-eyeball rule (owner-bound visuals get a human look before shipping)
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -251,11 +251,11 @@ the other:
     impassable) is exactly the class of cell that method structurally never targets on purpose — it
     would only get caught by accident. This is a recall gap, not an impossibility: the per-frame
     "on_prop" VQA question runs on every captured frame regardless of why the character is there, so
-    an incidental hit is possible, just not engineered. The first live run (PR #1520) scored 0 of 3
+    an incidental hit is possible, just not engineered. The first live run (PR #1520) scored 0 of 4
     recall against the owner's playtest-#7 missing-footprint punch list (woodpile, crate stack,
-    hut/shelter) for precisely this reason — see `qa/evidence/journey-eval-first-run/RECALL.md` for
-    the full comparison (a 4th playtest-#7 item, top-right trees/exit, is a separate occlusion-hull
-    bug outside this defect class entirely).
+    hut/shelter, top-right ruin) for precisely this reason — see
+    `qa/evidence/journey-eval-first-run/RECALL.md` for the full comparison (a 5th playtest-#7 item,
+    top-right trees/exit, is a separate occlusion-hull bug outside this defect class entirely).
   - **v2 (tracked, #1523)** adds an adversarial phase: click every painted-prop candidate region
     (from the manifest's footprint+occlusion sets, plus a coarse grid sweep of high-texture regions)
     and flag whenever the engine ACCEPTS the move — closing the exact gap v1 has by making the probe
@@ -264,3 +264,17 @@ the other:
     missing-footprint defects** — it answers a different question (does the legal path look right)
     than the coherence gate (does the paint sit on its authored cells) or a human playtest (does
     something painted-but-uncollided exist at all).
+
+## Long-running servers must launch detached (a live incident, 2026-07-11)
+
+An owner session's `viewer/server.py` was launched as a harness-tracked background task and died
+`exit 144` with no output the moment its parent turn ended — a long-running server is not a
+bounded command and the harness reaps it like one. **Any long-lived server (a viewer, a state
+listener, anything meant to outlive the turn that started it) must be launched DETACHED from a
+foreground shell** — `nohup <cmd> > <logfile> 2>&1 & echo $! > <pidfile>` — never handed to a
+run-in-background tool call, which is for bounded commands whose completion you want to be notified
+of, not for processes meant to keep running after the turn ends. Bank the PID to a pid file so a
+later turn (or a different agent) can check liveness (`kill -0 "$(cat <pidfile>)"`) and tear it down
+cleanly instead of hunting for it. The recovery recipe for the specific owner session this happened
+to lives in that session's log + plan file, not here — this entry is the standing rule, not the
+incident's play-by-play.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -244,15 +244,22 @@ the other:
   floating, missing/cloned actor, backdrop-transition-changed). This is the eval-blindness
   instrument: aesthetic panels measure beauty-vs-bar and can score highly around a T-posing actor or
   a character standing inside a painted prop.
-  - **★ v1 has a known structural blind spot (#1523, "the legal-path blind spot"):** the run only
-    walks cells the ENGINE considers legal, so it structurally cannot catch a missing-footprint prop
-    (standing on a painted object that the engine never flagged impassable) — exactly the defect
-    class the owner's playtest #7 found by hand (woodpile, crate stack, hut/shelter, top-right
-    trees). The first live run (PR #1520) scored 0/4 recall against that punch list for precisely
-    this reason — see `qa/evidence/journey-eval-first-run/RECALL.md` for the full comparison.
+  - **★ v1 has a known coverage gap (#1523, "the legal-path blind spot"):** the scripted route only
+    ever visits cells picked for OTHER reasons (adjacent to a prop the manifest already marks
+    impassable, or a narrative waypoint) — it never deliberately routes onto a cell just because it
+    LOOKS solid. A missing-footprint prop (standing on a painted object the engine never flagged
+    impassable) is exactly the class of cell that method structurally never targets on purpose — it
+    would only get caught by accident. This is a recall gap, not an impossibility: the per-frame
+    "on_prop" VQA question runs on every captured frame regardless of why the character is there, so
+    an incidental hit is possible, just not engineered. The first live run (PR #1520) scored 0 of 3
+    recall against the owner's playtest-#7 missing-footprint punch list (woodpile, crate stack,
+    hut/shelter) for precisely this reason — see `qa/evidence/journey-eval-first-run/RECALL.md` for
+    the full comparison (a 4th playtest-#7 item, top-right trees/exit, is a separate occlusion-hull
+    bug outside this defect class entirely).
   - **v2 (tracked, #1523)** adds an adversarial phase: click every painted-prop candidate region
     (from the manifest's footprint+occlusion sets, plus a coarse grid sweep of high-texture regions)
-    and flag whenever the engine ACCEPTS the move — closing the exact gap v1 has.
+    and flag whenever the engine ACCEPTS the move — closing the exact gap v1 has by making the probe
+    deliberate instead of incidental.
   - Until v2 lands, **do not treat a clean journey-eval v1 run as proof a room has no
     missing-footprint defects** — it answers a different question (does the legal path look right)
     than the coherence gate (does the paint sit on its authored cells) or a human playtest (does

--- a/docs/ROOM-PIPELINE-RUNBOOK.md
+++ b/docs/ROOM-PIPELINE-RUNBOOK.md
@@ -1,0 +1,331 @@
+# ROOM PIPELINE RUNBOOK — author a room end-to-end (cold-agent bootstrap)
+
+> **You were told "make a room" and given this repo. This page is the whole pipeline.** Read it top
+> to bottom, then execute — you do not need any prior conversation's context. Every step names its
+> exact file/command and the decision record that ratified it. This is the TRUE-GREYBOX lane (epic
+> #1508): geometry-first, registration by construction, no paint-vs-grid drift.
+
+## The one invariant every step below honors
+
+The Python engine (`servers/engine/`) is the **sole writer** of level-structure truth (walkable
+cells, occluders, pathing). Every artifact below — greybox, plate, manifest, VFX anchor — is a
+**presentation-layer derivation** of engine-authored geometry, never a second writer of it. If a
+step you're adding would let art or a generator invent grid truth independently, it's wrong by
+construction — see `docs/roadmap/GENERATOR-EXPORT-CONTRACT.md`'s framing of this same rule for the
+generator arms.
+
+## Scale convention — 1 cell = 5 ft ≈ 1 human
+
+The engine cell is **5 ft**. The greybox renderer's world scale is **2.0 world-units per cell**
+(`greybox_render_headless.cell_to_world`), so `2 world-units == 1 cell == 5 ft`. Size every
+authored prop against that ruler — **a standing human is ~1 cell wide**, so a prop's footprint
+should read as a multiple of "how many people could stand there," not an eyeballed blob. This
+convention is what makes cross-tool math (author → derive → DunGen/Tessera world-units-per-cell)
+compose without a unit-conversion bug; see "Scale mapping" in `GENERATOR-EXPORT-CONTRACT.md`.
+
+## The RICHNESS PRINCIPLE (load-bearing lesson, PR #1528 / CRYPT-REPLICATE)
+
+**Paint richness follows GEOMETRY richness.** CRYPT-REPLICATE spent a full style-pass iteration
+loop trying to out-paint a drift-rich incumbent plate (best honest result: 7.1, vs the incumbent's
+7.8) and could not close the gap with cosmetic style-pass levers alone. The honest path past a
+richer incumbent is **authoring a denser greybox** — more prop volumes = richer paint AND richer
+collision, simultaneously, because both are derived from the same geometry. Do not reach for "one
+more style-pass iteration" to fix a plate that reads as sparse; reach for `author_room_geometry.py`
+and add prop volumes instead. (Full note: `docs/RUNBOOK-INDEX.md` LARGE SPACES row / PR #1528.)
+
+---
+
+## The pipeline, step by step
+
+### 1. Author geometry — `tools/author_room_geometry.py`
+
+Emits a `room_geometry.json` (the `export_scene_grid.py`-shaped input every downstream tool
+consumes) directly from a room's own prop constants, at CORRECT WORLD SCALE — each prop sized as a
+kind's proxy volume (height from `greybox_render_headless._KIND_SPECS`) extruded on cells sized to
+the true 5-ft-grid object, not an eyeballed/drifted footprint.
+
+```bash
+python3 tools/author_room_geometry.py crypt -o /tmp/crypt_geometry.json
+python3 tools/author_room_geometry.py camp  -o /tmp/camp_geometry.json
+```
+
+**Shape-appropriate proxies (PR #1495 lesson):** box-shaped trees read as buildings to depth
+models. Route each prop through the kind that matches its true silhouette (cylinder → pillar, cone
+→ tree, box → crate/rubble/masonry) — the generator-export converter (`tools/dungen_to_fixtures.py`)
+applies the same shape→kind rule for generator-sourced props (see step 8a).
+
+**Geometry schema** (mirrors `qa/export_scene_grid.py`):
+```
+{cols, rows, material, cell_default_walkable, walls, props:[{id, kind, cells}],
+ impassable, door_cells, protected_lane_cells}
+```
+`walls` is every non-walkable cell (true perimeter + every prop footprint cell, conflated —
+`greybox_render_headless` dedupes prop cells out of the wall boxes for rendering).
+
+Deterministic, offline, read-only w.r.t. engine state.
+
+### 2. Derive the manifest — `tools/derive_room_manifest.py`
+
+**Owner playtest #5 architecture decision: the greybox geometry is the single source of truth for
+a room's FOOTPRINT + OCCLUSION + WALKABLE; manifests are DERIVED from it, never hand-authored.**
+This is what kills paint-vs-grid drift at the source instead of patching it downstream.
+
+```bash
+python3 tools/derive_room_manifest.py /tmp/crypt_geometry.json \
+    -o qa/room_manifests/crypt.cells.json --room crypt --recipe-key crypt
+```
+
+Per prop this computes:
+- **footprint** — the impassable FLOOR cells (collision + `check_grid_paint_coherence.py`'s
+  correctness check).
+- **occlusion** — the screen-space SILHOUETTE cells (a tall prop's silhouette rises up-screen off
+  its floor footprint — strictly contains but is offset from the footprint).
+- **screen_bbox** — the footprint reprojected under the contract camera.
+
+**Footprint-vs-occlusion is the distinction CAMP-TUNE's defect #5 turned on** (see the recall table
+below, `qa/evidence/journey-eval-first-run/RECALL.md`): a per-prop occlusion hull computed as the
+bounding box over a whole multi-cell footprint can blanket far more of the room than the prop
+actually occupies (a 9-cell L-shaped wall produced a 48-cell occlusion hull covering the room's
+exit). **Keep individual prop runs SHORT** (2-4 cells) specifically so each one's occlusion hull
+stays tight to itself — this is now a standing authoring rule, not just a one-off fix.
+
+Manifests are stamped `derivation: "derived"` + their source geometry — distinguishing them from
+legacy `measured` manifests (`qa/build_room_manifest.py` reconstructions) that exist only until a
+room's geometry JSON is authored.
+
+### 3. Greybox render (the shaded base + optional depth/normal sidecars)
+
+The shaded greybox render is BOTH the plate's visual base AND the ControlNet `controlImage` for
+step 4 — one artifact, two consumers, guaranteeing base and control agree pixel-for-pixel:
+
+```bash
+python3 qa/greybox_render_headless.py /tmp/crypt_geometry.json /tmp/crypt_greybox.png
+```
+
+This is the verified camera rig (`greybox_render_headless` — the #1396 recipe, <1e-3 vs Unity;
+dimetric, elevation 30°, yaw 45, `cell_size 2.0`, `ortho_size 13`).
+
+**Optional depth+normal sidecars** (`qa/greybox_sidecars_headless.py`) — a pure-PIL analog of the
+box `CohesionProbe.cs` G-buffer, co-registered pixel-for-pixel with the greybox render:
+```bash
+python3 qa/greybox_sidecars_headless.py /tmp/crypt_geometry.json \
+    /tmp/crypt_depth.png /tmp/crypt_normal.png
+```
+**Scope note (a PLATE SPRINT finding, not a live dependency):** the ADOPTED recipe (step 4) does
+**not** consume these sidecars — Scenario derives the depth control server-side from the shaded
+greybox `controlImage` directly. These sidecars exist for parity with the crypt relight-lane
+artifact and as a reproducible no-box path for any future relight; issue #1481 concluded the
+WOSRelight lane that DID consume them should **stop** (shared-greybox sidecars stamped
+vertical-banding seams onto warm plates — only a per-plate sidecar would be safe). Don't wire a new
+recipe to these unless you've re-read #1481 first.
+
+### 4. Registered base — flux depth-ControlNet (`docs/roadmap/PLATE-RECIPE-DECISION.md`)
+
+**Adopted pipeline (DECIDED 2026-07-10, supersedes the implicit `model_z-image` img2img default):**
+1. **flux.1-dev + depth-ControlNet base** from the room greybox — registration by construction (the
+   paint is conditioned directly on the authored geometry, so it cannot drift from it).
+2. Via `extensions/renderers/godot/tools/generate_room.py --controlnet depth` (or
+   `qa/plate_loop.py`'s `generate.controlnet` config field) — the greybox is `--base-plate`, Scenario
+   resolves it to `controlImage` with `controlModality=depth`.
+
+### 5. Coherence gate — `qa/check_grid_paint_coherence.py`
+
+The ABSOLUTE grid↔paint coherence gate (#1462/#1491) — this is what would have caught the
+sarcophagus incident (engine cells legal, but the paint sat ~3/4 cell off the grid footprint;
+actor stood on the authored impassable cell while the painted prop was elsewhere).
+
+- **Why `check_plate_drift.py` (relative) doesn't catch this:** that gate only asserts a regen
+  keeps a prop where a KNOWN-GOOD baseline had it — a prop that has ALWAYS been off-grid passes
+  forever. This gate is **absolute**: no baseline needed, it checks the paint against the grid's
+  OWN authored footprint.
+- **Method:** regenerate the grid's structural signature from the manifest FOOTPRINT via the same
+  contract greybox rig; build an edge template per prop (mean-subtracted, L2-normalised silhouette
+  edges — the modality-invariant bridge greybox↔paint); localise it in the plate's edge map via
+  normalised cross-correlation; any prop whose peak offset exceeds `MAX_OFFSET_CELLS` (0.5) →
+  **INCOHERENT, fail loud.**
+- **Reliability scope:** hard-silhouette props (pillars, sarcophagi, walls, altars) localise
+  reliably. Tall organic props (tree foliage) present a poor box-silhouette match — reported as a
+  diagnostic, not a blocking CI signal, for that class.
+
+Run it against every registered candidate before it goes to the panel.
+
+### 6. Style pass — the reference-images LAW + structure/dimetric locks
+
+**Gemini instruction-edit** (`model_google-gemini-3-1-flash`) over the flux depth-CN base, with two
+mandatory prompt clauses:
+
+- **STRUCTURE-LOCK** — "every wall, pillar, archway, doorway, staircase, tree, boulder, road edge,
+  and prop must stay in EXACTLY its current position, size, and shape... only the paint and
+  lighting treatment changes" (verbatim pattern used across every adopted style-pass prompt, e.g.
+  `qa/evidence/plate-sprint/camp-armB/style_pass_prompt_winning.txt`).
+- **DIMETRIC-LOCK** — an explicit camera-angle-preservation clause. Needed because dropping
+  `referenceImages` also drops an *implicit* camera pin that a reference image otherwise supplied
+  (`qa/evidence/plate-sprint/camp-armB/findings.json` finding 3) — but test it per-room: on a base
+  whose camera was never drifting, adding dimetric-lock wording measurably made results WORSE
+  (added prompt complexity/stochastic risk without fixing an actual defect). Don't cargo-cult it.
+
+**★ THE REFERENCE-IMAGES LAW (`PLATE-RECIPE-DECISION.md`):** Gemini `referenceImages` hijack
+CONTENT toward the reference, not just style. A reference is safe **only if its composition already
+matches the room greybox** (e.g. an anchor minted FROM that same greybox). For a room with no
+greybox-aligned anchor: use **no** `referenceImages` — text style description + scene-content
+grounding instead. Measured: no-ref registration recall 0.9439 vs same-room-ref 0.81-0.84 (PR #1492).
+A `STRUCTURE-LOCK EXCEPTION` clause is the sanctioned escape hatch for a specific, named artifact
+region (e.g. an unwanted concentric-ring pattern in ground texture) that the general lock would
+otherwise force Gemini to preserve — scope it tightly to the one region, never generally.
+
+**Registration gate:** edge-recall ≥0.95 for hard-edge/masonry rooms; for organic rooms edge-recall
+is ADVISORY (content-blind and class-dependent — issue #1491) — use the greybox-edge overlay as
+primary evidence instead.
+
+### 7. Blind panel — the in-band control recipe
+
+**`qa/plate_loop.py`** is the one-command conductor: generate → deterministic registration/pre-gate
+→ STAGE the panel packet → (orchestrator scores it) → ingest verdict → scores_db row + gallery row.
+
+```bash
+# Phase 1 — generate + deterministic gates + stage the panel
+python3 qa/plate_loop.py --room crypt --config cfg.json --out-dir out/ --gallery gallery.html
+# ... orchestrator runs the 5 blind scorers per <out-dir>/panel/prompts.json ...
+# Phase 2 — ingest the verdict
+python3 qa/plate_loop.py --panel-verdict verdict.json --out-dir out/ --gallery gallery.html
+```
+
+**★ THE PANEL IS AGENT-WORK, NOT SCRIPT-WORK** — `plate_loop.py` never calls an LLM. It stages
+blind slots (candidate / incumbent / disguised real-art control), writes the blind
+slot→A/B/C mapping OUTSIDE the panel image dir (scorers Read adjacent files), and the
+**orchestrator** runs the 5-scorer blind panel (the visual-critic skill recipe).
+
+**5-scorer blind panel composition:** candidate + incumbent canonical + a **disguised in-band
+real-art control** (validity band 6.8-9.2 on our instrument; out-of-band ⇒ advisory, re-run once).
+Best-of-N (N≥3) generations per iteration (measured run-to-run variance). **Never cite an absolute
+score as a quality verdict** — real shipped PoE2/BG2 art scores 3.0-5.6 on this same instrument; the
+control's presence is what makes a panel result citable at all (`docs/roadmap/VISUAL-PROMOTION-GATE-DECISION.md`
+formalizes this as the promotion gate's delta-anchored strategy for the "room" artifact class).
+
+### 8. Promote — `tools/library/promote.py --batch`
+
+The HV3 eval-gated promotion pipeline (Act II §4c, #1325) — the **sole writer** of the repo-root
+`library/` pack, additive by default (empty nomination queue ⇒ byte-identical library).
+
+```bash
+python3 tools/library/promote.py --batch \
+    --library library/ --nominations qa/nominations.jsonl --db qa/scores.db
+python3 tools/library/library_lint.py   # validate the result
+```
+
+**Two gate strategies by class** (`docs/roadmap/VISUAL-PROMOTION-GATE-DECISION.md`):
+- **TEXT** classes (quest/npc/location/encounter) → absolute threshold gate (overall ≥4.0, every
+  dim ≥3.0, control-valid).
+- **VISUAL** ("room") → **delta-anchored, never absolute**: deterministic pre-gate HARD FLOOR
+  passed + the panel's control landed in-band + candidate-minus-control delta ≥ -1.2 (noise law).
+
+`tier=canonical` is human curation ONLY — `promote.py` never assigns it. **Bootstrap note:** until
+HV5's auto-nominator exists, hand-author `qa/nominations.jsonl` — one JSON line per `artifact_id`
+(room nominations MUST declare `"class": "room"` since a visual score lives in a panel JSON, not
+the `artifacts` DB table).
+
+### 8a. The generator path — DunGen / Tessera export → converter (structure-source alternative)
+
+For a room sourced from a **generator layout** rather than hand-authored constants, the geometry
+step (1) is replaced by an export+convert hop; steps 2-8 above are unchanged downstream. Full
+contract: `docs/roadmap/GENERATOR-EXPORT-CONTRACT.md` (supersedes `DUNGEN-EXPORT-CONTRACT.md`,
+renamed when the Tessera Pro arm landed).
+
+```
+DunGen scene   ──[DunGenLayoutExporter.cs]───▶ dungen_layout.json   ──┐
+Tessera scene  ──[TesseraLayoutExporter.cs]──▶ tessera_layout.json ──┴─[dungen_to_fixtures.py]──▶
+    (a) <name>.scenegrid.json      — engine SceneGrid fixture (the sole-writer truth)
+    (b) <name>_geometry.json       — greybox geometry json (feeds step 3 directly)
+    (b') <name>_<room>_geometry.json  — --room: one cropped room = the registered-plate input
+```
+
+- Both Unity-Editor exporters (`extensions/renderers/unity/scripts/Editor/{DunGen,Tessera}LayoutExporter.cs`)
+  emit the **same top-level layout shape** (`generator`/`bounds`/`rooms`/`doorways`/`props`), so
+  `tools/dungen_to_fixtures.py` is a single converter for both arms — no schema fork. Tessera's
+  gaps (no native doorway object, no `is_main_path`) are additive-empty fields the converter already
+  tolerated before the Tessera arm landed.
+- **Scale mapping is identical to the hand-authored path:** `--world-units-per-cell 2.0` (2 Unity
+  units = 1 five-ft cell), same convention as step 0 above — this is what keeps the whole chain
+  unit-consistent regardless of which structure-source produced the layout.
+- Box drive recipe (when a live Unity session is available): `qa/evidence/dungen-spike/BOX-DRIVE-RECIPE.md`
+  — deploy the exporter → generate+export via unity-mcp `execute_code` → convert → greybox-render →
+  continue at step 4 of this runbook.
+- **Ratified architecture boundary (`docs/roadmap/TILED-SPACE-SPIKE.md` orchestrator ruling,
+  2026-07-12):** the room/plate stays the atomic unit at native painting density — never widen a
+  single generation to grow a space (measured: quality collapses 7→2 stretching one generation past
+  ~1 room). **Towns/larger spaces are a LAYOUT problem** solved at the generator-graph layer (room-scale
+  districts + door-cross transitions + visually MASKED boundaries), not a painting problem. A
+  shared-wide-depth-control + per-tile-paint + feather **hybrid** is the ratified special-case tool
+  for genuinely continuous wide vistas (e.g. a market square spanning two tiles) — used sparingly,
+  panel-gated per vista, never as the default town-building path.
+
+### 9. `plates_manifest.json` + `effects[]` anchors (runtime backdrop + VFX)
+
+**Runtime plate registry** (`docs/roadmap/W5E-PLATE-REGISTRY-DECISION.md`, DECIDED 2026-07-10): ONE
+persistent Unity scene; the backdrop is resolved AT RUNTIME by the engine's location slug via a
+StreamingAssets `plates_manifest.json` — no scene reload, no per-room bake, no Addressables.
+
+```jsonc
+{
+  "version": 1,
+  "plates": {
+    "<location_slug>": {
+      "plate": "plates/<file>.png",
+      "planeSize": [W, H],
+      "cameraPin": { "ortho": 13.0, "pitch": 30.0, "yaw": 45.0 },
+      "stage": "stage.json",
+      "effects": [ { "type": "fire_medium", "cell": [5, 8], "scale": 1.5 } ]
+    }
+  }
+}
+```
+
+**`effects[]` is the additive VFX-anchor mechanism** (PR #1525, VFX-ANCHORS): on plate load/swap,
+`CombatSurfaceClient.SpawnPlateEffects` despawns prior effect instances and spawns each entry's
+mapped prefab (via `effects_registry.json`, abstract `type` → prefab path — single source of truth
+for both the runtime resolver and the build) at the cell's world position, scaled, ParticleSystems
+warmed, parented under `_EffectsRoot`. **Pure presentation — no engine/gameplay contact.** Absent
+`effects`/registry/bundle-prefab ⇒ nothing spawns (byte-identical to the pre-VFX plate). The box
+renders **Built-in RP**; Hovl Shader-Graph particle materials get re-pointed to Legacy Particles at
+runtime (`RepointHovlMaterials`, reuses PR #1515) — a no-op for Synty/GAPH shaders.
+
+**Grid dims + occluders are NEVER in the manifest** — they stay engine truth on the `/combat-surface`
+poll; the manifest carries ONLY presentation data (plate file, plane size, camera pin, effects). This
+is what keeps the renderer a pure consumer (the sole-writer invariant, restated for this seam).
+`BuildMacOSPlayer.EnsurePackaged` copies `plates_manifest.json` + every referenced plate PNG +
+`effects_registry.json` into `StreamingAssets/` at build time.
+
+### 10. Player pickup — box rebuild
+
+The client (`CombatSurfaceClient.cs`) picks up a new/changed plate only after a rebuild bakes the
+updated `StreamingAssets` into the shipped app:
+
+```
+Tools/WorldOS/Build/macOS Player (Universal)   # Unity Editor menu item, on the box
+```
+
+Verify with `qa/player_smoke.sh` (free, ~30-60s, every player rebuild — `docs/RUNBOOK-INDEX.md`
+"player smoke" row) before treating a rebuild as done. A location whose manifest key is unknown ⇒
+current plate kept (invisible-but-safe), never a crash — check `plates_manifest.json` if a room you
+just promoted doesn't appear in the player.
+
+---
+
+## Cross-linked decision records (read before deviating from this runbook)
+
+| Decision | What it settled |
+|---|---|
+| `docs/roadmap/PLATE-RECIPE-DECISION.md` | The adopted flux depth-CN + Gemini style-pass recipe; the reference-images law; outdoor-class rejected-approaches register |
+| `docs/roadmap/TILED-SPACE-SPIKE.md` | Room = atomic paint unit; towns are a layout problem; the ratified hybrid seam recipe for special-case wide vistas |
+| `docs/roadmap/GENERATOR-EXPORT-CONTRACT.md` | The DunGen + Tessera Pro export contract; the additive schema; shape-appropriate proxy routing |
+| `docs/roadmap/W5E-PLATE-REGISTRY-DECISION.md` | Runtime plate registry (`plates_manifest.json`); why per-room baked scenes and Addressables were rejected for this slice |
+| `docs/roadmap/VISUAL-PROMOTION-GATE-DECISION.md` | Why the "room" class gates on control-relative delta, never an absolute score |
+| `docs/research/2026-07-10-stage-tech-research.md` | REJECTED-APPROACHES register cross-linked from the plate recipe decision |
+| `docs/RUNBOOK-INDEX.md` | The run-type registry — every run in this pipeline has a row (runner, tier, evidence, scores surface) |
+
+## Standing instruments that validate a room after it ships
+
+See `docs/OPERATIONS.md` "Standing visual/pipeline instruments" — the coherence gate
+(`check_grid_paint_coherence.py`) and journey-eval (`qa/journey_eval.py`) both run against a shipped
+room; `qa/evidence/journey-eval-first-run/RECALL.md` documents the current instrument gap (the
+legal-path blind spot, #1523) so you know what journey-eval does and does NOT yet catch.

--- a/docs/ROOM-PIPELINE-RUNBOOK.md
+++ b/docs/ROOM-PIPELINE-RUNBOOK.md
@@ -5,6 +5,14 @@
 > exact file/command and the decision record that ratified it. This is the TRUE-GREYBOX lane (epic
 > #1508): geometry-first, registration by construction, no paint-vs-grid drift.
 
+**Preflight (do this before any command below):** read `docs/OPERATIONS.md` first — it's the
+general cold-start bootstrap (worktree discipline, box claim etiquette, the Universal Run Contract)
+this page specializes for room authoring. Verify `pwd` before running anything: you should be inside
+a real checkout of this repo (`/Users/lume/WorldOS` or an approved same-disk worktree per
+OPERATIONS.md's worktree-discipline section) — never a bare scratch directory. Any step below that
+touches the live Unity project (step 9's `plates_manifest.json`, step 10's player rebuild) requires
+the canonical checkout or box path named in that step; don't improvise a different location.
+
 ## The one invariant every step below honors
 
 The Python engine (`servers/engine/`) is the **sole writer** of level-structure truth (walkable
@@ -57,9 +65,10 @@ kind's proxy volume (height from `greybox_render_headless._KIND_SPECS`) extruded
 the true 5-ft-grid object, not an eyeballed/drifted footprint.
 
 ```bash
-mkdir -p qa/evidence/<n>/   # this PR/issue's evidence dir — write geometry here, NOT /tmp
-python3 tools/author_room_geometry.py crypt -o qa/evidence/<n>/crypt_geometry.json
-python3 tools/author_room_geometry.py camp  -o qa/evidence/<n>/camp_geometry.json
+EVIDENCE_ID=1234   # this PR/issue's number — write geometry under it, NOT /tmp
+mkdir -p "qa/evidence/${EVIDENCE_ID}/"
+python3 tools/author_room_geometry.py crypt -o "qa/evidence/${EVIDENCE_ID}/crypt_geometry.json"
+python3 tools/author_room_geometry.py camp  -o "qa/evidence/${EVIDENCE_ID}/camp_geometry.json"
 ```
 **Write outputs under the repo, not `/tmp`:** `derive_room_manifest.py` (step 2) stamps the derived
 manifest's `source_geometry` field by resolving your `-o` path repo-relative (`tools/derive_room_manifest.py:_repo_relative`);
@@ -90,7 +99,7 @@ a room's FOOTPRINT + OCCLUSION + WALKABLE; manifests are DERIVED from it, never 
 This is what kills paint-vs-grid drift at the source instead of patching it downstream.
 
 ```bash
-python3 tools/derive_room_manifest.py qa/evidence/<n>/crypt_geometry.json \
+python3 tools/derive_room_manifest.py "qa/evidence/${EVIDENCE_ID}/crypt_geometry.json" \
     -o qa/room_manifests/crypt.cells.json --room crypt --recipe-key crypt
 ```
 
@@ -118,7 +127,7 @@ The shaded greybox render is BOTH the plate's visual base AND the ControlNet `co
 step 4 — one artifact, two consumers, guaranteeing base and control agree pixel-for-pixel:
 
 ```bash
-python3 qa/greybox_render_headless.py qa/evidence/<n>/crypt_geometry.json qa/evidence/<n>/crypt_greybox.png
+python3 qa/greybox_render_headless.py "qa/evidence/${EVIDENCE_ID}/crypt_geometry.json" "qa/evidence/${EVIDENCE_ID}/crypt_greybox.png"
 ```
 
 This is the verified camera rig (`greybox_render_headless` — the #1396 recipe, <1e-3 vs Unity;
@@ -127,8 +136,8 @@ dimetric, elevation 30°, yaw 45, `cell_size 2.0`, `ortho_size 13`).
 **Optional depth+normal sidecars** (`qa/greybox_sidecars_headless.py`) — a pure-PIL analog of the
 box `CohesionProbe.cs` G-buffer, co-registered pixel-for-pixel with the greybox render:
 ```bash
-python3 qa/greybox_sidecars_headless.py qa/evidence/<n>/crypt_geometry.json \
-    qa/evidence/<n>/crypt_depth.png qa/evidence/<n>/crypt_normal.png
+python3 qa/greybox_sidecars_headless.py "qa/evidence/${EVIDENCE_ID}/crypt_geometry.json" \
+    "qa/evidence/${EVIDENCE_ID}/crypt_depth.png" "qa/evidence/${EVIDENCE_ID}/crypt_normal.png"
 ```
 **Scope note (a PLATE SPRINT finding, not a live dependency):** the ADOPTED recipe (step 4) does
 **not** consume these sidecars — Scenario derives the depth control server-side from the shaded

--- a/docs/ROOM-PIPELINE-RUNBOOK.md
+++ b/docs/ROOM-PIPELINE-RUNBOOK.md
@@ -35,6 +35,18 @@ and add prop volumes instead. (Full note: `docs/RUNBOOK-INDEX.md` LARGE SPACES r
 
 ---
 
+## Worked example — a room from scratch, start to finish
+
+**NEW-ROOM-TAVERN (epic #1508, merged 2026-07-11) ran every step below, in order, on a room with no
+prior plate or seed** (proving the method generalises beyond regenerating an existing incumbent):
+geometry (`author_room_geometry.py tavern`, 6 props, world-true 12×10) → cutaway greybox + sidecars
+(coherence-green 6/6) → derived manifest → registered flux depth-CN base (edge-recall 0.980 ≥ 0.95
+masonry gate) → Gemini-noref layered style pass (best-of-3, seed123 adopted) → blind 5-scorer panel
+(candidate median 7.0 vs the registered PoE2 control 9.0, Δ−2.0 in-band ⇒ `tier=stable`) →
+`promote.py` (automated PASS) → `room_recipes.json` + `plates_manifest.json` wiring, ready for the
+box's next rebuild. Productive wall-clock: ~40 min. If a step below is ambiguous, that PR's diff and
+evidence (`qa/evidence/new-tavern/`) is the concrete ground truth to check against.
+
 ## The pipeline, step by step
 
 ### 1. Author geometry — `tools/author_room_geometry.py`
@@ -276,6 +288,15 @@ Tessera scene  ──[TesseraLayoutExporter.cs]──▶ tessera_layout.json ─
   `tools/derive_room_manifest.py`; do not skip this even though the box-drive recipe's own steps
   jump straight to greybox-render — the manifest is what `check_grid_paint_coherence.py` and runtime
   validation depend on)** → greybox-render → continue at step 4 of this runbook.
+- **DunGen-vs-Tessera verdict (both arms run for real on the box, 2026-07-11 —
+  `docs/roadmap/GENERATOR-EXPORT-CONTRACT.md` "Box comparison RESULTS"): ADOPT DunGen as the primary
+  dungeon/room STRUCTURE generator.** DunGen's native `Doorway`/`Connection` objects + room-graph flow
+  map directly onto the engine `SceneGrid` (25 doorways exported cleanly on a 26-tile sample); Tessera
+  Pro exported 0 doorways on its 396-tile castle run — no native connection object, so rooms come out
+  as disconnected floor islands — the decisive gap for THIS pipeline. **Keep Tessera Pro for
+  tile-dense WFC set-dressing/exterior fields** (walls, terrain) where connectivity isn't the point.
+  Both arms still feed the identical `tools/dungen_to_fixtures.py` with no schema fork — that
+  architecture win holds regardless of which generator you pick per-room.
 - **Architecture boundary — see the ruling appended to `docs/roadmap/TILED-SPACE-SPIKE.md`** (dated
   2026-07-12 in that file; confirm it has actually landed if you're reading this before that date —
   treat it as the documented owner direction either way): the room/plate stays the atomic unit at

--- a/docs/ROOM-PIPELINE-RUNBOOK.md
+++ b/docs/ROOM-PIPELINE-RUNBOOK.md
@@ -45,9 +45,16 @@ kind's proxy volume (height from `greybox_render_headless._KIND_SPECS`) extruded
 the true 5-ft-grid object, not an eyeballed/drifted footprint.
 
 ```bash
-python3 tools/author_room_geometry.py crypt -o /tmp/crypt_geometry.json
-python3 tools/author_room_geometry.py camp  -o /tmp/camp_geometry.json
+mkdir -p qa/evidence/<n>/   # this PR/issue's evidence dir — write geometry here, NOT /tmp
+python3 tools/author_room_geometry.py crypt -o qa/evidence/<n>/crypt_geometry.json
+python3 tools/author_room_geometry.py camp  -o qa/evidence/<n>/camp_geometry.json
 ```
+**Write outputs under the repo, not `/tmp`:** `derive_room_manifest.py` (step 2) stamps the derived
+manifest's `source_geometry` field by resolving your `-o` path repo-relative (`tools/derive_room_manifest.py:_repo_relative`);
+a path outside the repo (e.g. `/tmp/...`) falls through to being stored verbatim as a transient
+absolute path, breaking the derived manifest's single-source/reproducibility promise the moment that
+`/tmp` file is cleaned up. Use a committed evidence/artifact path for anything you intend to derive
+a manifest from.
 
 **Shape-appropriate proxies (PR #1495 lesson):** box-shaped trees read as buildings to depth
 models. Route each prop through the kind that matches its true silhouette (cylinder → pillar, cone
@@ -71,7 +78,7 @@ a room's FOOTPRINT + OCCLUSION + WALKABLE; manifests are DERIVED from it, never 
 This is what kills paint-vs-grid drift at the source instead of patching it downstream.
 
 ```bash
-python3 tools/derive_room_manifest.py /tmp/crypt_geometry.json \
+python3 tools/derive_room_manifest.py qa/evidence/<n>/crypt_geometry.json \
     -o qa/room_manifests/crypt.cells.json --room crypt --recipe-key crypt
 ```
 
@@ -99,7 +106,7 @@ The shaded greybox render is BOTH the plate's visual base AND the ControlNet `co
 step 4 — one artifact, two consumers, guaranteeing base and control agree pixel-for-pixel:
 
 ```bash
-python3 qa/greybox_render_headless.py /tmp/crypt_geometry.json /tmp/crypt_greybox.png
+python3 qa/greybox_render_headless.py qa/evidence/<n>/crypt_geometry.json qa/evidence/<n>/crypt_greybox.png
 ```
 
 This is the verified camera rig (`greybox_render_headless` — the #1396 recipe, <1e-3 vs Unity;
@@ -108,8 +115,8 @@ dimetric, elevation 30°, yaw 45, `cell_size 2.0`, `ortho_size 13`).
 **Optional depth+normal sidecars** (`qa/greybox_sidecars_headless.py`) — a pure-PIL analog of the
 box `CohesionProbe.cs` G-buffer, co-registered pixel-for-pixel with the greybox render:
 ```bash
-python3 qa/greybox_sidecars_headless.py /tmp/crypt_geometry.json \
-    /tmp/crypt_depth.png /tmp/crypt_normal.png
+python3 qa/greybox_sidecars_headless.py qa/evidence/<n>/crypt_geometry.json \
+    qa/evidence/<n>/crypt_depth.png qa/evidence/<n>/crypt_normal.png
 ```
 **Scope note (a PLATE SPRINT finding, not a live dependency):** the ADOPTED recipe (step 4) does
 **not** consume these sidecars — Scenario derives the depth control server-side from the shaded
@@ -152,7 +159,21 @@ Run it against every registered candidate before it goes to the panel.
 ### 6. Style pass — the reference-images LAW + structure/dimetric locks
 
 **Gemini instruction-edit** (`model_google-gemini-3-1-flash`) over the flux depth-CN base, with two
-mandatory prompt clauses:
+mandatory prompt clauses. **★ No single reusable CLI wraps this exact step today — don't confuse it
+with two DIFFERENT, already-wired mechanisms that also touch Gemini:**
+- `generate_room.py --style-pass <json>` is a **z-image + LoRA img2img** pass (model/loras/
+  lorasScale/strength) — not Gemini at all.
+- `generate_room.py --layered` chains its OWN two Gemini instruction-edit passes
+  (`_run_gemini_pass`, pass2 detail/populate + pass3 staging-last) — a different pipeline stage,
+  for a different purpose, than the base-registration style pass described here.
+- The adopted camp-armB / crypt-replicate style pass (the one `PLATE-RECIPE-DECISION.md` documents)
+  was run as a direct Scenario Gemini instruction-edit job against the flux depth-CN base, using the
+  prompt text committed at e.g. `qa/evidence/plate-sprint/camp-armB/style_pass_prompt_winning.txt` —
+  reproduce it by submitting that same prompt (STRUCTURE-LOCK + DIMETRIC-LOCK clauses intact) against
+  your new base via the Scenario API/MCP, not via `--style-pass`/`--layered`. Wiring this into a
+  first-class `generate_room.py` flag is open follow-up work, not yet done.
+
+Two mandatory prompt clauses, whichever way you submit the edit:
 
 - **STRUCTURE-LOCK** — "every wall, pillar, archway, doorway, staircase, tree, boulder, road edge,
   and prop must stay in EXACTLY its current position, size, and shape... only the paint and
@@ -220,9 +241,11 @@ python3 tools/library/library_lint.py   # validate the result
   passed + the panel's control landed in-band + candidate-minus-control delta ≥ -1.2 (noise law).
 
 `tier=canonical` is human curation ONLY — `promote.py` never assigns it. **Bootstrap note:** until
-HV5's auto-nominator exists, hand-author `qa/nominations.jsonl` — one JSON line per `artifact_id`
-(room nominations MUST declare `"class": "room"` since a visual score lives in a panel JSON, not
-the `artifacts` DB table).
+HV5's auto-nominator exists, hand-author `qa/nominations.jsonl` — one JSON line per `artifact_id`.
+**Room nominations MUST declare BOTH `"class": "room"` AND `"source_path"`** (the control-anchored
+panel JSON the visual gate reads) — a visual score lives in that panel JSON, not the `artifacts` DB
+table, and `promote.py` fails the nomination outright (`"visual nomination has no 'source_path'"`)
+without it; `class` alone is not sufficient.
 
 ### 8a. The generator path — DunGen / Tessera export → converter (structure-source alternative)
 
@@ -248,22 +271,33 @@ Tessera scene  ──[TesseraLayoutExporter.cs]──▶ tessera_layout.json ─
   units = 1 five-ft cell), same convention as step 0 above — this is what keeps the whole chain
   unit-consistent regardless of which structure-source produced the layout.
 - Box drive recipe (when a live Unity session is available): `qa/evidence/dungen-spike/BOX-DRIVE-RECIPE.md`
-  — deploy the exporter → generate+export via unity-mcp `execute_code` → convert → greybox-render →
-  continue at step 4 of this runbook.
-- **Ratified architecture boundary (`docs/roadmap/TILED-SPACE-SPIKE.md` orchestrator ruling,
-  2026-07-12):** the room/plate stays the atomic unit at native painting density — never widen a
-  single generation to grow a space (measured: quality collapses 7→2 stretching one generation past
-  ~1 room). **Towns/larger spaces are a LAYOUT problem** solved at the generator-graph layer (room-scale
-  districts + door-cross transitions + visually MASKED boundaries), not a painting problem. A
-  shared-wide-depth-control + per-tile-paint + feather **hybrid** is the ratified special-case tool
-  for genuinely continuous wide vistas (e.g. a market square spanning two tiles) — used sparingly,
-  panel-gated per vista, never as the default town-building path.
+  — deploy the exporter → generate+export via unity-mcp `execute_code` → convert → **derive the
+  manifest from the converter's `<name>_<room>_geometry.json` output (step 2 above —
+  `tools/derive_room_manifest.py`; do not skip this even though the box-drive recipe's own steps
+  jump straight to greybox-render — the manifest is what `check_grid_paint_coherence.py` and runtime
+  validation depend on)** → greybox-render → continue at step 4 of this runbook.
+- **Architecture boundary — see the ruling appended to `docs/roadmap/TILED-SPACE-SPIKE.md`** (dated
+  2026-07-12 in that file; confirm it has actually landed if you're reading this before that date —
+  treat it as the documented owner direction either way): the room/plate stays the atomic unit at
+  native painting density — never widen a single generation to grow a space (measured: quality
+  collapses 7→2 stretching one generation past ~1 room). **Towns/larger spaces are a LAYOUT problem**
+  solved at the generator-graph layer (room-scale districts + door-cross transitions + visually
+  MASKED boundaries), not a painting problem. A shared-wide-depth-control + per-tile-paint + feather
+  **hybrid** is that ruling's special-case tool for genuinely continuous wide vistas (e.g. a market
+  square spanning two tiles) — used sparingly, panel-gated per vista, never as the default
+  town-building path.
 
 ### 9. `plates_manifest.json` + `effects[]` anchors (runtime backdrop + VFX)
 
 **Runtime plate registry** (`docs/roadmap/W5E-PLATE-REGISTRY-DECISION.md`, DECIDED 2026-07-10): ONE
 persistent Unity scene; the backdrop is resolved AT RUNTIME by the engine's location slug via a
 StreamingAssets `plates_manifest.json` — no scene reload, no per-room bake, no Addressables.
+
+**★ Edit this at its real committed path, the Unity PROJECT root, not the repo root:**
+`extensions/renderers/unity/plates_manifest.json` (+ `extensions/renderers/unity/effects_registry.json`)
+— `BuildMacOSPlayer.EnsurePackaged` resolves both relative to `Application.dataPath`'s parent (the
+Unity project dir), so a copy dropped at the repo root is silently never packaged. Referenced plate
+PNGs live under `extensions/renderers/unity/plates/`.
 
 ```jsonc
 {
@@ -273,12 +307,16 @@ StreamingAssets `plates_manifest.json` — no scene reload, no per-room bake, no
       "plate": "plates/<file>.png",
       "planeSize": [W, H],
       "cameraPin": { "ortho": 13.0, "pitch": 30.0, "yaw": 45.0 },
-      "stage": "stage.json",
       "effects": [ { "type": "fire_medium", "cell": [5, 8], "scale": 1.5 } ]
     }
   }
 }
 ```
+**No per-plate `stage` field** — `CombatSurfaceClient.LoadPlateManifest` only parses `plate`,
+`planeSize`, `cameraPin`, and `effects` per entry (`CombatSurfaceClient.cs` `PlateEntry`/
+`LoadPlateManifest`). Stage data (fire flicker/glow anchors, #1463 W6.4) is a SEPARATE, single global
+`StreamingAssets/stage.json` copied verbatim by the same packaging step — it is not keyed per-plate
+and adding a `"stage"` key to a plate entry above is a silent no-op.
 
 **`effects[]` is the additive VFX-anchor mechanism** (PR #1525, VFX-ANCHORS): on plate load/swap,
 `CombatSurfaceClient.SpawnPlateEffects` despawns prior effect instances and spawns each entry's
@@ -325,7 +363,8 @@ just promoted doesn't appear in the player.
 
 ## Standing instruments that validate a room after it ships
 
-See `docs/OPERATIONS.md` "Standing visual/pipeline instruments" — the coherence gate
-(`check_grid_paint_coherence.py`) and journey-eval (`qa/journey_eval.py`) both run against a shipped
-room; `qa/evidence/journey-eval-first-run/RECALL.md` documents the current instrument gap (the
-legal-path blind spot, #1523) so you know what journey-eval does and does NOT yet catch.
+See `docs/OPERATIONS.md` "Journey-eval + the coherence gate — standing instruments" — the coherence
+gate (`check_grid_paint_coherence.py`) and journey-eval (`qa/journey_eval.py`) both run against a
+shipped room; `qa/evidence/journey-eval-first-run/RECALL.md` documents the current instrument gap
+(the legal-path blind spot, #1523) so you know what journey-eval does and does NOT yet catch. Both
+runners have rows in `docs/RUNBOOK-INDEX.md` "Visual / render".

--- a/docs/RUNBOOK-INDEX.md
+++ b/docs/RUNBOOK-INDEX.md
@@ -28,6 +28,8 @@
 |---|---|---|---|---|---|
 | visual pre-gate | `qa/visual_pregate.py` | free, every render | verdict numbers + manifest path (gate, not history) | — (gate) | visual-critic skill |
 | visual-critic panel | `qa/felt_rest_panel.py` / panel protocol | ~$2/scene | frames in qa/evidence/<n>/ + per-lens scores | visual (auto via felt_rest_panel; ⚠ other paths verify) | visual-critic skill |
+| coherence gate | `qa/check_grid_paint_coherence.py` | free, per registered plate candidate (BEFORE the panel) | per-prop offset (cells) + peak-NCC numbers, pass/fail (gate, not history) | — (gate) | ROOM-PIPELINE-RUNBOOK step 5; #1462/#1491 |
+| journey-eval | `qa/journey_eval.py` | ~$1 (per-frame VQA), per shipped room | frames + frames_manifest.json + journey_verdict.json in qa/journey_runs/<run>/ | — (gate; ⚠ v1 has the legal-path blind spot, #1523 — no scores_ledger row) | ROOM-PIPELINE-RUNBOOK + qa/evidence/journey-eval-first-run/RECALL.md |
 | box render/capture | gex44-unity-host skill + manage_camera | free (GPU) | PNG captures (super_size 2-4) → feeds pre-gate/panel | — (feeds visual) | BOX.md + gex44-unity-host; ⚠ motion_reel.py capture hook is a TODO stub |
 | demo reel | `qa/demo_reel.py` | free | frame series + GIF (the pixels rule artifact) | — (visibility) | OPERATIONS pixels rule |
 

--- a/qa/evidence/journey-eval-first-run/RECALL.md
+++ b/qa/evidence/journey-eval-first-run/RECALL.md
@@ -1,0 +1,79 @@
+# RECALL — owner playtest #7 vs journey-eval run 1 (the legal-path blind spot, #1523)
+
+This table is the honest instrument record for `journey_eval.py` v1's first live run
+(`journey_verdict.json`, this directory; see `NOTES.md` for the full run report). It compares what a
+**human playtest** (owner, playtest #7 — `qa/evidence/camp-tune/findings.json`) found by hand against
+what the **automated journey-eval instrument** caught on its first live run, so the instrument's real
+recall — not its intended recall — is on record before anyone cites a clean journey-eval run as proof
+a room has no missing-footprint defects.
+
+## Why this comparison exists
+
+`journey_eval.py` walks a scripted path of clicks the ENGINE considers legal, then asks factual VQA
+questions of the resulting frames. That method has a structural hole named in #1523: it **cannot
+click onto a cell the engine already refuses** (an unwalkable/impassable cell), so it can never
+observe the specific defect class "the engine accepted a move onto a cell whose paint reads as a
+solid object" — a missing-footprint bug is invisible to a run that only walks legal paths. Playtest
+#7 found exactly that class by hand, on the same room (`camp_clearing_night_truegrey_v1.png`), before
+any of it was fixed. The recall table below is the receipt.
+
+## Owner playtest #7 defects (human eyeball, pre-fix) — `qa/evidence/camp-tune/findings.json`
+
+| # | Defect | Class | Fixed by (author_room_geometry / derive_room_manifest re-authoring) |
+|---|--------|-------|---|
+| 1 | **Woodpile** walkable (should block) | missing footprint | `FIREWOOD_CELLS` extended onto the painted log mass |
+| 2 | **Crate stack** (left) walkable on boxes + a phantom blocked cell with no paint under it | missing footprint + phantom occlusion | `CRATE_L_CELLS` re-authored to the 3 actually-painted boxes; phantom `POST_CELLS` retired |
+| 3 | **Hut/shelter** (top-center) walk-through | missing footprint | `SHELTER_CELLS` re-authored to the posts + back wall/canvas |
+| 4 | Top-right **trees / camp exit**: over-covering occlusion hid the player near the exit | occlusion-hull bug (not a footprint miss) | `wall_br` split into 3 short runs — hull shrank 48 cells → 7 cells apiece |
+| — | **Fire-pit blocking** | — | Confirmed CORRECT already — not a defect; no fix needed |
+
+Note: item 4 (trees/exit) is an *occlusion* bug (the silhouette hull over-covered open ground), not a
+missing-footprint bug like 1-3 — it's included here because it's part of the same playtest-#7 punch
+list the owner named, but it's a different mechanism (see `docs/ROOM-PIPELINE-RUNBOOK.md` step 2,
+"footprint-vs-occlusion is the distinction CAMP-TUNE's defect #5 turned on").
+
+## What journey-eval run 1 caught (`journey_verdict.json`, PR #1520, ship-camp-1 session)
+
+The run walked the crypt→parley→door-cross→combat-entry loop over `walkslice_smoke01` (a different
+campaign/manifest than camp-tune's fixture, but the same class of question — does the legal path look
+right). 9 frames captured, 6/6 click steps landed clean.
+
+| Finding | How caught | Class |
+|---|---|---|
+| `combat_entry/post` → `transition_backdrop_unchanged` (1 of 9 frames flagged) | Automated VQA (transition pair-check) | Combat-entry not visibly registering (goblin cell guess miss, or a render/click gap) — NOT a footprint defect |
+| "Mira the Keeper" parley dialog persists across the door-cross transition | Manual eyeball, NOT one of the tracked VQA questions | UI/dialog-lifecycle gap, flagged for awareness only, not filed in-lane |
+
+**All automated on-prop / t-pose / floating / missing-or-cloned / broken-backdrop flags were clean
+across every frame** — including direct approaches to the crypt's sarcophagus and both pillars.
+
+## The recall number
+
+**0 of the 4 playtest-#7 missing-footprint-class defects (woodpile, crate stack, hut, trees/exit)
+would have been catchable by journey-eval v1's methodology, even on this exact run's room** — not
+because they were re-introduced (camp-tune's fixes were already merged by the time this run executed),
+but because journey-eval v1 structurally cannot produce the observation "the engine accepted a click
+onto a painted-solid cell." It only asks factual questions of frames reached via LEGAL clicks; a
+missing-footprint bug is, by definition, a cell the engine treats as legal that shouldn't be. Confirmed
+directly in #1523's own framing: *"currently 0/4 by the legal-path run."*
+
+**What journey-eval v1 IS good at (this run's real catch):** transition-integrity questions (did the
+backdrop plausibly change on a room-crossing action) and, per the manual-eyeball note, surfacing
+UI-lifecycle oddities a VQA question set didn't anticipate — genuinely different defect classes than
+playtest #7's, not a subset or superset of it.
+
+## The fix in flight
+
+**journey_eval v2 (#1523)** adds the missing adversarial phase: click every painted-prop candidate
+region (from the manifest's footprint+occlusion sets, plus a coarse grid sweep of high-texture
+regions) and flag whenever the engine ACCEPTS the move onto a cell whose paint reads as a solid
+object — the mechanism that would have caught all 3 of playtest #7's missing-footprint defects (1-3
+above) automatically, pre-ship, instead of relying on the owner's eyes. Recall target: 4/4 (or a
+justified partial) against this same playtest-#7 punch list, re-run once v2 lands.
+
+## Standing implication for anyone shipping a room
+
+See `docs/OPERATIONS.md` "Journey-eval + the coherence gate — standing instruments": until v2 lands,
+a clean journey-eval v1 run is evidence the LEGAL path looks right — it is not evidence the room has
+no missing-footprint defects. Run `qa/check_grid_paint_coherence.py` (the absolute grid↔paint gate)
+and, ideally, a human pass over the manifest's prop list against the painted plate before treating a
+room as free of this defect class.

--- a/qa/evidence/journey-eval-first-run/RECALL.md
+++ b/qa/evidence/journey-eval-first-run/RECALL.md
@@ -48,8 +48,8 @@ across every frame** — including direct approaches to the crypt's sarcophagus 
 
 ## The recall number
 
-**0 of the 4 playtest-#7 missing-footprint-class defects (woodpile, crate stack, hut, trees/exit)
-would have been catchable by journey-eval v1's methodology, even on this exact run's room** — not
+**0 of 3 playtest-#7 missing-footprint-class defects (woodpile, crate stack, hut) would have been
+catchable by journey-eval v1's methodology, even on this exact run's room** — not
 because they were re-introduced (camp-tune's fixes were already merged by the time this run executed),
 but because journey-eval v1 structurally cannot produce the observation "the engine accepted a click
 onto a painted-solid cell." It only asks factual questions of frames reached via LEGAL clicks; a
@@ -67,8 +67,16 @@ playtest #7's, not a subset or superset of it.
 region (from the manifest's footprint+occlusion sets, plus a coarse grid sweep of high-texture
 regions) and flag whenever the engine ACCEPTS the move onto a cell whose paint reads as a solid
 object — the mechanism that would have caught all 3 of playtest #7's missing-footprint defects (1-3
-above) automatically, pre-ship, instead of relying on the owner's eyes. Recall target: 4/4 (or a
-justified partial) against this same playtest-#7 punch list, re-run once v2 lands.
+above) automatically, pre-ship, instead of relying on the owner's eyes.
+
+**Recall target: 3/3 on the missing-footprint class** (woodpile, crate stack, hut — items 1-3), not
+4/4 against the full punch list. Item 4 (trees/exit over-occlusion) is a DIFFERENT mechanism — an
+occlusion-hull sizing bug, not an accepted-move-onto-a-solid-cell bug — and v2's click-and-flag
+adversarial phase as scoped does not exercise it. Don't let "4/4" become the tracked target for #1523;
+that would set future agents up to expect v2 to close an occlusion-regression class it was never
+built to catch. If occlusion-hull regressions need their own standing check, that's a separate
+follow-up (e.g. a hull-size-vs-footprint-size assertion in `derive_room_manifest.py`'s own test
+suite), not a v2 deliverable. Re-run the 3/3 footprint check once v2 lands.
 
 ## Standing implication for anyone shipping a room
 

--- a/qa/evidence/journey-eval-first-run/RECALL.md
+++ b/qa/evidence/journey-eval-first-run/RECALL.md
@@ -10,12 +10,19 @@ a room has no missing-footprint defects.
 ## Why this comparison exists
 
 `journey_eval.py` walks a scripted path of clicks the ENGINE considers legal, then asks factual VQA
-questions of the resulting frames. That method has a structural hole named in #1523: it **cannot
-click onto a cell the engine already refuses** (an unwalkable/impassable cell), so it can never
-observe the specific defect class "the engine accepted a move onto a cell whose paint reads as a
-solid object" — a missing-footprint bug is invisible to a run that only walks legal paths. Playtest
-#7 found exactly that class by hand, on the same room (`camp_clearing_night_truegrey_v1.png`), before
-any of it was fixed. The recall table below is the receipt.
+questions of the resulting frames (including a per-frame "is the character standing on a painted
+object?" check, asked of every captured frame, not just deliberate approach steps). **This is a
+coverage gap, not a structural impossibility:** a missing-footprint cell (one the engine wrongly
+treats as walkable) is itself engine-legal, so a frame that happens to land on one COULD in
+principle trip that check. The real hole named in #1523 is that v1's script never DELIBERATELY
+routes through candidate painted-solid regions to test them — the auto-derived `prop_approach` steps
+target cells adjacent to props the manifest ALREADY marks impassable (`qa/journey_eval.py`: "one
+prop_approach step per impassable"), which by definition excludes exactly the props a
+missing-footprint bug is about; the plan-authored waypoints (start/parley/door/combat) are chosen for
+narrative reasons, not to probe suspect cells. So recall against this defect class is **unguaranteed,
+not impossible** — it depends entirely on whether the scripted route happens to cross the bad cell.
+Playtest #7 found this class by hand, on the same room (`camp_clearing_night_truegrey_v1.png`),
+before any of it was fixed. The recall table below is the receipt.
 
 ## Owner playtest #7 defects (human eyeball, pre-fix) — `qa/evidence/camp-tune/findings.json`
 
@@ -49,12 +56,14 @@ across every frame** — including direct approaches to the crypt's sarcophagus 
 ## The recall number
 
 **0 of 3 playtest-#7 missing-footprint-class defects (woodpile, crate stack, hut) would have been
-catchable by journey-eval v1's methodology, even on this exact run's room** — not
-because they were re-introduced (camp-tune's fixes were already merged by the time this run executed),
-but because journey-eval v1 structurally cannot produce the observation "the engine accepted a click
-onto a painted-solid cell." It only asks factual questions of frames reached via LEGAL clicks; a
-missing-footprint bug is, by definition, a cell the engine treats as legal that shouldn't be. Confirmed
-directly in #1523's own framing: *"currently 0/4 by the legal-path run."*
+reliably caught by journey-eval v1's methodology, even on this exact run's room** — not because they
+were re-introduced (camp-tune's fixes were already merged by the time this run executed), but
+because journey-eval v1's scripted route never deliberately visits a cell just because it LOOKS
+solid; it only visits cells the manifest/plan already picked for other reasons (adjacent to a
+KNOWN-impassable prop, or a narrative waypoint). A missing-footprint cell is exactly the one class
+of cell that method structurally never targets on purpose — it would only get caught by accident, if
+the route happened to cross it. Confirmed directly in #1523's own framing: *"currently 0/4 by the
+legal-path run."*
 
 **What journey-eval v1 IS good at (this run's real catch):** transition-integrity questions (did the
 backdrop plausibly change on a room-crossing action) and, per the manual-eyeball note, surfacing

--- a/qa/evidence/journey-eval-first-run/RECALL.md
+++ b/qa/evidence/journey-eval-first-run/RECALL.md
@@ -31,13 +31,16 @@ before any of it was fixed. The recall table below is the receipt.
 | 1 | **Woodpile** walkable (should block) | missing footprint | `FIREWOOD_CELLS` extended onto the painted log mass |
 | 2 | **Crate stack** (left) walkable on boxes + a phantom blocked cell with no paint under it | missing footprint + phantom occlusion | `CRATE_L_CELLS` re-authored to the 3 actually-painted boxes; phantom `POST_CELLS` retired |
 | 3 | **Hut/shelter** (top-center) walk-through | missing footprint | `SHELTER_CELLS` re-authored to the posts + back wall/canvas |
-| 4 | Top-right **trees / camp exit**: over-covering occlusion hid the player near the exit | occlusion-hull bug (not a footprint miss) | `wall_br` split into 3 short runs — hull shrank 48 cells → 7 cells apiece |
+| 4 | **Top-right ruin**: walk into the wall slightly (previously unmodeled) | missing footprint | 3 new props added — `ruin_tower1`, `ruin_tower2`, `ruin_link` |
+| 5 | Top-right **trees / camp exit**: over-covering occlusion hid the player near the exit | occlusion-hull bug (not a footprint miss) | `wall_br` split into 3 short runs — hull shrank 48 cells → 7 cells apiece |
 | — | **Fire-pit blocking** | — | Confirmed CORRECT already — not a defect; no fix needed |
 
-Note: item 4 (trees/exit) is an *occlusion* bug (the silhouette hull over-covered open ground), not a
-missing-footprint bug like 1-3 — it's included here because it's part of the same playtest-#7 punch
+Note: item 5 (trees/exit) is an *occlusion* bug (the silhouette hull over-covered open ground), not a
+missing-footprint bug like 1-4 — it's included here because it's part of the same playtest-#7 punch
 list the owner named, but it's a different mechanism (see `docs/ROOM-PIPELINE-RUNBOOK.md` step 2,
-"footprint-vs-occlusion is the distinction CAMP-TUNE's defect #5 turned on").
+"footprint-vs-occlusion is the distinction CAMP-TUNE's defect #5 turned on"). Items 1-4 are ALL
+missing-footprint-class — four, not three; an earlier draft of this file dropped item 4 (the ruin)
+and misnumbered item 5 as "item 4," undercounting the missing-footprint denominator. Fixed here.
 
 ## What journey-eval run 1 caught (`journey_verdict.json`, PR #1520, ship-camp-1 session)
 
@@ -55,14 +58,14 @@ across every frame** — including direct approaches to the crypt's sarcophagus 
 
 ## The recall number
 
-**0 of 3 playtest-#7 missing-footprint-class defects (woodpile, crate stack, hut) would have been
-reliably caught by journey-eval v1's methodology, even on this exact run's room** — not because they
-were re-introduced (camp-tune's fixes were already merged by the time this run executed), but
+**0 of 4 playtest-#7 missing-footprint-class defects (woodpile, crate stack, hut, ruin) would have
+been reliably caught by journey-eval v1's methodology, even on this exact run's room** — not because
+they were re-introduced (camp-tune's fixes were already merged by the time this run executed), but
 because journey-eval v1's scripted route never deliberately visits a cell just because it LOOKS
 solid; it only visits cells the manifest/plan already picked for other reasons (adjacent to a
 KNOWN-impassable prop, or a narrative waypoint). A missing-footprint cell is exactly the one class
 of cell that method structurally never targets on purpose — it would only get caught by accident, if
-the route happened to cross it. Confirmed directly in #1523's own framing: *"currently 0/4 by the
+the route happened to cross it. This matches #1523's own framing exactly: *"currently 0/4 by the
 legal-path run."*
 
 **What journey-eval v1 IS good at (this run's real catch):** transition-integrity questions (did the
@@ -75,17 +78,17 @@ playtest #7's, not a subset or superset of it.
 **journey_eval v2 (#1523)** adds the missing adversarial phase: click every painted-prop candidate
 region (from the manifest's footprint+occlusion sets, plus a coarse grid sweep of high-texture
 regions) and flag whenever the engine ACCEPTS the move onto a cell whose paint reads as a solid
-object — the mechanism that would have caught all 3 of playtest #7's missing-footprint defects (1-3
+object — the mechanism that would have caught all 4 of playtest #7's missing-footprint defects (1-4
 above) automatically, pre-ship, instead of relying on the owner's eyes.
 
-**Recall target: 3/3 on the missing-footprint class** (woodpile, crate stack, hut — items 1-3), not
-4/4 against the full punch list. Item 4 (trees/exit over-occlusion) is a DIFFERENT mechanism — an
-occlusion-hull sizing bug, not an accepted-move-onto-a-solid-cell bug — and v2's click-and-flag
-adversarial phase as scoped does not exercise it. Don't let "4/4" become the tracked target for #1523;
-that would set future agents up to expect v2 to close an occlusion-regression class it was never
-built to catch. If occlusion-hull regressions need their own standing check, that's a separate
-follow-up (e.g. a hull-size-vs-footprint-size assertion in `derive_room_manifest.py`'s own test
-suite), not a v2 deliverable. Re-run the 3/3 footprint check once v2 lands.
+**Recall target: 4/4 on the missing-footprint class** (woodpile, crate stack, hut, ruin — items 1-4)
+— this matches #1523's own "0/4" framing exactly. Item 5 (trees/exit over-occlusion) is a DIFFERENT
+mechanism — an occlusion-hull sizing bug, not an accepted-move-onto-a-solid-cell bug — and v2's
+click-and-flag adversarial phase as scoped does not exercise it, so don't fold it into the tracked
+#1523 target: that would set future agents up to expect v2 to close an occlusion-regression class it
+was never built to catch. If occlusion-hull regressions need their own standing check, that's a
+separate follow-up (e.g. a hull-size-vs-footprint-size assertion in `derive_room_manifest.py`'s own
+test suite), not a v2 deliverable. Re-run the 4/4 footprint check once v2 lands.
 
 ## Standing implication for anyone shipping a room
 


### PR DESCRIPTION
## Summary

- Overnight docs-consolidate lane: make this week's pipeline + process changes discoverable for any future cold agent (owner directive).
- Docs + template only — no engine/renderer/box changes, additive throughout.

## Linked Issue

Closes #

## Changes

- **`docs/ROOM-PIPELINE-RUNBOOK.md` (new)** — the true-greybox room pipeline end-to-end with exact commands/files: author geometry (`tools/author_room_geometry.py`) -> derive manifest (`tools/derive_room_manifest.py`) -> greybox render (+ optional depth/normal sidecars) -> registered base (flux depth-CN) -> coherence gate -> style pass (reference-images law + structure/dimetric locks) -> blind panel (in-band control recipe) -> `promote.py --batch` -> `plates_manifest.json` + `effects[]` anchors (PR #1525 mechanism) -> player pickup (box rebuild). Cross-links every decision record (PLATE-RECIPE-DECISION, TILED-SPACE-SPIKE ruling, GENERATOR-EXPORT-CONTRACT, W5E-PLATE-REGISTRY-DECISION, VISUAL-PROMOTION-GATE-DECISION) and includes the DunGen/Tessera generator path as the structure-source alternative.
- **`.github/pull_request_template.md`** — strengthened the visual-evidence section to mandate frames be **embedded inline** (markdown image syntax) rather than merely linked/referenced ("the owner browses PRs — frames must render inline").
- **`docs/OPERATIONS.md`** — four additive sections: worktree discipline (exact-path-only removal + `.worldos-keep` marker, per #1516's three-lanes-deleted incident); the orchestrator-eyeball rule (owner-bound visuals get a personal review before shipping); box claim-queue etiquette (poll boundedly, repo-side-first + the Built-in-RP note); journey-eval + the coherence gate as standing instruments, with the #1523 v2 legal-path-blind-spot note.
- **`qa/evidence/journey-eval-first-run/RECALL.md` (new)** — the honest recall table: owner playtest #7's hand-found defects (woodpile/crates/hut/trees-exit-occluder, fire-block confirmed correct) vs what journey-eval run 1 automatically caught (combat-entry transition flag + a manual parley-persist note) — 0/4 on the missing-footprint class, the legal-path blind spot #1523 exists to close.

## Licensing / CLA

- [x] I have read `CLA.md` and submit this contribution under the WorldOS Contributor License Agreement.
- [x] I have not included confidential information, private customer data, private imported content, or third-party-restricted material.
- [x] Any third-party material in this PR is clearly identified with source and license.

## Validation

Docs-only change. Verified every cross-linked file/decision-record path exists in-repo (`docs/roadmap/*`, `qa/*`, `tools/*`); no code paths touched; no test surface.

## Release / WorldOS Proof Tier

- [x] Not release-affecting

## Release Notes / Changelog

- Release-note impact: none (internal docs)
- Verification/evidence tail needed?: no

## Notes For Next Agent

- Exact next action: none — this closes the docs-consolidate lane. journey_eval v2 (#1523) is the tracked follow-up that will let `RECALL.md`'s recall number be re-measured.