### PR TITLE
walkslice: camp return door + spawn off the extended firewood footprint

### DIFF
--- a/qa/seed_gfx_walkslice.py
+++ b/qa/seed_gfx_walkslice.py
@@ -34,6 +34,12 @@ DOOR = [6, 0]
 # (cols 2-7 x rows 7-9) and both pillars — a prop-free door zone. The crypt is the hub: camp <-> crypt
 # <-> tavern.
 TAVERN_DOOR = [0, 5]
+# The camp's RETURN doorway back to the crypt (SHIP-MORNING smoke's "known gap": the camp grid had no
+# authored door_cells, so the camp was a DEAD END for a real player — the smoke could only leave via the
+# QA-side travel_to primitive). Top-edge (5,0) sits in the painted gate-post gap on the north path; the
+# camp's rows 0-1 carry no prop footprint, so the door cell and its Chebyshev-1 landing ring
+# (cols 4-6 x rows 0-1) are prop-free by construction.
+CAMP_DOOR = [5, 0]
 
 
 def build_crypt_grid(loc_id: str):
@@ -62,6 +68,30 @@ def build_crypt_grid(loc_id: str):
     # re-measured pillars ((3,3)/(3,4) and (8,9)/(9,9)), owner-playtest-#5 collision-coherence.
     grid.spawns = {"party": [(3, 5), (4, 5)], "npcs": [(3, 6)]}
     grid.art.layout_hash = sg._layout_hash(grid)  # layout changed (added door) — refresh the hash
+    return grid
+
+
+def build_camp_grid(loc_id: str):
+    """The walkslice camp = the CANONICAL camp_clearing_night grid (``seed_gfx_camp._build_camp_grid``
+    — ONE camp source, #1396 coherence class) plus the walkslice's world topology: the RETURN doorway
+    to the crypt at ``CAMP_DOOR`` (the painted gate-post gap, top edge) and rest-mode ``spawns`` on
+    clear ground by the fire. Two defects fixed here (ship-morning frames, orchestrator eyeball +
+    data-verified): (1) the camp had NO door_cells — a dead end for a clicking player; (2) the old
+    party spawn (8,9) collided with the firewood footprint after CAMP-TUNE (#1526) extended it to
+    [[7,8],[8,8],[8,9]] — the hero rendered standing ON the woodpile. Pure (no server) — directly
+    unit-testable, mirroring ``build_crypt_grid``."""
+    import scene_grid as sg  # noqa: PLC0415
+    import seed_gfx_camp as camp  # noqa: PLC0415  (reuse the camp_clearing_night grid — ONE camp source)
+
+    grid = camp._build_camp_grid(CID, loc_id)
+    # the camp has no perimeter wall cells (outdoor clearing; walkable floor by default), so the door
+    # only needs an explicit door-typed cell + the door_cells registration for the renderer's glow/label.
+    grid.cells.append(sg.SceneCell(c=CAMP_DOOR[0], r=CAMP_DOOR[1], type="door", walkable=True))
+    grid.door_cells = [(CAMP_DOOR[0], CAMP_DOOR[1])]
+    # party on the clear open ground between the fire ((4-5,8-9)) and the firewood ((7,8)-(8,9)):
+    # (6,9)/(7,9) touch no footprint; NPC (9,7) clear of the back-right wall run ((10,5)...).
+    grid.spawns = {"party": [(6, 9), (7, 9)], "npcs": [(9, 7)]}
+    grid.art.layout_hash = sg._layout_hash(grid)  # layout changed (door + spawns) — refresh the hash
     return grid
 
 
@@ -138,7 +168,6 @@ def main() -> None:
     sys.path.insert(0, os.path.join(HERE, "..", "servers", "engine"))
     import server  # noqa: PLC0415
     from models import Campaign  # noqa: PLC0415
