### PR TITLE
SWEEP-PRECISION: exempt authored occlusion in journey_visual_sweep's inverse-coherence check (#1552 follow-up)

### DIFF
--- a/qa/evidence/sweep-precision/README.md
+++ b/qa/evidence/sweep-precision/README.md
@@ -1,0 +1,66 @@
+# SWEEP-PRECISION evidence
+
+The occlusion-exemption fix to `qa/journey_visual_sweep.py`'s inverse-coherence check (#1552 follow-up).
+Full walkslice-world sweep, scratch viewer, before vs after this fix — same code base commit
+(`fc1a24a9`, includes #1564 CAMP-CELLS + #1565 FRESH-CRYPT), only the detector logic differs.
+
+`before/report.json` — the pre-fix sweep (footprint-only exemption, as it shipped through #1552).
+`after/report.json` — the post-fix sweep (footprint + authored-occlusion exemption, this PR).
+
+## All-rooms CLEAN% — before vs after
+
+| room | plate | CLEAN% before | flags before | CLEAN% after | flags after | occlusion-exempted |
+|---|---|---|---|---|---|---|
+| crypt | `crypt_fresh_v1.png` (#1565's canonical crypt, painted over the sparser un-reconciled walkslice grid, #1559) | **77.9%** | 21/94 | **90.5%** | 9/94 | 12 |
+| camp_clearing_night | `camp_clearing_night_truegrey_v1.png` | 95.6% | 6/134 | 95.6% | 6/134 | 0 (see note) |
+| tavern | `tavern_fit2_v1.png` | 100.0% | 0/43 | 100.0% | 0/43 | 0 (already clean) |
+| **overall** | | **90.1%** | 27 findings | **94.5%** | 15 findings | |
+
+**crypt is the headline case this PR closes.** `crypt_fresh_v1.png` is #1565's richly-authored 20-prop
+crypt, adopted as the canonical `crypt` plate — but the *live* walkslice engine grid hasn't been
+re-authored with fresh-crypt's full prop set yet (`qa/evidence/crypt-fresh/WALKSLICE-RECONCILIATION.md`,
+#1559, explicitly deferred). So today's live crypt room only authors 3 props (`pillar_l`, `pillar_r`,
+`sarcophagus` — the sparse incumbent geometry), while the plate paints all 20. Before this fix, every
+cell the plate's extra silhouette fell on was flagged as "invented furniture" (21 flags, all of them
+really just the plate legitimately being denser than the grid). After this fix, `resolve_occlusion_cells`
+matches each of those 3 *live* props by id+footprint against the committed manifest corpus
+(`qa/room_manifests/*.cells.json`) and exempts the 12 cells that genuinely fall inside their authored
+occlusion bands (`pillar_l`/`pillar_r` resolve via `crypt_dense_v1.cells.json`, `sarcophagus` via the same
+file's 35-cell computed silhouette — see `after/report.json`'s `rooms[].occlusion_notes`).
+
+**The 9 flags that remain are correctly NOT suppressed.** They belong to the separate, already-tracked
+walkslice-reconciliation gap (#1559) — plate content with no authored prop backing it in the live grid at
+all. This fix only ever exempts a cell inside a prop's *authored* occlusion; it never blanket-suppresses
+a room just because it's dense. The negative control in `qa/test_journey_visual_sweep.py`
+(`test_red_first_genuinely_invented_tavern_furniture_still_flags`) proves the same discipline on
+committed, unrelated assets: the old `tavern_truegrey` plate, cross-referenced against the later
+`tavern_fit2` manifest (a stress case — a manifest generation the live room never used), still flags
+4 of 5 baseline cells because no authored prop anywhere covers them.
+
+**camp shows 0 exempted, but for two DIFFERENT reasons, both visible in `occlusion_notes`, neither a
+defect in this fix:**
+1. 16 of camp's 22 live props resolve occlusion cleanly (`camp_truegrey.cells.json` /
+   `camp_clearing_night_v2.cells.json`); the other 6 (`camp_sack`, `firewood_tail`, `gear_stones`,
+   `ruin_rubble1`, `ruin_rubble2`, `shelter_post_r`) are PR #1564's brand-new camp props (CAMP-CELLS,
+   merged the same day as #1565) — the committed manifest predates them, so `resolve_occlusion_cells`
+   correctly logs "no manifest prop matches" and falls back to no exemption (a manifest-regen follow-up).
+2. Camp's 6 flagged cells (`(3,10) (4,10) (9,5) (9,6) (9,7) (9,8)`) are NOT footprint-vs-occlusion at
+   all — #1564's own commit message identifies them as the detector's silhouette band sweeping UP-AND-
+   BACK on screen into a NEIGHBOURING object (the fire, a deliberately-walkable bedroll mat) rather than
+   anything painted at the flagged cell's own floor position, i.e. an ALREADY-TRIAGED false-positive
+   class this PR does not touch (a different defect from the one #1552/#1565 raised). Camp's CLEAN%
+   is correctly unchanged (95.6% both runs) — no regression, no silent improvement claimed.
+
+## Red-first unit proof (`qa/test_journey_visual_sweep.py`)
+
+* `test_red_first_fresh_crypt_dense_room_flags_drop_after_occlusion_exemption` — #1565's fresh crypt
+  scored against its OWN derived manifest (`qa/room_manifests/crypt_fresh.cells.json`, all 20 props
+  matching by id+footprint): 15 baseline flags -> **0** after the fix, all 15 moved to `exempted`.
+* `test_red_first_genuinely_invented_tavern_furniture_still_flags` — the negative control described
+  above: 5 baseline flags -> 4 still flagged, 1 exempted (the shared `hearth` prop's silhouette band).
+
+Reproduce: `python3 -m pytest qa/test_journey_visual_sweep.py -q` (13 pre-existing + 9 new = 22 tests,
+pure functions, no engine/HTTP).
+
+Reproduce the live sweep: `python3 qa/journey_visual_sweep.py run --state-dir <scratch> --rundir <dir>
+--port <port ≥8767, never 8766>`.

--- a/qa/evidence/sweep-precision/after/report.json
+++ b/qa/evidence/sweep-precision/after/report.json
@@ -1,0 +1,863 @@
+{
+  "hub": "crypt",
+  "overall_clean_pct": 94.5,
+  "per_room": [
+    {
+      "room": "crypt",
+      "plate_status": "resolved",
+      "hero_steps": 1,
+      "hero_pass": 1,
+      "walkable_floor_cells": 94,
+      "inverse_coherence_flags": 9,
+      "occlusion_exempted": 12,
+      "clean_pct": 90.5,
+      "meets_95": false
+    },
+    {
+      "room": "camp_clearing_night",
+      "plate_status": "resolved",
+      "hero_steps": 1,
+      "hero_pass": 1,
+      "walkable_floor_cells": 134,
+      "inverse_coherence_flags": 6,
+      "occlusion_exempted": 0,
+      "clean_pct": 95.6,
+      "meets_95": true
+    },
+    {
+      "room": "tavern",
+      "plate_status": "resolved",
+      "hero_steps": 1,
+      "hero_pass": 1,
+      "walkable_floor_cells": 43,
+      "inverse_coherence_flags": 0,
+      "occlusion_exempted": 0,
+      "clean_pct": 100.0,
+      "meets_95": true
+    }
+  ],
+  "findings_by_class": {
+    "invented_furniture_flags": 15,
+    "reciprocal_door_failures": 0,
+    "hero_position_failures": 0
+  },
+  "rooms": [
+    {
+      "room": "crypt",
+      "cols": 14,
+      "rows": 11,
+      "plate": "/Users/lume/WorldOS-worktrees/wt-sweep-precision/qa/evidence/crypt-fresh/crypt_fresh_v1.png",
+      "plate_status": "resolved",
+      "inverse_coherence": {
+        "room": "crypt",
+        "edge_thr": 128,
+        "z_cut": 3.0,
+        "baseline_median": 0.0116,
+        "mad": 0.0087,
+        "threshold": 0.0502,
+        "n_cells": 94,
+        "flagged": [
+          {
+            "cell": [
+              11,
+              4
+            ],
+            "density": 0.1063,
+            "z": 7.36,
+            "ratio": 9.14
+          },
+          {
+            "cell": [
+              4,
+              2
+            ],
+            "density": 0.1051,
+            "z": 7.27,
+            "ratio": 9.04
+          },
+          {
+            "cell": [
+              11,
+              3
+            ],
+            "density": 0.0912,
+            "z": 6.19,
+            "ratio": 7.85
+          },
+          {
+            "cell": [
+              12,
+              4
+            ],
+            "density": 0.0842,
+            "z": 5.64,
+            "ratio": 7.24
+          },
+          {
+            "cell": [
+              12,
+              3
+            ],
+            "density": 0.0813,
+            "z": 5.42,
+            "ratio": 6.99
+          },
+          {
+            "cell": [
+              10,
+              4
+            ],
+            "density": 0.0761,
+            "z": 5.02,
+            "ratio": 6.55
+          },
+          {
+            "cell": [
+              5,
+              1
+            ],
+            "density": 0.0734,
+            "z": 4.8,
+            "ratio": 6.31
+          },
+          {
+            "cell": [
+              10,
+              3
+            ],
+            "density": 0.0577,
+            "z": 3.59,
+            "ratio": 4.97
+          },
+          {
+            "cell": [
+              5,
+              2
+            ],
+            "density": 0.0531,
+            "z": 3.22,
+            "ratio": 4.56
+          }
+        ],
+        "exempted": [
+          {
+            "cell": [
+              6,
+              5
+            ],
+            "density": 0.1093,
+            "z": 7.59,
+            "ratio": 9.4
+          },
+          {
+            "cell": [
+              8,
+              4
+            ],
+            "density": 0.1069,
+            "z": 7.41,
+            "ratio": 9.2
+          },
+          {
+            "cell": [
+              6,
+              4
+            ],
+            "density": 0.101,
+            "z": 6.95,
+            "ratio": 8.69
+          },
+          {
+            "cell": [
+              7,
+              4
+            ],
+            "density": 0.0946,
+            "z": 6.45,
+            "ratio": 8.14
+          },
+          {
+            "cell": [
+              7,
+              5
+            ],
+            "density": 0.0928,
+            "z": 6.31,
+            "ratio": 7.98
+          },
+          {
+            "cell": [
+              7,
+              3
+            ],
+            "density": 0.0677,
+            "z": 4.36,
+            "ratio": 5.82
+          },
+          {
+            "cell": [
+              9,
+              4
+            ],
+            "density": 0.0672,
+            "z": 4.32,
+            "ratio": 5.78
+          },
+          {
+            "cell": [
+              8,
+              3
+            ],
+            "density": 0.0649,
+            "z": 4.14,
+            "ratio": 5.58
+          },
+          {
+            "cell": [
+              5,
+              5
+            ],
+            "density": 0.0579,
+            "z": 3.6,
+            "ratio": 4.98
+          },
+          {
+            "cell": [
+              4,
+              3
+            ],
+            "density": 0.0544,
+            "z": 3.32,
+            "ratio": 4.68
+          },
+          {
+            "cell": [
+              9,
+              3
+            ],
+            "density": 0.0543,
+            "z": 3.32,
+            "ratio": 4.67
+          },
+          {
+            "cell": [
+              8,
+              5
+            ],
+            "density": 0.0522,
+            "z": 3.15,
+            "ratio": 4.49
+          }
+        ],
+        "n_exempted": 12
+      },
+      "flagged_cells": [
+        [
+          11,
+          4
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          11,
+          3
+        ],
+        [
+          12,
+          4
+        ],
+        [
+          12,
+          3
+        ],
+        [
+          10,
+          4
+        ],
+        [
+          5,
+          1
+        ],
+        [
+          10,
+          3
+        ],
+        [
+          5,
+          2
+        ]
+      ],
+      "exempted_cells": [
+        [
+          6,
+          5
+        ],
+        [
+          8,
+          4
+        ],
+        [
+          6,
+          4
+        ],
+        [
+          7,
+          4
+        ],
+        [
+          7,
+          5
+        ],
+        [
+          7,
+          3
+        ],
+        [
+          9,
+          4
+        ],
+        [
+          8,
+          3
+        ],
+        [
+          5,
+          5
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          9,
+          3
+        ],
+        [
+          8,
+          5
+        ]
+      ],
+      "occlusion_notes": [
+        "pillar_l: occlusion from crypt_dense_v1.cells.json (2 cells)",
+        "pillar_r: occlusion from crypt_dense_v1.cells.json (2 cells)",
+        "sarcophagus: occlusion from crypt_dense_v1.cells.json (35 cells)"
+      ],
+      "n_walkable_floor": 94,
+      "calibration": null,
+      "hero_checks": [
+        {
+          "step": 0,
+          "pass": true,
+          "cell": [
+            3,
+            5
+          ],
+          "feet": [
+            525.8,
+            457.1
+          ],
+          "feet_in_quad": true,
+          "on_flagged_cell": false,
+          "reason": null
+        }
+      ]
+    },
+    {
+      "room": "camp_clearing_night",
+      "cols": 16,
+      "rows": 12,
+      "plate": "/Users/lume/WorldOS-worktrees/wt-sweep-precision/qa/evidence/plate-audit/camp_clearing_night_truegrey_v1.png",
+      "plate_status": "resolved",
+      "inverse_coherence": {
+        "room": "camp_clearing_night",
+        "edge_thr": 128,
+        "z_cut": 3.0,
+        "baseline_median": 0.0036,
+        "mad": 0.0033,
+        "threshold": 0.02,
+        "n_cells": 134,
+        "flagged": [
+          {
+            "cell": [
+              3,
+              10
+            ],
+            "density": 0.0553,
+            "z": 10.52,
+            "ratio": 15.47
+          },
+          {
+            "cell": [
+              9,
+              5
+            ],
+            "density": 0.0358,
+            "z": 6.55,
+            "ratio": 10.01
+          },
+          {
+            "cell": [
+              9,
+              7
+            ],
+            "density": 0.0309,
+            "z": 5.56,
+            "ratio": 8.64
+          },
+          {
+            "cell": [
+              4,
+              10
+            ],
+            "density": 0.0302,
+            "z": 5.42,
+            "ratio": 8.46
+          },
+          {
+            "cell": [
+              9,
+              8
+            ],
+            "density": 0.0279,
+            "z": 4.95,
+            "ratio": 7.81
+          },
+          {
+            "cell": [
+              9,
+              6
+            ],
+            "density": 0.0276,
+            "z": 4.88,
+            "ratio": 7.71
+          }
+        ],
+        "exempted": [],
+        "n_exempted": 0
+      },
+      "flagged_cells": [
+        [
+          3,
+          10
+        ],
+        [
+          9,
+          5
+        ],
+        [
+          9,
+          7
+        ],
+        [
+          4,
+          10
+        ],
+        [
+          9,
+          8
+        ],
+        [
+          9,
+          6
+        ]
+      ],
+      "exempted_cells": [],
+      "occlusion_notes": [
+        "bedroll_l: occlusion from camp_clearing_night_v2.cells.json (4 cells)",
+        "bedroll_r: occlusion from camp_clearing_night_v2.cells.json (3 cells)",
+        "camp_sack: no manifest prop matches this id+footprint \u2014 occlusion NOT exempted (current behaviour)",
+        "campfire: occlusion from camp_clearing_night_v2.cells.json (4 cells)",
+        "crate_c: occlusion from camp_clearing_night_v2.cells.json (2 cells)",
+        "crate_l: occlusion from camp_truegrey.cells.json (12 cells)",
+        "crate_r: occlusion from camp_clearing_night_v2.cells.json (3 cells)",
+        "crate_wall: occlusion from camp_clearing_night_v2.cells.json (1 cells)",
+        "firewood: occlusion from camp_truegrey.cells.json (4 cells)",
+        "firewood_tail: no manifest prop matches this id+footprint \u2014 occlusion NOT exempted (current behaviour)",
+        "gear_stones: no manifest prop matches this id+footprint \u2014 occlusion NOT exempted (current behaviour)",
+        "ruin_link: occlusion from camp_truegrey.cells.json (7 cells)",
+        "ruin_rubble1: no manifest prop matches this id+footprint \u2014 occlusion NOT exempted (current behaviour)",
+        "ruin_rubble2: no manifest prop matches this id+footprint \u2014 occlusion NOT exempted (current behaviour)",
+        "ruin_tower1: occlusion from camp_truegrey.cells.json (3 cells)",
+        "ruin_tower2: occlusion from camp_truegrey.cells.json (10 cells)",
+        "shelter: occlusion from camp_truegrey.cells.json (14 cells)",
+        "shelter_post_r: no manifest prop matches this id+footprint \u2014 occlusion NOT exempted (current behaviour)",
+        "wall_bl: occlusion from camp_clearing_night_v2.cells.json (3 cells)",
+        "wall_br: occlusion from camp_truegrey.cells.json (7 cells)",
+        "wall_br2: occlusion from camp_truegrey.cells.json (7 cells)",
+        "wall_br3: occlusion from camp_truegrey.cells.json (7 cells)"
+      ],
+      "n_walkable_floor": 134,
+      "calibration": {
+        "clean_cells": [
+          [
+            4,
+            3
+          ],
+          [
+            5,
+            3
+          ],
+          [
+            6,
+            3
+          ],
+          [
+            4,
+            4
+          ],
+          [
+            5,
+            4
+          ],
+          [
+            6,
+            4
+          ],
+          [
+            5,
+            5
+          ],
+          [
+            6,
+            5
+          ]
+        ],
+        "clean_cells_flagged": [],
+        "ok": true
+      },
+      "hero_checks": [
+        {
+          "step": 1,
+          "pass": true,
+          "cell": [
+            4,
+            0
+          ],
+          "feet": [
+            296.0,
+            342.2
+          ],
+          "feet_in_quad": true,
+          "on_flagged_cell": false,
+          "reason": null
+        }
+      ]
+    },
+    {
+      "room": "tavern",
+      "cols": 12,
+      "rows": 10,
+      "plate": "/Users/lume/WorldOS-worktrees/wt-sweep-precision/qa/evidence/tavern-fit2/tavern_fit2_v1.png",
+      "plate_status": "resolved",
+      "inverse_coherence": {
+        "room": "tavern",
+        "edge_thr": 128,
+        "z_cut": 3.0,
+        "baseline_median": 0.0395,
+        "mad": 0.0162,
+        "threshold": 0.1116,
+        "n_cells": 43,
+        "flagged": [],
+        "exempted": [],
+        "n_exempted": 0
+      },
+      "flagged_cells": [],
+      "exempted_cells": [],
+      "occlusion_notes": [
+        "bar_counter: occlusion from tavern_fit.cells.json (20 cells)",
+        "barrels: occlusion from tavern_fit.cells.json (7 cells)",
+        "barrels_corner: occlusion from tavern_fit2.cells.json (6 cells)",
+        "bench_ne: occlusion from tavern_fit2.cells.json (4 cells)",
+        "bench_nw: occlusion from tavern_fit2.cells.json (4 cells)",
+        "bench_s: occlusion from tavern_fit2.cells.json (4 cells)",
+        "casks_bar: occlusion from tavern_fit2.cells.json (6 cells)",
+        "hearth: occlusion from tavern_fit.cells.json (6 cells)",
+        "shelf_bar: occlusion from tavern_fit2.cells.json (6 cells)",
+        "stools_bar: occlusion from tavern_fit2.cells.json (4 cells)",
+        "table_ne: occlusion from tavern_fit.cells.json (7 cells)",
+        "table_nw: occlusion from tavern_fit.cells.json (7 cells)",
+        "table_s: occlusion from tavern_fit.cells.json (7 cells)",
+        "woodpile: occlusion from tavern_fit2.cells.json (4 cells)"
+      ],
+      "n_walkable_floor": 43,
+      "calibration": null,
+      "hero_checks": [
+        {
+          "step": 3,
+          "pass": true,
+          "cell": [
+            7,
+            1
+          ],
+          "feet": [
+            588.5,
+            279.6
+          ],
+          "feet_in_quad": true,
+          "on_flagged_cell": false,
+          "reason": null
+        }
+      ]
+    }
+  ],
+  "transitions": [
+    {
+      "from": "crypt",
+      "to": "camp_clearing_night",
+      "crossed": true,
+      "arrival": [
+        4,
+        0
+      ],
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          4,
+          0
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          5,
+          0
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    },
+    {
+      "from": "camp_clearing_night",
+      "to": "crypt",
+      "crossed": true,
+      "arrival": [
+        5,
+        1
+      ],
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          5,
+          1
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          6,
+          0
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    },
+    {
+      "from": "crypt",
+      "to": "tavern",
+      "crossed": true,
+      "arrival": [
+        7,
+        1
+      ],
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          7,
+          1
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          8,
+          0
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    },
+    {
+      "from": "tavern",
+      "to": "crypt",
+      "crossed": true,
+      "arrival": [
+        12,
+        3
+      ],
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          12,
+          3
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          13,
+          4
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    }
+  ],
+  "steps": [
+    {
+      "step": 0,
+      "kind": "spawn",
+      "room": "crypt",
+      "label": "spawn in crypt",
+      "frame": "frames/step00_spawn_crypt.png",
+      "hero_check": {
+        "pass": true,
+        "cell": [
+          3,
+          5
+        ],
+        "feet": [
+          525.8,
+          457.1
+        ],
+        "feet_in_quad": true,
+        "on_flagged_cell": false,
+        "reason": null
+      },
+      "reciprocal": null
+    },
+    {
+      "step": 1,
+      "kind": "arrive",
+      "room": "camp_clearing_night",
+      "label": "crossed crypt -> camp_clearing_night",
+      "frame": "frames/step01_arrive_camp_clearing_night.png",
+      "hero_check": {
+        "pass": true,
+        "cell": [
+          4,
+          0
+        ],
+        "feet": [
+          296.0,
+          342.2
+        ],
+        "feet_in_quad": true,
+        "on_flagged_cell": false,
+        "reason": null
+      },
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          4,
+          0
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          5,
+          0
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    },
+    {
+      "step": 2,
+      "kind": "return",
+      "room": "crypt",
+      "label": "returned camp_clearing_night -> crypt",
+      "frame": "frames/step02_return_crypt.png",
+      "hero_check": {
+        "pass": false,
+        "cell": [
+          5,
+          1
+        ],
+        "feet": [
+          442.2,
+          331.8
+        ],
+        "feet_in_quad": true,
+        "on_flagged_cell": true,
+        "reason": "hero stands on cell [5, 1] the plate painted an object onto (inverse-coherence flag) \u2014 actor-inside-the-object"
+      },
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          5,
+          1
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          6,
+          0
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    },
+    {
+      "step": 3,
+      "kind": "arrive",
+      "room": "tavern",
+      "label": "crossed crypt -> tavern",
+      "frame": "frames/step03_arrive_tavern.png",
+      "hero_check": {
+        "pass": true,
+        "cell": [
+          7,
+          1
+        ],
+        "feet": [
+          588.5,
+          279.6
+        ],
+        "feet_in_quad": true,
+        "on_flagged_cell": false,
+        "reason": null
+      },
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          7,
+          1
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          8,
+          0
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    },
+    {
+      "step": 4,
+      "kind": "return",
+      "room": "crypt",
+      "label": "returned tavern -> crypt",
+      "frame": "frames/step04_return_crypt.png",
+      "hero_check": {
+        "pass": false,
+        "cell": [
+          12,
+          3
+        ],
+        "feet": [
+          818.2,
+          227.3
+        ],
+        "feet_in_quad": true,
+        "on_flagged_cell": true,
+        "reason": "hero stands on cell [12, 3] the plate painted an object onto (inverse-coherence flag) \u2014 actor-inside-the-object"
+      },
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          12,
+          3
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          13,
+          4
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    }
+  ]
+}

--- a/qa/evidence/sweep-precision/before/report.json
+++ b/qa/evidence/sweep-precision/before/report.json
@@ -1,0 +1,804 @@
+{
+  "hub": "crypt",
+  "overall_clean_pct": 90.1,
+  "per_room": [
+    {
+      "room": "crypt",
+      "plate_status": "resolved",
+      "hero_steps": 1,
+      "hero_pass": 1,
+      "walkable_floor_cells": 94,
+      "inverse_coherence_flags": 21,
+      "clean_pct": 77.9,
+      "meets_95": false
+    },
+    {
+      "room": "camp_clearing_night",
+      "plate_status": "resolved",
+      "hero_steps": 1,
+      "hero_pass": 1,
+      "walkable_floor_cells": 134,
+      "inverse_coherence_flags": 6,
+      "clean_pct": 95.6,
+      "meets_95": true
+    },
+    {
+      "room": "tavern",
+      "plate_status": "resolved",
+      "hero_steps": 1,
+      "hero_pass": 1,
+      "walkable_floor_cells": 43,
+      "inverse_coherence_flags": 0,
+      "clean_pct": 100.0,
+      "meets_95": true
+    }
+  ],
+  "findings_by_class": {
+    "invented_furniture_flags": 27,
+    "reciprocal_door_failures": 0,
+    "hero_position_failures": 0
+  },
+  "rooms": [
+    {
+      "room": "crypt",
+      "cols": 14,
+      "rows": 11,
+      "plate": "/private/tmp/wt-sweep-precision-before/qa/evidence/crypt-fresh/crypt_fresh_v1.png",
+      "plate_status": "resolved",
+      "inverse_coherence": {
+        "room": "crypt",
+        "edge_thr": 128,
+        "z_cut": 3.0,
+        "baseline_median": 0.0116,
+        "mad": 0.0087,
+        "threshold": 0.0502,
+        "n_cells": 94,
+        "flagged": [
+          {
+            "cell": [
+              6,
+              5
+            ],
+            "density": 0.1093,
+            "z": 7.59,
+            "ratio": 9.4
+          },
+          {
+            "cell": [
+              8,
+              4
+            ],
+            "density": 0.1069,
+            "z": 7.41,
+            "ratio": 9.2
+          },
+          {
+            "cell": [
+              11,
+              4
+            ],
+            "density": 0.1063,
+            "z": 7.36,
+            "ratio": 9.14
+          },
+          {
+            "cell": [
+              4,
+              2
+            ],
+            "density": 0.1051,
+            "z": 7.27,
+            "ratio": 9.04
+          },
+          {
+            "cell": [
+              6,
+              4
+            ],
+            "density": 0.101,
+            "z": 6.95,
+            "ratio": 8.69
+          },
+          {
+            "cell": [
+              7,
+              4
+            ],
+            "density": 0.0946,
+            "z": 6.45,
+            "ratio": 8.14
+          },
+          {
+            "cell": [
+              7,
+              5
+            ],
+            "density": 0.0928,
+            "z": 6.31,
+            "ratio": 7.98
+          },
+          {
+            "cell": [
+              11,
+              3
+            ],
+            "density": 0.0912,
+            "z": 6.19,
+            "ratio": 7.85
+          },
+          {
+            "cell": [
+              12,
+              4
+            ],
+            "density": 0.0842,
+            "z": 5.64,
+            "ratio": 7.24
+          },
+          {
+            "cell": [
+              12,
+              3
+            ],
+            "density": 0.0813,
+            "z": 5.42,
+            "ratio": 6.99
+          },
+          {
+            "cell": [
+              10,
+              4
+            ],
+            "density": 0.0761,
+            "z": 5.02,
+            "ratio": 6.55
+          },
+          {
+            "cell": [
+              5,
+              1
+            ],
+            "density": 0.0734,
+            "z": 4.8,
+            "ratio": 6.31
+          },
+          {
+            "cell": [
+              7,
+              3
+            ],
+            "density": 0.0677,
+            "z": 4.36,
+            "ratio": 5.82
+          },
+          {
+            "cell": [
+              9,
+              4
+            ],
+            "density": 0.0672,
+            "z": 4.32,
+            "ratio": 5.78
+          },
+          {
+            "cell": [
+              8,
+              3
+            ],
+            "density": 0.0649,
+            "z": 4.14,
+            "ratio": 5.58
+          },
+          {
+            "cell": [
+              5,
+              5
+            ],
+            "density": 0.0579,
+            "z": 3.6,
+            "ratio": 4.98
+          },
+          {
+            "cell": [
+              10,
+              3
+            ],
+            "density": 0.0577,
+            "z": 3.59,
+            "ratio": 4.97
+          },
+          {
+            "cell": [
+              4,
+              3
+            ],
+            "density": 0.0544,
+            "z": 3.32,
+            "ratio": 4.68
+          },
+          {
+            "cell": [
+              9,
+              3
+            ],
+            "density": 0.0543,
+            "z": 3.32,
+            "ratio": 4.67
+          },
+          {
+            "cell": [
+              5,
+              2
+            ],
+            "density": 0.0531,
+            "z": 3.22,
+            "ratio": 4.56
+          },
+          {
+            "cell": [
+              8,
+              5
+            ],
+            "density": 0.0522,
+            "z": 3.15,
+            "ratio": 4.49
+          }
+        ]
+      },
+      "flagged_cells": [
+        [
+          6,
+          5
+        ],
+        [
+          8,
+          4
+        ],
+        [
+          11,
+          4
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          6,
+          4
+        ],
+        [
+          7,
+          4
+        ],
+        [
+          7,
+          5
+        ],
+        [
+          11,
+          3
+        ],
+        [
+          12,
+          4
+        ],
+        [
+          12,
+          3
+        ],
+        [
+          10,
+          4
+        ],
+        [
+          5,
+          1
+        ],
+        [
+          7,
+          3
+        ],
+        [
+          9,
+          4
+        ],
+        [
+          8,
+          3
+        ],
+        [
+          5,
+          5
+        ],
+        [
+          10,
+          3
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          9,
+          3
+        ],
+        [
+          5,
+          2
+        ],
+        [
+          8,
+          5
+        ]
+      ],
+      "n_walkable_floor": 94,
+      "calibration": null,
+      "hero_checks": [
+        {
+          "step": 0,
+          "pass": true,
+          "cell": [
+            3,
+            5
+          ],
+          "feet": [
+            525.8,
+            457.1
+          ],
+          "feet_in_quad": true,
+          "on_flagged_cell": false,
+          "reason": null
+        }
+      ]
+    },
+    {
+      "room": "camp_clearing_night",
+      "cols": 16,
+      "rows": 12,
+      "plate": "/private/tmp/wt-sweep-precision-before/qa/evidence/plate-audit/camp_clearing_night_truegrey_v1.png",
+      "plate_status": "resolved",
+      "inverse_coherence": {
+        "room": "camp_clearing_night",
+        "edge_thr": 128,
+        "z_cut": 3.0,
+        "baseline_median": 0.0036,
+        "mad": 0.0033,
+        "threshold": 0.02,
+        "n_cells": 134,
+        "flagged": [
+          {
+            "cell": [
+              3,
+              10
+            ],
+            "density": 0.0553,
+            "z": 10.52,
+            "ratio": 15.47
+          },
+          {
+            "cell": [
+              9,
+              5
+            ],
+            "density": 0.0358,
+            "z": 6.55,
+            "ratio": 10.01
+          },
+          {
+            "cell": [
+              9,
+              7
+            ],
+            "density": 0.0309,
+            "z": 5.56,
+            "ratio": 8.64
+          },
+          {
+            "cell": [
+              4,
+              10
+            ],
+            "density": 0.0302,
+            "z": 5.42,
+            "ratio": 8.46
+          },
+          {
+            "cell": [
+              9,
+              8
+            ],
+            "density": 0.0279,
+            "z": 4.95,
+            "ratio": 7.81
+          },
+          {
+            "cell": [
+              9,
+              6
+            ],
+            "density": 0.0276,
+            "z": 4.88,
+            "ratio": 7.71
+          }
+        ]
+      },
+      "flagged_cells": [
+        [
+          3,
+          10
+        ],
+        [
+          9,
+          5
+        ],
+        [
+          9,
+          7
+        ],
+        [
+          4,
+          10
+        ],
+        [
+          9,
+          8
+        ],
+        [
+          9,
+          6
+        ]
+      ],
+      "n_walkable_floor": 134,
+      "calibration": {
+        "clean_cells": [
+          [
+            4,
+            3
+          ],
+          [
+            5,
+            3
+          ],
+          [
+            6,
+            3
+          ],
+          [
+            4,
+            4
+          ],
+          [
+            5,
+            4
+          ],
+          [
+            6,
+            4
+          ],
+          [
+            5,
+            5
+          ],
+          [
+            6,
+            5
+          ]
+        ],
+        "clean_cells_flagged": [],
+        "ok": true
+      },
+      "hero_checks": [
+        {
+          "step": 1,
+          "pass": true,
+          "cell": [
+            4,
+            0
+          ],
+          "feet": [
+            296.0,
+            342.2
+          ],
+          "feet_in_quad": true,
+          "on_flagged_cell": false,
+          "reason": null
+        }
+      ]
+    },
+    {
+      "room": "tavern",
+      "cols": 12,
+      "rows": 10,
+      "plate": "/private/tmp/wt-sweep-precision-before/qa/evidence/tavern-fit2/tavern_fit2_v1.png",
+      "plate_status": "resolved",
+      "inverse_coherence": {
+        "room": "tavern",
+        "edge_thr": 128,
+        "z_cut": 3.0,
+        "baseline_median": 0.0395,
+        "mad": 0.0162,
+        "threshold": 0.1116,
+        "n_cells": 43,
+        "flagged": []
+      },
+      "flagged_cells": [],
+      "n_walkable_floor": 43,
+      "calibration": null,
+      "hero_checks": [
+        {
+          "step": 3,
+          "pass": true,
+          "cell": [
+            7,
+            1
+          ],
+          "feet": [
+            588.5,
+            279.6
+          ],
+          "feet_in_quad": true,
+          "on_flagged_cell": false,
+          "reason": null
+        }
+      ]
+    }
+  ],
+  "transitions": [
+    {
+      "from": "crypt",
+      "to": "camp_clearing_night",
+      "crossed": true,
+      "arrival": [
+        4,
+        0
+      ],
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          4,
+          0
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          5,
+          0
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    },
+    {
+      "from": "camp_clearing_night",
+      "to": "crypt",
+      "crossed": true,
+      "arrival": [
+        5,
+        1
+      ],
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          5,
+          1
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          6,
+          0
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    },
+    {
+      "from": "crypt",
+      "to": "tavern",
+      "crossed": true,
+      "arrival": [
+        7,
+        1
+      ],
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          7,
+          1
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          8,
+          0
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    },
+    {
+      "from": "tavern",
+      "to": "crypt",
+      "crossed": true,
+      "arrival": [
+        12,
+        3
+      ],
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          12,
+          3
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          13,
+          4
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    }
+  ],
+  "steps": [
+    {
+      "step": 0,
+      "kind": "spawn",
+      "room": "crypt",
+      "label": "spawn in crypt",
+      "frame": "frames/step00_spawn_crypt.png",
+      "hero_check": {
+        "pass": true,
+        "cell": [
+          3,
+          5
+        ],
+        "feet": [
+          525.8,
+          457.1
+        ],
+        "feet_in_quad": true,
+        "on_flagged_cell": false,
+        "reason": null
+      },
+      "reciprocal": null
+    },
+    {
+      "step": 1,
+      "kind": "arrive",
+      "room": "camp_clearing_night",
+      "label": "crossed crypt -> camp_clearing_night",
+      "frame": "frames/step01_arrive_camp_clearing_night.png",
+      "hero_check": {
+        "pass": true,
+        "cell": [
+          4,
+          0
+        ],
+        "feet": [
+          296.0,
+          342.2
+        ],
+        "feet_in_quad": true,
+        "on_flagged_cell": false,
+        "reason": null
+      },
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          4,
+          0
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          5,
+          0
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    },
+    {
+      "step": 2,
+      "kind": "return",
+      "room": "crypt",
+      "label": "returned camp_clearing_night -> crypt",
+      "frame": "frames/step02_return_crypt.png",
+      "hero_check": {
+        "pass": false,
+        "cell": [
+          5,
+          1
+        ],
+        "feet": [
+          442.2,
+          331.8
+        ],
+        "feet_in_quad": true,
+        "on_flagged_cell": true,
+        "reason": "hero stands on cell [5, 1] the plate painted an object onto (inverse-coherence flag) \u2014 actor-inside-the-object"
+      },
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          5,
+          1
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          6,
+          0
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    },
+    {
+      "step": 3,
+      "kind": "arrive",
+      "room": "tavern",
+      "label": "crossed crypt -> tavern",
+      "frame": "frames/step03_arrive_tavern.png",
+      "hero_check": {
+        "pass": true,
+        "cell": [
+          7,
+          1
+        ],
+        "feet": [
+          588.5,
+          279.6
+        ],
+        "feet_in_quad": true,
+        "on_flagged_cell": false,
+        "reason": null
+      },
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          7,
+          1
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          8,
+          0
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    },
+    {
+      "step": 4,
+      "kind": "return",
+      "room": "crypt",
+      "label": "returned tavern -> crypt",
+      "frame": "frames/step04_return_crypt.png",
+      "hero_check": {
+        "pass": false,
+        "cell": [
+          12,
+          3
+        ],
+        "feet": [
+          818.2,
+          227.3
+        ],
+        "feet_in_quad": true,
+        "on_flagged_cell": true,
+        "reason": "hero stands on cell [12, 3] the plate painted an object onto (inverse-coherence flag) \u2014 actor-inside-the-object"
+      },
+      "reciprocal": {
+        "pass": true,
+        "arrival": [
+          12,
+          3
+        ],
+        "max_cheb": 2,
+        "nearest_door": [
+          13,
+          4
+        ],
+        "cheb": 1,
+        "reason": null
+      }
+    }
+  ]
+}

--- a/qa/journey_visual_sweep.py
+++ b/qa/journey_visual_sweep.py
@@ -33,6 +33,22 @@ qa/seed_gfx_walkslice.py), and at every room + every door round-trip it VERIFIES
      authored-walkable cell" FLAG. This is the pass that catches the tavern's invented benches / furniture
      the manifest never authored.
 
+     SWEEP-PRECISION (follow-up noted in #1552, closed here): occlusion != footprint. A tall AUTHORED
+     prop's silhouette legitimately paints OVER walkable cells behind it under the iso projection (occlu-
+     sion strictly contains but is offset from the prop's floor footprint — docs/ROOM-PIPELINE-RUNBOOK.md
+     Sec.2). Through #1552 this check only ever excluded FOOTPRINT cells, so a dense, richly-authored room
+     (more tall props => more legitimate up-screen silhouette) necessarily flagged MORE than a sparse one —
+     punishing exactly the density the owner wants. Cells inside any authored prop's OCCLUSION cell set
+     (resolve_occlusion_cells, below) are now EXEMPTED from being flagged — never from the room's own
+     clean-floor baseline calibration, and never silently: every exemption is counted and logged per room
+     so precision stays auditable, not just improved. Live-sweep proof (#1565's crypt_fresh_v1 plate,
+     registered as canonical crypt but painted over the sparser un-reconciled walkslice grid, #1559): 21
+     flags before this fix (CLEAN% 77.9) -> 9 after (CLEAN% 90.5, 12 cells exempted as authored-occlusion
+     silhouette). The 9 that still flag are the SEPARATE, already-tracked #1559 walkslice-reconciliation
+     gap (the live crypt grid hasn't been re-authored with fresh-crypt's full prop set yet) — this fix
+     correctly does NOT paper over an unauthored gap, only exempts what a committed manifest ACTUALLY
+     authors (proof: qa/test_journey_visual_sweep.py's tavern_truegrey-vs-tavern_fit2 negative control).
+
   4. A per-step composite FRAME (the registered plate + the hero marker at its projected feet + the
      floor quad + every flagged cell, checks annotated) -> a human gallery.html, plus a machine
      report.json and a per-room CLEAN% table (CLEAN% = passing (steps + inverse-coherence cells) / total —
@@ -88,6 +104,16 @@ from journey_click_sweep import (  # noqa: E402
 # instrument can never disagree with the rig the plates are registered to.
 from greybox_render_headless import PX_W, PX_H, cell_to_world, world_to_screen  # noqa: E402
 from plate_overlays import edge_mask  # noqa: E402  (shared FIND_EDGES->binary primitive)
+
+# tools/derive_room_manifest.derive_occlusion_cells is the ON-THE-FLY occlusion fallback (SWEEP-PRECISION,
+# below) — the exact function that PRODUCES every committed qa/room_manifests/*.cells.json `occlusion`
+# field, reusing the same box-corner screen-projection qa/check_grid_paint_coherence.py's
+# prop_box_screen_bbox uses (refined to a convex-hull/point-in-polygon test, not an axis-aligned bbox, so
+# a rotated silhouette isn't over-approximated).
+_TOOLS_DIR = _ROOT / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+from derive_room_manifest import derive_occlusion_cells  # noqa: E402
 
 
 # ── Plate resolution: engine location.id -> the registered 1344x768 plate on disk ───────────────────
@@ -247,6 +273,102 @@ def cell_edge_density(edge_img: Image.Image, quad: list) -> float:
     return hit / inside if inside else 0.0
 
 
+# ── Occlusion resolution: authored SILHOUETTE cells a tall prop legitimately paints over ────────────
+# docs/ROOM-PIPELINE-RUNBOOK.md Sec.2: footprint = the impassable FLOOR cells; occlusion = the up-screen
+# SILHOUETTE cells a tall prop's box paints over under the iso projection — strictly contains but is
+# offset from the footprint (a coffin's silhouette rises off its floor cells the same way an actor
+# standing behind it would still read above it). manifest_from_surface (journey_click_sweep, reused
+# verbatim above) is sourced from the LIVE /combat-surface and only ever carries {id, footprint} per prop
+# — the live scene_grid's SceneCell has no occlusion/kind fields at all (servers/engine/scene_grid.py) —
+# so occlusion can never be read off the live surface directly; it has to come from the room's own
+# committed DERIVED manifest (qa/room_manifests/<room>.cells.json, tools/derive_room_manifest.py's output).
+_ROOM_MANIFESTS_DIR = _QA_DIR / "room_manifests"
+_STATIC_MANIFESTS_CACHE: Optional[list] = None
+
+
+def load_static_manifests(manifests_dir: Path = _ROOM_MANIFESTS_DIR, *, refresh: bool = False) -> list:
+    """Every committed qa/room_manifests/*.cells.json, loaded once (module-level cache — pass
+    refresh=True to force a re-read; the unit tests do, so a fixture manifest never leaks across tests
+    or a later real run). Corrupt/unreadable files are skipped, never raised: this is a best-effort
+    precision aid, never a hard dependency of the sweep (a room with no resolvable manifest just gets the
+    pre-#1565 CURRENT behaviour — see resolve_occlusion_cells)."""
+    global _STATIC_MANIFESTS_CACHE
+    if _STATIC_MANIFESTS_CACHE is not None and not refresh:
+        return _STATIC_MANIFESTS_CACHE
+    out: list = []
+    manifests_dir = Path(manifests_dir)
+    if manifests_dir.is_dir():
+        for mp in sorted(manifests_dir.glob("*.cells.json")):
+            try:
+                out.append(json.loads(mp.read_text(encoding="utf-8")))
+            except (OSError, ValueError):
+                continue
+    _STATIC_MANIFESTS_CACHE = out
+    return out
+
+
+def resolve_occlusion_cells(live_props: list, cols: int, rows: int, *,
+                            manifests: Optional[list] = None) -> tuple:
+    """For every LIVE prop ({id, footprint} off manifest_from_surface), resolve its authored OCCLUSION
+    cell set — PER PROP, never per room (a room's props can straddle manifest generations: the tavern
+    room today authors 14 props but only 6 of them predate the fit2 density-law upgrade, #1557/#1559):
+
+      1. EXACT MATCH — scan every loaded manifest's own props for one with the SAME id AND the IDENTICAL
+         footprint cell set (both are derived from the same authored geometry, so an identical id +
+         footprint IS the same authored prop, regardless of which manifest file happens to carry it).
+         Use its committed `occlusion` list verbatim.
+      2. DERIVE — the matched prop entry has no `occlusion` field (an older/measured manifest) but does
+         carry a `kind` — derive on the fly with tools/derive_room_manifest.derive_occlusion_cells, the
+         exact function that PRODUCES every committed `occlusion` field.
+      3. NO MATCH anywhere — fall back to CURRENT (pre-#1565) behaviour for this one prop: no exemption.
+         Never silently dropped — recorded in `notes` so a cold room (no manifest resolvable at all) is
+         still visible in the report, not silently unimproved.
+
+    Returns (occlusion_cells, notes): occlusion_cells is a set of (c, r) tuples (the union over every
+    prop — always a superset of that prop's own footprint, though the footprint is separately excluded by
+    inverse_coherence_flags already); notes is one string per prop describing how it resolved, surfaced
+    in the room report so exemption stays auditable, never a silent mask."""
+    manifests = load_static_manifests() if manifests is None else manifests
+    occlusion_cells: set = set()
+    notes: list = []
+    for prop in live_props:
+        pid = str(prop.get("id", "?"))
+        footprint = sorted((int(c), int(r)) for (c, r) in prop.get("footprint", []))
+        if not footprint:
+            continue
+        match = None
+        for m in manifests:
+            for sp in m.get("props", []):
+                if str(sp.get("id", "?")) != pid:
+                    continue
+                sp_fp = sorted((int(c), int(r)) for (c, r) in (sp.get("footprint") or sp.get("cells") or []))
+                if sp_fp == footprint:
+                    match = (m, sp)
+                    break
+            if match:
+                break
+        if match is None:
+            notes.append(f"{pid}: no manifest prop matches this id+footprint — occlusion NOT exempted "
+                        "(current behaviour)")
+            continue
+        m, sp = match
+        sp_occlusion = sp.get("occlusion")
+        if sp_occlusion:
+            occlusion_cells.update((int(c), int(r)) for (c, r) in sp_occlusion)
+            notes.append(f"{pid}: occlusion from {m.get('room', '?')}.cells.json ({len(sp_occlusion)} cells)")
+            continue
+        kind = sp.get("kind")
+        if kind:
+            derived = derive_occlusion_cells([list(c) for c in footprint], kind, cols, rows)
+            occlusion_cells.update((int(c), int(r)) for (c, r) in derived)
+            notes.append(f"{pid}: occlusion DERIVED (kind={kind}, matched manifest has no `occlusion` "
+                        f"field) ({len(derived)} cells)")
+            continue
+        notes.append(f"{pid}: matched {m.get('room', '?')}.cells.json but it carries neither `occlusion` "
+                    "nor `kind` — occlusion NOT exempted (current behaviour)")
+    return occlusion_cells, notes
+
+
 # ── Check 3: inverse-coherence (the painted-object detector) ────────────────────────────────────────
 # A cell is FLAGGED when its hard-edge silhouette density is a robust OUTLIER above the room's own floor
 # baseline: density > median + Z_CUT * 1.4826 * MAD (a MAD-scaled robust z-score; 1.4826 makes MAD a
@@ -272,12 +394,14 @@ class InverseCoherenceResult:
     threshold: float
     n_cells: int
     flagged: list = field(default_factory=list)          # [{cell, density, z, ratio}]
+    exempted: list = field(default_factory=list)          # same shape — would-flag cells inside authored occlusion
     densities: dict = field(default_factory=dict)         # "c,r" -> density (for the frame overlay)
 
     def as_dict(self) -> dict:
         return {"room": self.room, "edge_thr": IC_EDGE_THR, "z_cut": Z_CUT,
                 "baseline_median": round(self.baseline_median, 4), "mad": round(self.mad, 4),
-                "threshold": round(self.threshold, 4), "n_cells": self.n_cells, "flagged": self.flagged}
+                "threshold": round(self.threshold, 4), "n_cells": self.n_cells,
+                "flagged": self.flagged, "exempted": self.exempted, "n_exempted": len(self.exempted)}
 
 
 def _robust_z(v: float, med: float, mad: float) -> float:
@@ -286,12 +410,28 @@ def _robust_z(v: float, med: float, mad: float) -> float:
 
 def inverse_coherence_flags(edge_img: Image.Image, walkable: list, prop_cells: set,
                             cols: int, rows: int, room: str = "?", *,
-                            z_cut: float = Z_CUT, abs_floor: float = ABS_FLOOR) -> InverseCoherenceResult:
+                            z_cut: float = Z_CUT, abs_floor: float = ABS_FLOOR,
+                            occlusion_cells: Optional[set] = None) -> InverseCoherenceResult:
     """Flag every authored-WALKABLE, non-prop cell whose hard-edge STANDING-SILHOUETTE density is a robust
     outlier above the room's own floor baseline (robust-z >= z_cut AND density >= abs_floor) — i.e. the
     plate painted an object where the grid authored clear floor (invented furniture; the tavern-benches /
     the actor-inside-the-coffin class). `edge_img` is the plate's HARD-edge mask (load_plate_edges @
-    IC_EDGE_THR). Self-calibrating per room; the camp clean cells only pin that z_cut is high enough."""
+    IC_EDGE_THR). Self-calibrating per room; the camp clean cells only pin that z_cut is high enough.
+
+    `occlusion_cells` (SWEEP-PRECISION; from resolve_occlusion_cells) EXEMPTS a cell from being flagged —
+    an authored TALL prop's silhouette legitimately paints over it, occlusion != footprint (docs/ROOM-
+    PIPELINE-RUNBOOK.md Sec.2). The per-room baseline (median/MAD) is calibrated EXACTLY as before —
+    over every authored-walkable, non-footprint cell, occlusion included — so the Z_CUT/ABS_FLOOR
+    constants (co-calibrated against the camp clean-floor anchor pre-#1565) keep meaning what they always
+    meant; occlusion is applied ONLY as a post-hoc partition of cells that already cleared the outlier
+    bar. This also sidesteps a degenerate case a baseline-exclusion design would hit on a genuinely dense
+    room: #1565's fresh crypt authors so much silhouette that its occlusion union covers the room's ENTIRE
+    walkable floor, which would leave zero cells to calibrate a "clear floor" median from at all. A cell
+    inside `occlusion_cells` that clears the bar is recorded in `exempted`, not `flagged` — still visible
+    in the report (never a silent mask), just not counted against CLEAN%. A cell outside every authored
+    occlusion band that still clears the bar is exactly the invented-furniture class this check exists to
+    catch (unauthored anywhere) and flags exactly as before (#1552's tavern benches)."""
+    occlusion_cells = occlusion_cells or set()
     cells = [(int(c), int(r)) for (c, r) in walkable if (int(c), int(r)) not in prop_cells]
     densities: dict = {}
     for (c, r) in cells:
@@ -303,14 +443,17 @@ def inverse_coherence_flags(edge_img: Image.Image, walkable: list, prop_cells: s
     mad = statistics.median([abs(v - med) for v in vals]) or 0.0
     threshold = max(med + z_cut * 1.4826 * mad, abs_floor)
     flagged = []
+    exempted = []
     for (c, r), d in sorted(densities.items(), key=lambda kv: -kv[1]):
         if d > threshold and d >= abs_floor:
-            flagged.append({"cell": [c, r], "density": round(d, 4),
-                            "z": round(_robust_z(d, med, mad), 2),
-                            "ratio": round(d / med, 2) if med > 0 else None})
+            entry = {"cell": [c, r], "density": round(d, 4),
+                     "z": round(_robust_z(d, med, mad), 2),
+                     "ratio": round(d / med, 2) if med > 0 else None}
+            (exempted if (c, r) in occlusion_cells else flagged).append(entry)
     return InverseCoherenceResult(
-        room=room, baseline_median=med, mad=mad, threshold=threshold, n_cells=len(vals),
-        flagged=flagged, densities={f"{c},{r}": d for (c, r), d in densities.items()})
+        room=room, baseline_median=med, mad=mad, threshold=threshold, n_cells=len(cells),
+        flagged=flagged, exempted=exempted,
+        densities={f"{c},{r}": d for (c, r), d in densities.items()})
 
 
 # ── Check 2: reciprocal-door landing ────────────────────────────────────────────────────────────────
@@ -374,11 +517,14 @@ def _draw_quad(draw, quad, outline, width=2, fill=None):
 def composite_frame(plate_path: Optional[str | Path], hero_cell: Optional[tuple], cols: int, rows: int,
                     flagged_cells: list, doors: list, out_path: Path, *,
                     label: str = "", checks: Optional[list] = None,
-                    reciprocal_target: Optional[list] = None) -> None:
+                    reciprocal_target: Optional[list] = None,
+                    exempted_cells: Optional[list] = None) -> None:
     """Render the human evidence frame: the registered plate (or a grey placeholder if box-only) + the
     hero marker at its projected feet + the hero cell's floor quad (green pass / red on-flagged) + every
-    inverse-coherence flagged cell (orange) + door cells (blue) + the reciprocal return door (cyan) +
-    a text annotation of the checks. This is what the gallery shows per step."""
+    inverse-coherence flagged cell (orange) + every occlusion-EXEMPTED cell (dashed olive-green — would
+    have flagged, but sits inside an authored prop's silhouette band; SWEEP-PRECISION) + door cells (blue)
+    + the reciprocal return door (cyan) + a text annotation of the checks. This is what the gallery shows
+    per step."""
     if plate_path and Path(plate_path).is_file():
         base = Image.open(plate_path).convert("RGB")
         if base.size != (PX_W, PX_H):
@@ -396,6 +542,9 @@ def composite_frame(plate_path: Optional[str | Path], hero_cell: Optional[tuple]
     if reciprocal_target:
         _draw_quad(draw, cell_floor_quad(int(reciprocal_target[0]), int(reciprocal_target[1]), cols, rows),
                    (0, 220, 220, 255), width=3)
+    for cell in exempted_cells or []:
+        _draw_quad(draw, cell_floor_quad(int(cell[0]), int(cell[1]), cols, rows),
+                   (150, 200, 60, 200), width=1)
     for cell in flagged_cells or []:
         _draw_quad(draw, cell_floor_quad(int(cell[0]), int(cell[1]), cols, rows),
                    (255, 140, 0, 255), width=2, fill=(255, 140, 0, 55))
@@ -460,17 +609,22 @@ def run_journey(get_surface: Callable[[], dict], cross_door: Callable[[dict], di
         cols, rows = _grid(surface)
         manifest = manifest_from_surface(surface)
         walkable = manifest.get("walkable", [])
-        prop_cells = {(int(c), int(r)) for p in manifest.get("props", []) for (c, r) in p.get("footprint", [])}
+        live_props = manifest.get("props", [])
+        prop_cells = {(int(c), int(r)) for p in live_props for (c, r) in p.get("footprint", [])}
+        occlusion_cells, occlusion_notes = resolve_occlusion_cells(live_props, cols, rows)
         plate = _plate_for(loc_id)
         if plate is not None:
-            ic = inverse_coherence_flags(load_plate_edges(plate), walkable, prop_cells, cols, rows, loc_id)
+            ic = inverse_coherence_flags(load_plate_edges(plate), walkable, prop_cells, cols, rows, loc_id,
+                                         occlusion_cells=occlusion_cells)
             ic_dict = ic.as_dict()
             flagged_cells = [f["cell"] for f in ic.flagged]
+            exempted_cells = [f["cell"] for f in ic.exempted]
             plate_status = "resolved"
         else:
             ic_dict = {"room": loc_id, "status": "no-plate",
                        "reason": "plate ships box-only; inverse-coherence skipped (absence != failure)"}
             flagged_cells = []
+            exempted_cells = []
             plate_status = "no-plate"
         # camp calibration receipt: the designated known-clean cells must NOT be among the flags.
         calib = None
@@ -482,7 +636,8 @@ def run_journey(get_surface: Callable[[], dict], cross_door: Callable[[dict], di
                      "ok": not clean_flagged}
         rec = {"room": loc_id, "cols": cols, "rows": rows, "plate": str(plate) if plate else None,
                "plate_status": plate_status, "inverse_coherence": ic_dict,
-               "flagged_cells": flagged_cells, "n_walkable_floor": len(
+               "flagged_cells": flagged_cells, "exempted_cells": exempted_cells,
+               "occlusion_notes": occlusion_notes, "n_walkable_floor": len(
                    [1 for (c, r) in walkable if (int(c), int(r)) not in prop_cells]),
                "calibration": calib, "hero_checks": []}
         rooms[loc_id] = rec
@@ -494,6 +649,7 @@ def run_journey(get_surface: Callable[[], dict], cross_door: Callable[[dict], di
         cols, rows = _grid(surface)
         rec = rooms.get(loc_id) or _visit_room(surface)
         flagged = rec.get("flagged_cells", [])
+        exempted = rec.get("exempted_cells", [])
         hero = _hero_cell(surface, hero_id)
         hero_chk = hero_feet_check(hero, cols, rows, {tuple(c) for c in flagged})
         checks_txt = [f"room={loc_id}  hero_cell={hero_chk.get('cell')}  "
@@ -503,12 +659,14 @@ def run_journey(get_surface: Callable[[], dict], cross_door: Callable[[dict], di
                               f"({reciprocal.get('reason') or 'within Chebyshev-'+str(max_cheb)})")
         if rec.get("plate_status") == "resolved":
             checks_txt.append(f"inverse-coherence flags={len(flagged)} "
-                              f"(walkable floor cells={rec['n_walkable_floor']})")
+                              f"(walkable floor cells={rec['n_walkable_floor']}, "
+                              f"occlusion-exempted={len(exempted)})")
         recip_target = reciprocal.get("nearest_door") if reciprocal else None
         frame_name = f"step{step_no:02d}_{kind}_{loc_id}.png"
         composite_frame(rec.get("plate"), hero, cols, rows, flagged,
                         surface.get("doors") or [], frames_dir / frame_name,
-                        label=f"[{step_no}] {label}", checks=checks_txt, reciprocal_target=recip_target)
+                        label=f"[{step_no}] {label}", checks=checks_txt, reciprocal_target=recip_target,
+                        exempted_cells=exempted)
         step = {"step": step_no, "kind": kind, "room": loc_id, "label": label, "frame": f"frames/{frame_name}",
                 "hero_check": hero_chk, "reciprocal": reciprocal}
         steps.append(step)
@@ -579,6 +737,7 @@ def build_report(room_recs: list, steps: list, transitions: list, hub_id: str) -
         n_hero += hero_total - hero_pass
         n_floor = rec.get("n_walkable_floor", 0)
         n_flag = len(rec.get("flagged_cells", []))
+        n_exempt = len(rec.get("exempted_cells", []))
         n_furniture += n_flag
         clean_cells = n_floor - n_flag
         num = hero_pass + clean_cells
@@ -587,6 +746,7 @@ def build_report(room_recs: list, steps: list, transitions: list, hub_id: str) -
         per_room.append({"room": loc, "plate_status": rec.get("plate_status"),
                          "hero_steps": hero_total, "hero_pass": hero_pass,
                          "walkable_floor_cells": n_floor, "inverse_coherence_flags": n_flag,
+                         "occlusion_exempted": n_exempt,
                          "clean_pct": clean_pct, "meets_95": (clean_pct is not None and clean_pct >= 95.0)})
     for t in transitions:
         recip = t.get("reciprocal")
@@ -612,6 +772,7 @@ def write_gallery(report: dict, out_path: Path) -> None:
         f"<td>{r['room']}</td><td>{r['plate_status']}</td>"
         f"<td>{r['hero_pass']}/{r['hero_steps']}</td>"
         f"<td>{r['inverse_coherence_flags']} / {r['walkable_floor_cells']}</td>"
+        f"<td>{r.get('occlusion_exempted', 0)}</td>"
         f"<td><b>{'' if r['clean_pct'] is None else str(r['clean_pct'])+'%'}</b></td></tr>"
         for r in report["per_room"])
     f = report["findings_by_class"]
@@ -652,7 +813,8 @@ def write_gallery(report: dict, out_path: Path) -> None:
  <span>reciprocal-door failures: <b>{f['reciprocal_door_failures']}</b></span>
  <span>hero-position failures: <b>{f['hero_position_failures']}</b></span>
 </div>
-<table><tr><th>room</th><th>plate</th><th>hero-pos pass</th><th>furniture flags / floor cells</th><th>CLEAN%</th></tr>
+<table><tr><th>room</th><th>plate</th><th>hero-pos pass</th><th>furniture flags / floor cells</th>
+<th>occlusion-exempted</th><th>CLEAN%</th></tr>
 {rows_html}</table>
 <div class=cards>
 {''.join(cards)}
@@ -731,7 +893,7 @@ def _print_summary(report: dict) -> None:
     for r in report["per_room"]:
         print(f"  ROOM {r['room']}: CLEAN {r['clean_pct']}%  hero {r['hero_pass']}/{r['hero_steps']}  "
               f"furniture-flags {r['inverse_coherence_flags']}/{r['walkable_floor_cells']}  "
-              f"[{r['plate_status']}]")
+              f"occlusion-exempted={r.get('occlusion_exempted', 0)}  [{r['plate_status']}]")
     print(f"  FINDINGS: invented-furniture={f['invented_furniture_flags']}  "
           f"reciprocal-door-failures={f['reciprocal_door_failures']}  "
           f"hero-position-failures={f['hero_position_failures']}")

--- a/qa/test_journey_visual_sweep.py
+++ b/qa/test_journey_visual_sweep.py
@@ -3,11 +3,21 @@
 checks (#1540). No engine, no HTTP, no live viewer: every function here is exercised against synthetic
 plates / manifests so the paint-truth logic is pinned independent of the player.
 
+SWEEP-PRECISION additions (this file): the occlusion-exemption tests at the bottom, both synthetic
+(resolve_occlusion_cells unit coverage) and RED-FIRST on REAL committed assets:
+  * fresh-crypt (qa/evidence/crypt-fresh/crypt_fresh_v1.png + qa/room_manifests/crypt_fresh.cells.json —
+    both canonical since #1565 merged): 15 baseline flags on its OWN derived manifest, all 15 fall inside
+    authored occlusion -> 0 remain after the fix.
+  * tavern_truegrey vs tavern_fit2 (both already committed): a genuinely-invented-furniture NEGATIVE
+    control -- cross-referencing a DIFFERENT room generation's occlusion data must not paper over real
+    invented furniture; 4 of 5 baseline flags have no authored occlusion anywhere and must still flag.
+
   uv run --directory servers/engine python -m pytest qa/test_journey_visual_sweep.py -q
   (or plain: python -m pytest qa/test_journey_visual_sweep.py -q  — PIL is the only dependency)
 """
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -20,6 +30,7 @@ if str(_QA) not in sys.path:
 from journey_visual_sweep import (  # noqa: E402
     cell_floor_quad, cell_silhouette_quad, feet_screen, point_in_quad, cell_edge_density,
     inverse_coherence_flags, reciprocal_door_check, hero_feet_check, chebyshev, build_report,
+    resolve_occlusion_cells, load_plate_edges,
 )
 
 COLS, ROWS = 12, 10
@@ -139,6 +150,170 @@ def test_build_report_clean_pct_and_finding_counts():
     assert row["clean_pct"] == 83.3 and not row["meets_95"]
     assert rep["findings_by_class"] == {"invented_furniture_flags": 1,
                                         "reciprocal_door_failures": 1, "hero_position_failures": 1}
+
+
+# ── occlusion resolution (SWEEP-PRECISION) ──────────────────────────────────────────────────────────
+def test_resolve_occlusion_cells_exact_match_uses_committed_occlusion():
+    # A live prop {id, footprint} straight off manifest_from_surface (no kind, no occlusion — the live
+    # scene_grid never carries either). A committed manifest has the SAME id + footprint (the same
+    # authored prop) WITH an occlusion list -> that list is used verbatim.
+    live_props = [{"id": "pillar_l", "footprint": [[3, 3], [3, 4]]}]
+    manifest = {"room": "fixture_room", "props": [
+        {"id": "pillar_l", "kind": "stone_pillar", "footprint": [[3, 3], [3, 4]],
+         "occlusion": [[3, 3], [3, 4], [3, 2], [4, 2]]},
+    ]}
+    occ, notes = resolve_occlusion_cells(live_props, COLS, ROWS, manifests=[manifest])
+    assert occ == {(3, 3), (3, 4), (3, 2), (4, 2)}
+    assert any("fixture_room" in n and "pillar_l" in n for n in notes)
+
+
+def test_resolve_occlusion_cells_derives_when_matched_manifest_has_no_occlusion_field():
+    # The matched prop entry carries a `kind` but no `occlusion` (an older/measured manifest) -- derive
+    # on the fly. A tall kind's derived silhouette must be a strict SUPERSET of its own footprint (the
+    # occlusion band always contains the footprint plus the up-screen cells its box paints over).
+    live_props = [{"id": "sarcophagus", "footprint": [[4, 6], [5, 6]]}]
+    manifest = {"room": "fixture_measured", "props": [
+        {"id": "sarcophagus", "kind": "sarcophagus", "footprint": [[4, 6], [5, 6]]},  # no "occlusion" key
+    ]}
+    occ, notes = resolve_occlusion_cells(live_props, 14, 11, manifests=[manifest])
+    assert {(4, 6), (5, 6)} <= occ, "derived occlusion must at least contain the footprint"
+    assert len(occ) > 2, "a real prop's silhouette should rise off its own footprint, not equal it"
+    assert any("DERIVED" in n and "sarcophagus" in n for n in notes)
+
+
+def test_resolve_occlusion_cells_falls_back_when_no_manifest_matches():
+    # No committed manifest has this id+footprint anywhere (a cold room, or a prop whose geometry
+    # changed) -> current (pre-#1565) behaviour: no exemption, and the gap is LOGGED, not silent.
+    live_props = [{"id": "brand_new_prop", "footprint": [[1, 1]]}]
+    occ, notes = resolve_occlusion_cells(live_props, COLS, ROWS, manifests=[])
+    assert occ == set()
+    assert any("NOT exempted" in n and "brand_new_prop" in n for n in notes)
+
+
+def test_resolve_occlusion_cells_skips_props_with_no_footprint():
+    occ, notes = resolve_occlusion_cells([{"id": "ghost", "footprint": []}], COLS, ROWS, manifests=[])
+    assert occ == set() and notes == []
+
+
+# ── inverse coherence WITH occlusion exemption (SWEEP-PRECISION) ───────────────────────────────────
+def test_inverse_coherence_exempts_a_cell_inside_authored_occlusion():
+    # Same shape as test_inverse_coherence_flags_the_invented_object_and_not_distant_clean_floor, but
+    # the "bench" cell is now inside an AUTHORED prop's occlusion band (a tall prop's silhouette
+    # legitimately painting over it) -- it must move to `exempted`, not `flagged`, and CLEAN% must not
+    # count it against the room.
+    walkable = [(c, r) for c in range(2, 10) for r in range(2, 8)]
+    silhouette_cell = (8, 3)
+    edges = _edge_field([silhouette_cell])
+    res = inverse_coherence_flags(edges, [list(c) for c in walkable], set(), COLS, ROWS, "synthetic",
+                                  occlusion_cells={silhouette_cell})
+    assert silhouette_cell not in {tuple(f["cell"]) for f in res.flagged}
+    assert silhouette_cell in {tuple(f["cell"]) for f in res.exempted}
+
+
+def test_inverse_coherence_still_flags_invented_furniture_outside_every_occlusion_band():
+    # The exemption set is non-empty (some OTHER prop's occlusion), but does not cover the painted
+    # object's cell -- genuinely invented furniture (unauthored anywhere) must still flag. This is the
+    # #1552 tavern-benches guarantee: occlusion exemption must never become a blanket suppressor.
+    walkable = [(c, r) for c in range(2, 10) for r in range(2, 8)]
+    invented = (8, 3)
+    unrelated_occlusion = {(2, 2), (2, 3)}   # nowhere near the invented cell
+    edges = _edge_field([invented])
+    res = inverse_coherence_flags(edges, [list(c) for c in walkable], set(), COLS, ROWS, "synthetic",
+                                  occlusion_cells=unrelated_occlusion)
+    assert invented in {tuple(f["cell"]) for f in res.flagged}
+    assert res.exempted == []
+
+
+def test_inverse_coherence_baseline_unchanged_by_occlusion_cells():
+    # occlusion_cells is a POST-HOC partition only -- it must never move the median/MAD baseline itself
+    # (co-calibrated against the camp clean-floor anchor pre-#1565; a room where occlusion covers the
+    # ENTIRE walkable floor, #1565's fresh crypt, would otherwise leave nothing to calibrate against).
+    walkable = [(c, r) for c in range(2, 10) for r in range(2, 8)]
+    tall_prop_cell = (8, 3)
+    edges = _edge_field([tall_prop_cell])
+    with_occ = inverse_coherence_flags(edges, [list(c) for c in walkable], set(), COLS, ROWS, "synthetic",
+                                       occlusion_cells={tall_prop_cell})
+    without_occ = inverse_coherence_flags(edges, [list(c) for c in walkable], set(), COLS, ROWS, "synthetic")
+    assert with_occ.baseline_median == without_occ.baseline_median
+    assert with_occ.mad == without_occ.mad
+    assert f"{tall_prop_cell[0]},{tall_prop_cell[1]}" in with_occ.densities
+
+
+# ── RED-FIRST: real committed assets (SWEEP-PRECISION) ──────────────────────────────────────────────
+# #1565 (FRESH-CRYPT) merged to main while this PR was in flight — qa/room_manifests/crypt_fresh.cells.json
+# and qa/evidence/crypt-fresh/crypt_fresh_v1.png are now the CANONICAL committed assets (no need for a
+# PR-scoped fixture copy anymore; verified byte-identical to the pre-merge copies this test used).
+_FRESH_CRYPT_PLATE = _QA / "evidence" / "crypt-fresh" / "crypt_fresh_v1.png"
+_FRESH_CRYPT_MANIFEST = _QA / "room_manifests" / "crypt_fresh.cells.json"
+_TAVERN_TRUEGREY_PLATE = _QA / "evidence" / "new-tavern" / "tavern_truegrey_v1.png"
+_TAVERN_TRUEGREY_MANIFEST = _QA / "room_manifests" / "tavern_truegrey.cells.json"
+_TAVERN_FIT2_MANIFEST = _QA / "room_manifests" / "tavern_fit2.cells.json"
+
+
+def _needs(*paths):
+    import pytest
+    missing = [str(p) for p in paths if not p.is_file()]
+    if missing:
+        pytest.skip(f"evidence fixture(s) not present: {missing}")
+
+
+def test_red_first_fresh_crypt_dense_room_flags_drop_after_occlusion_exemption():
+    # THE #1552 FOLLOW-UP THIS PR CLOSES: #1565's fresh crypt (20 authored props, richer than the
+    # sparse incumbent's 3) scores its OWN derived manifest 15 baseline flags -- every single one a
+    # legitimate authored-occlusion silhouette (a denser room paints more up-screen silhouette, not
+    # more invented furniture). Before this fix ALL 15 count against CLEAN%; after it, ZERO do.
+    _needs(_FRESH_CRYPT_PLATE, _FRESH_CRYPT_MANIFEST)
+    manifest = json.loads(_FRESH_CRYPT_MANIFEST.read_text(encoding="utf-8"))
+    cols, rows = manifest["grid"]["cols"], manifest["grid"]["rows"]
+    walkable = manifest["walkable"]
+    prop_cells = {(c, r) for p in manifest["props"] for (c, r) in p["footprint"]}
+    live_props = [{"id": p["id"], "footprint": p["footprint"]} for p in manifest["props"]]
+
+    edges = load_plate_edges(_FRESH_CRYPT_PLATE)
+    baseline = inverse_coherence_flags(edges, walkable, prop_cells, cols, rows, "crypt_fresh_baseline")
+    assert len(baseline.flagged) == 15, (
+        f"baseline (pre-fix) flag count drifted from the measured 15: {baseline.flagged}")
+
+    occlusion_cells, notes = resolve_occlusion_cells(live_props, cols, rows, manifests=[manifest])
+    assert len(notes) == len(live_props), "every authored prop must resolve (this IS its own manifest)"
+    fixed = inverse_coherence_flags(edges, walkable, prop_cells, cols, rows, "crypt_fresh_fixed",
+                                    occlusion_cells=occlusion_cells)
+    assert fixed.flagged == [], (
+        f"every fresh-crypt flag is a verified authored-occlusion silhouette; still flagged: {fixed.flagged}")
+    assert len(fixed.exempted) == 15, f"expected all 15 baseline flags to move to exempted: {fixed.exempted}"
+
+
+def test_red_first_genuinely_invented_tavern_furniture_still_flags():
+    # THE NEGATIVE CONTROL: the OLD tavern_truegrey plate (painted before the fit2 density-law props
+    # existed) evaluated on its OWN grid, with occlusion cross-referenced against tavern_fit2's manifest
+    # (a LATER room generation with 8 more props, including benches truegrey's own grid never authored).
+    # Per-prop id+footprint matching only pulls in occlusion for the 6 props truegrey and fit2 share
+    # VERBATIM (hearth/bar_counter/table_nw/table_ne/table_s/barrels) -- fit2's bench/stool/shelf/cask
+    # occlusion can never apply here because no LIVE prop in truegrey's own grid has those ids at all.
+    # 4 of the 5 baseline flags have no authored occlusion anywhere and MUST still flag.
+    _needs(_TAVERN_TRUEGREY_PLATE, _TAVERN_TRUEGREY_MANIFEST, _TAVERN_FIT2_MANIFEST)
+    truegrey = json.loads(_TAVERN_TRUEGREY_MANIFEST.read_text(encoding="utf-8"))
+    fit2 = json.loads(_TAVERN_FIT2_MANIFEST.read_text(encoding="utf-8"))
+    cols, rows = truegrey["grid"]["cols"], truegrey["grid"]["rows"]
+    walkable = truegrey["walkable"]
+    prop_cells = {(c, r) for p in truegrey["props"] for (c, r) in p["footprint"]}
+    live_props = [{"id": p["id"], "footprint": p["footprint"]} for p in truegrey["props"]]
+
+    edges = load_plate_edges(_TAVERN_TRUEGREY_PLATE)
+    baseline = inverse_coherence_flags(edges, walkable, prop_cells, cols, rows, "tavern_truegrey_baseline")
+    baseline_cells = {tuple(f["cell"]) for f in baseline.flagged}
+    assert baseline_cells == {(2, 2), (2, 1), (3, 1), (7, 1), (1, 3)}, (
+        f"baseline (pre-fix) flag set drifted from the measured set: {baseline_cells}")
+
+    # deliberately cross-reference the LATER fit2 manifest -- the mismatched-generation stress case.
+    occlusion_cells, _notes = resolve_occlusion_cells(live_props, cols, rows, manifests=[fit2, truegrey])
+    fixed = inverse_coherence_flags(edges, walkable, prop_cells, cols, rows, "tavern_truegrey_fixed",
+                                    occlusion_cells=occlusion_cells)
+    still_flagged = {tuple(f["cell"]) for f in fixed.flagged}
+    assert still_flagged == {(2, 2), (2, 1), (3, 1), (1, 3)}, (
+        f"genuinely-invented furniture must still flag; got {still_flagged}")
+    assert {tuple(f["cell"]) for f in fixed.exempted} == {(7, 1)}, (
+        "exactly one baseline flag (inside the shared hearth's occlusion band) should exempt")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes the visual journey sweep's inverse-coherence detector (`qa/journey_visual_sweep.py`, #1552) so it
stops penalizing AUTHORED occlusion. Under the iso projection a tall authored prop's silhouette
legitimately paints OVER walkable cells behind it (occlusion != footprint — the manifest distinction in
`qa/room_manifests/*.cells.json`'s per-prop `occlusion` cell lists, docs/ROOM-PIPELINE-RUNBOOK.md Sec.2).
Through #1552 this check only ever excluded FOOTPRINT cells, so a dense, richly-authored room (more tall
props => more legitimate up-screen silhouette) necessarily flagged MORE than a sparse one — punishing
exactly the density the owner wants. This was #1552's own noted follow-up ("subtract authored-occluder
bands").

## Change

`resolve_occlusion_cells()` (new) resolves, per LIVE prop (id + footprint straight off
`manifest_from_surface` — the live scene_grid carries neither `kind` nor `occlusion`):
1. **exact match** — scan the committed `qa/room_manifests/*.cells.json` corpus for a prop with the
   SAME id + IDENTICAL footprint (both derived from the same authored geometry); use its committed
   `occlusion` list verbatim.
2. **derive** — the matched entry has a `kind` but no `occlusion` field (an older/measured manifest) —
   derive on the fly via `tools/derive_room_manifest.derive_occlusion_cells`, the exact function that
   PRODUCES every committed `occlusion` field (the same box-corner projection
   `check_grid_paint_coherence.py`'s `prop_box_screen_bbox` uses, refined to a convex-hull/point-in-
   polygon test).
3. **no match** — fall back to CURRENT (pre-fix) behaviour for that one prop; logged, never silent.

`inverse_coherence_flags()` partitions cells that clear the outlier bar into `flagged` vs `exempted`
(new field). **The baseline calibration (median/MAD) is UNCHANGED** — occlusion is a post-hoc partition
only, never folded into "what does clean floor look like": a room where occlusion covers the ENTIRE
walkable floor (#1565's fresh crypt) would otherwise leave nothing to calibrate a baseline from.
Exempted-count is surfaced per room (report.json, gallery.html, print summary) so precision stays
auditable, never a silent mask.

## Red-first proof

**Fresh crypt, own manifest** (`qa/test_journey_visual_sweep.py::test_red_first_fresh_crypt_dense_room_flags_drop_after_occlusion_exemption`,
real committed assets — `qa/evidence/crypt-fresh/crypt_fresh_v1.png` + `qa/room_manifests/crypt_fresh.cells.json`,
both canonical since #1565 merged): **15 baseline flags → 0** — every one moves to `exempted`.

**Negative control — genuinely-invented furniture must still flag**
(`test_red_first_genuinely_invented_tavern_furniture_still_flags`): the OLD `tavern_truegrey` plate,
cross-referenced against the LATER `tavern_fit2` manifest (a stress case — a manifest generation the
live room never used) via the same per-prop id+footprint matching: **4 of 5 baseline flags still flag**
(no authored prop anywhere covers them); only 1 exempts (the shared `hearth` prop's silhouette band).
Precision, not a blanket suppressor.

## Live full-sweep — all-rooms CLEAN%, before vs after (same commit, only the detector differs)

| room | plate | CLEAN% before | flags before | CLEAN% after | flags after | occlusion-exempted |
|---|---|---|---|---|---|---|
| crypt | `crypt_fresh_v1.png` (canonical since #1565, painted over the sparser un-reconciled walkslice grid, #1559) | **77.9%** | 21/94 | **90.5%** | 9/94 | 12 |
| camp_clearing_night | `camp_clearing_night_truegrey_v1.png` | 95.6% | 6/134 | 95.6% | 6/134 | 0 (see note) |
| tavern | `tavern_fit2_v1.png` | 100.0% | 0/43 | 100.0% | 0/43 | 0 (already clean) |
| **overall** | | **90.1%** | 27 findings | **94.5%** | 15 findings | |

**crypt is the headline case.** `crypt_fresh_v1.png` (#1565, 20 authored props) is the canonical `crypt`
plate, but the *live* walkslice engine grid still only authors the sparse 3-prop incumbent geometry
(`pillar_l`/`pillar_r`/`sarcophagus` — reconciliation deferred, #1559). Before this fix, every cell the
richer plate's silhouette fell on that the sparse grid didn't author was flagged (21). After: 12 of those
cells resolve to genuinely authored occlusion (via `crypt_dense_v1.cells.json`'s matching prop
geometry) and exempt; the remaining 9 are the SEPARATE, already-tracked #1559 gap (plate content with
literally no authored prop backing it in the live grid) — correctly **not** suppressed. Full breakdown +
occlusion_notes in `qa/evidence/sweep-precision/README.md`.

**camp shows 0 exempted for two unrelated, already-diagnosed reasons** (not a defect in this fix): 6 of
its 22 props are PR #1564's brand-new camp props, added the same day, that the committed manifest
predates (logged as "no manifest prop matches", not silently dropped); and camp's 6 flagged cells are
#1564's own documented false-positive class (silhouette-band bleed into a neighbouring object), unrelated
to footprint-vs-occlusion. See `qa/evidence/sweep-precision/README.md` for the full explanation.

## Tests

`python3 -m pytest qa/test_journey_visual_sweep.py -q` → **22 passed** (13 pre-existing + 9 new, pure
functions, no engine/HTTP). Related suites unaffected: `test_journey_click_sweep.py`,
`test_grid_paint_coherence.py`, `test_derive_room_manifest.py` → 23 passed.

Live full sweep run twice (scratch viewer, ports 8790/8791, never :8766) — before/after table above,
raw `report.json` for both embedded at `qa/evidence/sweep-precision/{before,after}/report.json`.

## Safety / scope

Additive detector-precision change only: `qa/journey_visual_sweep.py` (own path) +
`qa/test_journey_visual_sweep.py` (own path) + a new `qa/evidence/sweep-precision/` evidence dir. No
engine/seed/manifest files touched; no owner surfaces (`:8766`, `/tmp/walkslice_owner`, LaunchAgents)
touched at any point — every live run used a scratch state dir + a scratch viewer on port ≥8767, torn
down by PID.

## Notes for next agent

- camp's manifest (`qa/room_manifests/camp_truegrey.cells.json`) is stale vs PR #1564's 6 new props —
  regenerating it via `tools/derive_room_manifest.py` would let this fix's exemption reach camp too.
- The 9 remaining crypt flags close only when #1559's walkslice-reconciliation lands (re-authoring the
  live crypt grid with fresh-crypt's full prop set) — tracked separately, not a gap in this PR.