### PR TITLE
M-ALIGN: reciprocal-door arrival contract — land at the door you came through (#1541)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1388,15 +1388,18 @@ def cross_door(campaign_id: str, x: int, y: int) -> dict:
         raise ValueError(f"{getattr(loc, 'name', '')!r} has no connected room to cross to")
     door_idx = door_cells_list.index((int(x), int(y)))
     dest_id = conns[door_idx] if door_idx < len(conns) else conns[0]
+    source_id = loc.id  # where we crossed FROM — the reciprocal-door anchor in the destination (#1541)
     result = travel_to(campaign_id, dest_id)
     # W4 follow-up (#1378): the party's stage_cell was just CLEARED by travel_to's _move_party_to
     # (per-room scoping). If the destination room is ALSO painted, re-stage the party beside its
     # entry door so the linked room's rest board renders them standing there — not the empty
-    # door-bar state (demo-reel frame 06). ADDITIVE: an un-painted destination gets no writes.
+    # door-bar state (demo-reel frame 06). #1541: anchor on the destination's door back to the
+    # source (the reciprocal door), so you land at the door you'd leave by — not door_cells[0].
+    # ADDITIVE: an un-painted destination gets no writes.
     with campaign_lock(campaign_id):
         c2 = _require(campaign_id)  # fresh state — travel_to persisted its own copy above
         dest = c2.locations.get(c2.current_location_id) if c2.current_location_id else None
-        if dest is not None and _seed_stage_cells_on_arrival(c2, dest):
+        if dest is not None and _seed_stage_cells_on_arrival(c2, dest, source_id=source_id):
             save_campaign(c2)
     result["crossed_door"] = [int(x), int(y)]
     result["multi_connection"] = len(conns) > 1
@@ -4754,11 +4757,24 @@ def _nearest_walkable_cell(
     return None  # no walkable cell anywhere in this room
 
 
-def _seed_stage_cells_on_arrival(c: "Campaign", dest: "Location") -> list[str]:
+def _seed_stage_cells_on_arrival(
+    c: "Campaign", dest: "Location", source_id: str | None = None
+) -> list[str]:
     """W4 follow-up (#1378): on a ``cross_door`` arrival, seed each traveling party member's
     ``Character.stage_cell`` to a walkable cell beside the destination room's entry door, so the
     linked room's rest board renders the party re-staged — not the empty door-bar state left when
     ``_move_party_to`` clears every member's stage_cell on travel.
+
+    RECIPROCAL-DOOR arrival (#1541): when ``source_id`` (the location we just crossed FROM) is
+    given, the arrival door is the destination's door that maps BACK to the source — the
+    ``door_cells[j]`` whose ``connections[j] == source_id`` (the SAME positional authoring
+    convention ``cross_door`` resolves the forward hop by: door_cells[i] -> connections[i]). So
+    exiting the tavern lands the party at the crypt's TAVERN door, not its lowest-sorted (camp)
+    door. Falls back to the lowest-sorted door — the pre-#1541 behavior, byte-identical — when
+    there is NO such door (``source_id`` is ``None``, unmapped, or the destination has fewer door
+    cells than the source's connection index). The party stands BESIDE the door, never on the
+    threshold (``reachable`` excludes the start cell, so members land on its Chebyshev-1 ring and
+    spread outward when it is crowded).
 
     Mirrors ``_seed_combat_cells_from_stage``'s discipline: a deterministic member order, cells
     ranked nearest-the-door first, each member claiming the NEXT free cell so two tokens never
@@ -4771,16 +4787,25 @@ def _seed_stage_cells_on_arrival(c: "Campaign", dest: "Location") -> list[str]:
     grid = getattr(dest, "scene_grid", None)
     if grid is None:
         return []
-    door_cells = sorted({(int(a), int(b)) for (a, b) in (getattr(grid, "door_cells", None) or [])})
+    # RAW (authored-order) door cells for the positional door->connection mapping; the sorted set
+    # (deduped, stable) is the fallback anchor when no reciprocal door resolves.
+    raw_doors = [(int(a), int(b)) for (a, b) in (getattr(grid, "door_cells", None) or [])]
+    door_cells = sorted(set(raw_doors))
     if not door_cells:
         return []
     width, height, blocked = rest_blocked_cells(c, dest)
     if width <= 0 or height <= 0:
         return []
-    # Best-effort ARRIVAL door: the lowest-sorted door of the destination. There is no authored
-    # door->origin map yet (the same limitation cross_door surfaces via `multi_connection`), so a
-    # deterministic first pick stands in. The party stands BESIDE it, never on the threshold.
+    # ARRIVAL door: the RECIPROCAL door back to `source_id` when we know where we came from —
+    # door_cells[j] where the destination's connections[j] == source_id — else the lowest-sorted
+    # door (pre-#1541 best-effort). The party stands BESIDE it, never on the threshold.
     door = door_cells[0]
+    if source_id is not None:
+        conns = [cid for cid in (getattr(dest, "connections", None) or []) if isinstance(cid, str)]
+        for idx, cid in enumerate(conns):
+            if cid == source_id and idx < len(raw_doors):
+                door = raw_doors[idx]
+                break
     # Candidate rest cells: every FREE cell reachable from the door (routes around walls/props so
     # nobody lands in a walled-off pocket), ranked nearest-first with a stable (y, x) tiebreak.
     reach = combat_grid.reachable(door, width + height, set(), width, height, impassable=blocked)

--- a/servers/engine/tests/test_arrival_reciprocal_door.py
+++ b/servers/engine/tests/test_arrival_reciprocal_door.py
@@ -1,0 +1,134 @@
+"""Reciprocal-door arrival contract (#1541, M-ALIGN): crossing a doorway from room A to room B must
+land the party at B's door that maps BACK to A — the door you'd walk through to return — not at B's
+lowest-sorted door. The defect: ``_seed_stage_cells_on_arrival`` always anchored the party at
+``door_cells[0]``, so leaving the tavern (whose crypt-facing door is the crypt's SECOND door) dropped
+the hero beside the crypt's CAMP door instead. Owner playtest #8: exiting the tavern placed him at
+random in the crypt.
+
+Exercises the real walkslice three-room seed (crypt hub <-> camp + tavern) end-to-end.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# the gfx seeds live in <repo>/qa (pythonpath is servers/engine only).
+_QA = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "qa"))
+if _QA not in sys.path:
+    sys.path.insert(0, _QA)
+
+import combat_grid  # noqa: E402
+import server  # noqa: E402  (conftest puts servers/engine on the path)
+import seed_gfx_walkslice as ws  # noqa: E402
+from scene_grid import SceneGrid, SceneGridSpec, SceneCellDefault  # noqa: E402
+
+CRYPT = "crypt"
+CAMP = "camp_clearing_night"
+TAVERN = "tavern"
+DOOR = tuple(ws.DOOR)                      # crypt's camp-facing door (6,0) — door_cells[0]
+TAVERN_DOOR = tuple(ws.TAVERN_DOOR)        # crypt's tavern-facing door (13,4) — door_cells[1]
+CAMP_DOOR = tuple(ws.CAMP_DOOR)            # camp's single return door (5,0)
+TAVERN_BACK_DOOR = tuple(ws.TAVERN_BACK_DOOR)  # tavern's single return door
+
+
+@pytest.fixture
+def seeded(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(sys, "argv", ["seed_gfx_walkslice.py", str(tmp_path)])
+    ws.main()  # in-process seed of the three-room world into tmp_path
+    return ws.CID
+
+
+def _hero_id(cid: str) -> str:
+    c = server._require(cid)
+    return next(hid for hid, ch in c.characters.items() if ch.kind == "player")
+
+
+def test_tavern_round_trip_lands_at_the_reciprocal_door(seeded):
+    """crypt -> tavern -> crypt: returning FROM the tavern must land the hero beside the crypt's
+    TAVERN door (13,4) — the door back to the tavern — NOT the crypt's camp door (6,0), which is
+    door_cells[0] and is where the pre-fix ``door_cells[0]`` anchor wrongly placed him."""
+    cid = seeded
+    hero = _hero_id(cid)
+
+    # A(crypt) -> B(tavern) via the crypt's tavern door.
+    server.cross_door(cid, TAVERN_DOOR[0], TAVERN_DOOR[1])
+    c = server._require(cid)
+    assert c.current_location_id == TAVERN
+    cell = c.characters[hero].stage_cell
+    assert cell is not None
+    assert combat_grid.chebyshev_cells(tuple(cell), TAVERN_BACK_DOOR) <= 1  # at the tavern's return door
+
+    # B(tavern) -> A(crypt) via the tavern's return door: land at the crypt's TAVERN-facing door.
+    server.cross_door(cid, TAVERN_BACK_DOOR[0], TAVERN_BACK_DOOR[1])
+    c = server._require(cid)
+    assert c.current_location_id == CRYPT
+    cell = c.characters[hero].stage_cell
+    assert cell is not None
+    assert combat_grid.chebyshev_cells(tuple(cell), TAVERN_DOOR) <= 1, (
+        f"hero landed at {tuple(cell)} — should be beside the crypt's tavern door {TAVERN_DOOR}, "
+        f"not the camp door {DOOR}"
+    )
+
+
+def test_camp_round_trip_lands_at_the_reciprocal_door(seeded):
+    """crypt <-> camp coherence: the camp leg (whose reciprocal door IS door_cells[0]) still lands
+    the hero beside the camp's return door and back at the crypt's camp door."""
+    cid = seeded
+    hero = _hero_id(cid)
+
+    server.cross_door(cid, DOOR[0], DOOR[1])  # crypt -> camp
+    c = server._require(cid)
+    assert c.current_location_id == CAMP
+    cell = c.characters[hero].stage_cell
+    assert cell is not None
+    assert combat_grid.chebyshev_cells(tuple(cell), CAMP_DOOR) <= 1
+
+    server.cross_door(cid, CAMP_DOOR[0], CAMP_DOOR[1])  # camp -> crypt
+    c = server._require(cid)
+    assert c.current_location_id == CRYPT
+    cell = c.characters[hero].stage_cell
+    assert cell is not None
+    assert combat_grid.chebyshev_cells(tuple(cell), DOOR) <= 1
+
+
+# ── byte-identical fallback: no door back to the source -> today's door_cells[0] anchor ──────────
+def _author_grid(cid, loc_id, door_cells):
+    c = server._require(cid)
+    c.locations[loc_id].scene_grid = SceneGrid(
+        scene_id=f"{cid}:{loc_id}", location_id=loc_id, kind="dungeon", biome="test",
+        grid=SceneGridSpec(cols=14, rows=11, cell_size_ft=5, projection="dimetric-2to1"),
+        cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
+        cells=[], props=[], door_cells=[tuple(d) for d in door_cells],
+    )
+    server.save_campaign(c)
+
+
+def test_fallback_to_first_door_is_byte_identical_when_no_reciprocal(tmp_path, monkeypatch):
+    """When there is no door that maps back to the source, the arrival anchor falls back to the
+    lowest-sorted door — byte-identical to the pre-#1541 behavior (which had no source concept and
+    always used ``door_cells[0]``). Proven by seeding the SAME destination with (a) no source and
+    (b) a source that has no reciprocal door, and asserting an identical placement."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("fallback")["id"]
+    a = server.add_location(campaign_id=cid, name="Room A", make_current=True)["id"]
+    dest = server.add_location(campaign_id=cid, name="Dest", connections=[a])["id"]
+    _author_grid(cid, dest, [[3, 0], [10, 8]])  # two doors; dest.connections == [a]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=30)["id"]
+    c = server._require(cid)
+    c.characters[hero].location_id = dest  # traveling member already in the destination
+    server.save_campaign(c)
+
+    def _seed_with(source_id):
+        cc = server._require(cid)
+        cc.characters[hero].stage_cell = None  # reset before each seed
+        placed = server._seed_stage_cells_on_arrival(cc, cc.locations[dest], source_id=source_id)
+        return placed, cc.characters[hero].stage_cell
+
+    baseline = _seed_with(None)                    # pre-fix contract (no source)
+    no_reciprocal = _seed_with("not-a-connection")  # a source that maps to no door here
+    assert baseline == no_reciprocal               # byte-identical fallback to door_cells[0]
+    # And the fallback anchor is the lowest-sorted door (3,0), not (10,8).
+    assert combat_grid.chebyshev_cells(tuple(baseline[1]), (3, 0)) <= 1


### PR DESCRIPTION
Fixes #1541.

## Defect (code-verified)
`cross_door()` → `travel_to` → `_seed_stage_cells_on_arrival` re-staged the arriving party at the destination's `door_cells[0]` regardless of which room they crossed FROM. So leaving the tavern — whose crypt-facing door is the crypt's **second** door (13,4) — dropped the hero beside the crypt's **camp** door (6,0). Owner playtest #8: exiting the tavern placed him at random in the crypt; exiting the camp spawned him "outside a tree."

## Fix (additive, engine sole-writer invariant)
`_seed_stage_cells_on_arrival` now takes an optional `source_id` (the location just crossed FROM) and anchors the arrival on the **reciprocal door** — the destination's `door_cells[j]` whose `connections[j] == source_id`, the same positional authoring convention `cross_door` uses to resolve the forward hop (`door_cells[i] → connections[i]`). The party lands on that door's walkable **Chebyshev-1 ring** (`combat_grid.reachable` excludes the threshold cell and ranks nearest-first, spreading outward when crowded); NPCs keep their normal staging.

Falls back to today's lowest-sorted `door_cells[0]` anchor — **byte-identical** to pre-#1541 behavior — only when there is no door mapping back to the source (`source_id` is `None`, unmapped, or the destination has fewer door cells than the source's connection index). All existing invariants respected: engine sole writer, additive-by-default, `rest_blocked_cells` blocked-cell filtering stays in force.

## RED-first evidence (engine logic — no pixels)
New `tests/test_arrival_reciprocal_door.py` drives the real walkslice three-room seed (crypt hub ↔ camp + tavern) end-to-end.

Before the fix, the tavern round-trip test failed exactly on the defect:
```
tests/test_arrival_reciprocal_door.py:70: in test_tavern_round_trip_lands_at_the_reciprocal_door
E   AssertionError: hero landed at (5, 1) — should be beside the crypt's tavern door (13, 4), not the camp door (6, 0)
E   assert 8 <= 1
2 failed, 1 passed
```

After the fix, the named acceptance command is green:
```
$ uv run --directory servers/engine python -m pytest tests/test_cross_door.py tests/test_walkslice_seed_grid.py tests/test_arrival_reciprocal_door.py -q -p no:xdist
21 passed in 0.58s
```
Full engine suite: **3526 passed**.

Tests added:
- `test_tavern_round_trip_lands_at_the_reciprocal_door` — the discriminating case (tavern-facing door is the crypt's non-first door).
- `test_camp_round_trip_lands_at_the_reciprocal_door` — camp coherence (reciprocal *is* `door_cells[0]`).
- `test_fallback_to_first_door_is_byte_identical_when_no_reciprocal` — proves the fallback path is unchanged.

Note: the visual-journey lane (#1540) has this same round trip as a screenshot check; this fix is what flips it green. That worktree was not touched.