-    import seed_gfx_camp as camp  # noqa: PLC0415  (reuse the camp_clearing_night grid — ONE camp source)
 
     server.save_campaign(Campaign(
         id=CID, title="Walkable Slice smoke",
@@ -167,8 +196,9 @@ def main() -> None:
     for neighbour in (camp_loc["id"], tavern_loc["id"]):
         if neighbour not in c.locations[crypt_loc["id"]].connections:
             c.locations[crypt_loc["id"]].connections.append(neighbour)
-    camp_grid = camp._build_camp_grid(CID, camp_loc["id"])
-    camp_grid.spawns = {"party": [(8, 9), (7, 9)], "npcs": [(9, 7)]}
+    # the camp carries the canonical grid + its RETURN door to the crypt (no more dead end) + spawns
+    # moved off the extended firewood footprint — see build_camp_grid.
+    camp_grid = build_camp_grid(camp_loc["id"])
     c.locations[camp_loc["id"]].scene_grid = camp_grid
     # the tavern carries its own world-true grid + a back-wall door_cell returning to the crypt.
     tavern_grid = build_tavern_grid(tavern_loc["id"])

--- a/servers/engine/tests/test_walkslice_seed_grid.py
+++ b/servers/engine/tests/test_walkslice_seed_grid.py
@@ -20,6 +20,7 @@ if _QA not in sys.path:
 
 import server  # noqa: E402, F401  (import-first: resolves the models<->scene_grid import cycle)
 import scene_grid as sg  # noqa: E402
+import seed_gfx_camp as camp_seed  # noqa: E402
 import seed_gfx_combat as combat  # noqa: E402
 import seed_gfx_walkslice as ws  # noqa: E402
 
@@ -27,6 +28,8 @@ W, H = combat.GRID_W, combat.GRID_H  # 14x11
 DOOR = (ws.DOOR[0], ws.DOOR[1])
 TAVERN_DOOR = (ws.TAVERN_DOOR[0], ws.TAVERN_DOOR[1])
 TW, TH = ws.TAVERN_W, ws.TAVERN_H  # 12x10
+CW, CH = camp_seed.GRID_W, camp_seed.GRID_H  # 16x12
+CAMP_DOOR = (ws.CAMP_DOOR[0], ws.CAMP_DOOR[1])
 
 
 def _impassable(grid) -> set[tuple[int, int]]:
@@ -35,6 +38,10 @@ def _impassable(grid) -> set[tuple[int, int]]:
 
 def _impassable_t(grid) -> set[tuple[int, int]]:
     return {(x, y) for (x, y) in (tuple(cell) for cell in sg.impassable_cells(grid, TW, TH))}
+
+
+def _impassable_c(grid) -> set[tuple[int, int]]:
+    return {(x, y) for (x, y) in (tuple(cell) for cell in sg.impassable_cells(grid, CW, CH))}
 
 
 def test_walkslice_crypt_reuses_canonical_grid_minus_the_doors():
@@ -113,3 +120,33 @@ def test_walkslice_tavern_spawns_are_walkable_and_off_props():
         for (c, r) in cells:
             assert (c, r) not in blocked, f"tavern {role} spawn {(c, r)} is BLOCKED (wall/prop)"
             assert (c, r) not in prop_cells, f"tavern {role} spawn {(c, r)} stands on a prop"
+
+
+def test_walkslice_camp_has_a_walkable_return_door():
+    """The camp is NOT a dead end (the ship-morning smoke's 'known gap': no authored door_cells meant a
+    clicking player could never leave — the smoke escaped via the QA-side travel_to primitive). One
+    door cell back to the crypt, in the prop-free painted gate-post gap on the top edge, walkable, with
+    a clear Chebyshev-1 landing ring."""
+    grid = ws.build_camp_grid("camp")
+    assert grid.door_cells == [CAMP_DOOR]
+    blocked = _impassable_c(grid)
+    assert CAMP_DOOR not in blocked, "camp return door must be walkable"
+    for dc in range(-1, 2):
+        for dr in range(0, 2):  # rows -1 are off-grid; ring rows 0-1
+            cell = (CAMP_DOOR[0] + dc, CAMP_DOOR[1] + dr)
+            if 0 <= cell[0] < CW and 0 <= cell[1] < CH:
+                assert cell not in blocked, f"camp door landing ring cell {cell} is blocked"
+
+
+def test_walkslice_camp_spawns_are_walkable_and_off_props():
+    """Party + NPC spawn on clear ground. Regression: the old party spawn (8,9) collided with the
+    firewood footprint after CAMP-TUNE (#1526) extended it to include (8,9) — the hero rendered
+    standing ON the woodpile (ship-morning frame2, orchestrator-eyeball find)."""
+    grid = ws.build_camp_grid("camp")
+    blocked = _impassable_c(grid)
+    prop_cells = {(c, r) for p in grid.props for (c, r) in p.cells}
+    assert (8, 9) in prop_cells, "premise: (8,9) is a firewood footprint cell (#1526)"
+    for role, cells in grid.spawns.items():
+        for (c, r) in cells:
+            assert (c, r) not in blocked, f"camp {role} spawn {(c, r)} is BLOCKED (prop)"
+            assert (c, r) not in prop_cells, f"camp {role} spawn {(c, r)} stands on a prop"


### PR DESCRIPTION
## What

Two data-verified defects in the walkslice camp, both found by orchestrator eyeball on the ship-morning frames and confirmed against the snapshot + manifest:

1. **The camp was a dead end.** `camp_clearing_night`'s scene_grid had NO `door_cells` — a clicking player could enter from the crypt and never leave (the ship-morning smoke's camp→crypt "PASS" used the QA-side `travel_to` primitive; its SMOKE_RESULT.md flagged this as a known gap). New `CAMP_DOOR = (5,0)` sits in the painted gate-post gap on the north path; camp rows 0-1 carry no prop footprint, so the door cell and its Chebyshev-1 landing ring are prop-free by construction. Single door → `connections[0]` resolution is correct both pre- and post-#1532.
2. **The hero spawned standing ON the woodpile.** The walkslice party spawn `(8,9)` collided with the firewood footprint after CAMP-TUNE (#1526) extended it to `[[7,8],[8,8],[8,9]]`. Moved to `(6,9)/(7,9)` — clear ground between the fire and the woodpile.

New pure helper `build_camp_grid(loc_id)` mirrors `build_crypt_grid` (ONE camp source reused via `seed_gfx_camp._build_camp_grid`, walkslice topology added on top, layout hash refreshed after mutation — which also fixes the previously stale hash from `main()` mutating spawns post-hash).

## Tests

- `test_walkslice_camp_has_a_walkable_return_door` — door registered, walkable, clear landing ring.
- `test_walkslice_camp_spawns_are_walkable_and_off_props` — asserts the (8,9)-is-firewood premise, then that no spawn sits on any footprint.
- 17/17 walkslice + cross_door green locally; seed run end-to-end against a scratch state dir: `door_cells [[5,0]]`, `spawns {'party': [[6,9],[7,9]], 'npcs': [[9,7]]}`.

## Visual Evidence (embedded per template rule)

The defect frame — hero on the woodpile, and no door label anywhere in the camp (dead end):

![camp before](https://raw.githubusercontent.com/electricsheephq/WorldOS/bd295b32/qa/evidence/ship-morning/frame2_camp_fire.png)

Post-merge the owner world gets re-seeded (wt-owner-play at new main) — the return door renders with the standard glow+label at (5,0) in the gate gap; after-frame will accompany the morning report.

Invariants: engine sole writer untouched (seed-only), additive (new helper + constant), no renderer changes.