### PR TITLE
qa: walk_test.py — the automated WALKABILITY gate + red-first pytest (#1582)

### DIFF
--- a/qa/test_walk_test.py
+++ b/qa/test_walk_test.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Red-first proof that the WALKABILITY gate has teeth (epic #1581, issue #1582).
+
+The live green proof comes after the camera-rig fix + box rebuild (issue #1583, Step 4). THIS test
+proves — deterministically, with no rebuild and no image analysis — that walk_test's assertion logic
+FAILS on the shipped-2026-07-15 broken camera pose and PASSES on the build_room_unified contract pose.
+A gate that can't go red is not a gate.
+
+Run: python3 -m pytest qa/test_walk_test.py -q -p no:xdist
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import walk_test as W  # noqa: E402
+
+CRYPT_ORTHO = 11.7851
+
+
+def _contract_snapshot(ortho=CRYPT_ORTHO):
+    """The pose ApplyPlate must reproduce: Euler(30,45,0), pos=-fwd*80, aim at origin, pinned ortho."""
+    px, py, pz = W.contract_cam_pos()
+    return {"ok": True, "camOrtho": ortho, "camRx": 30.0, "camRy": 45.0, "camRz": 0.0,
+            "camPx": px, "camPy": py, "camPz": pz, "originVX": 0.5, "originVY": 0.5}
+
+
+def test_contract_pose_passes():
+    """A camera that matches build_room_unified's rig has ZERO failures — the room is projectable."""
+    assert W.check_camera_pose(_contract_snapshot(), CRYPT_ORTHO) == []
+
+
+def test_broken_aim_fails():
+    """The actual 2026-07-15 bug: ortho pinned but position never set → camera keeps a stale aim, so
+    world origin projects OFF viewport-center. The gate MUST catch this."""
+    snap = _contract_snapshot()
+    snap["originVX"], snap["originVY"] = 0.72, 0.34  # origin far from center → offset plate
+    snap["camPx"] += 18.0  # stale/previous-room position
+    fails = W.check_camera_pose(snap, CRYPT_ORTHO)
+    assert fails, "broken aim must fail the camera gate"
+    assert any("origin" in f for f in fails)
+
+
+def test_wrong_ortho_fails():
+    snap = _contract_snapshot(ortho=13.0)  # inherited a different room's ortho
+    assert any("camOrtho" in f for f in W.check_camera_pose(snap, CRYPT_ORTHO))
+
+
+def test_rotated_rig_fails():
+    snap = _contract_snapshot()
+    snap["camRy"] = 60.0  # camera re-angled off the frozen dimetric contract
+    assert any("camRy" in f for f in W.check_camera_pose(snap, CRYPT_ORTHO))
+
+
+def test_missing_camera_fields_is_loud_not_silent():
+    """An old player build without the /debug camera extension must FAIL loud (never silently green)."""
+    fails = W.check_camera_pose({"ok": True, "enq": 3, "last": "cell(8,9)"}, CRYPT_ORTHO)
+    assert fails and "unavailable" in fails[0]
+
+
+def test_walkmask_from_surface():
+    """Engine truth: cellDefault=floor is walkable; listed wall/prop cells are blocked; doors walkable."""
+    surf = {
+        "grid": {"cols": 4, "rows": 3, "cellDefault": {"type": "floor", "walkable": True},
+                 "cells": [{"c": 0, "r": 0, "walkable": False}, {"c": 1, "r": 1, "walkable": False},
+                           {"c": 2, "r": 0, "type": "door", "walkable": True}]},
+        "doors": [{"cell": [2, 0], "to": "next"}],
+    }
+    m = W.walkmask_from_surface(surf)
+    assert (1, 1) in m["blocked"] and (0, 0) in m["blocked"]
+    assert (2, 0) in m["doors"] and (2, 0) in m["walkable"]  # a door is walkable
+    assert (3, 2) in m["walkable"]  # default floor
+
+
+def test_contract_cam_pos_aims_back_and_up():
+    x, y, z = W.contract_cam_pos()
+    assert y > 0 and x < 0 and z < 0  # pulled back-and-up along -forward (Euler 30/45)
+    assert abs((x * x + y * y + z * z) ** 0.5 - 80.0) < 1e-6  # exactly PULLBACK units from origin

--- a/qa/walk_test.py
+++ b/qa/walk_test.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""THE automated WALKABILITY gate — drive the live player and PROVE a room is walkable.
+
+Epic #1581, issue #1582. Beauty (the blind panel) and WALKABILITY are DIFFERENT gates: a plate can
+score 8.3 on the panel and still be unwalkable (character projects off the plate, walks through walls,
+no occlusion). We shipped 3 panel-8+ unwalkable rooms on 2026-07-15 because this gate did not exist as
+automation. This is that gate.
+
+It drives the live player over the QA channel (:8971 /click,/shot,/debug) and the engine surface
+(:8766 /combat-surface = the ground truth) and asserts, with NO human:
+
+  1. CAMERA POSE == the build_room_unified contract (the root-cause check). The plate was painted by a
+     camera at Euler(30,45,0), pos=-(fwd)*80, aiming at world origin, at the pinned ortho. Actors AND
+     occluders are world-placed and projected through Camera.main, so if the runtime camera != that
+     contract, EVERYTHING projects offset from the plate (walk-on-tomb / walk-through-wall / no pillar
+     masking — all one bug). The client exposes its actual camera pose on /debug; we assert it matches.
+     The crisp, aspect-independent form: world origin must project to viewport CENTER (0.5,0.5).
+  2. ENGINE TRUTH — every clicked reachable cell resolves the token TO that cell (token == click);
+     every impassable cell REJECTS the move (token unchanged). GEOMETRY IS GROUND TRUTH.
+  3. DOORS — each door cell is walkable and (cosmetically) sits on the painted arch.
+  4. OCCLUSION + evidence — /shot behind occluders for a contact sheet.
+
+GEOMETRY IS GROUND TRUTH (VISION.md): collision/occlusion come from the grid + boxes sidecar; the
+plate is cosmetic. So (1) is the linchpin — once the camera reproduces the contract, actors and
+occluders land on the painted masses automatically (no per-cell pixel tuning).
+
+The camera-pose asserts and the engine asserts are CU-free (no LLM, no image analysis). /shot is only
+for the human/occlusion evidence contact sheet. The pure assertion helpers below are unit-tested in
+qa/test_walk_test.py (red-first: a broken camera snapshot must FAIL, a contract snapshot must PASS).
+
+Usage:
+  qa/walk_test.py --room crypt                         # gate the current room on the live player
+  qa/walk_test.py --room crypt --exhaustive            # click EVERY reachable + impassable cell
+  qa/walk_test.py --room crypt --out qa/evidence/walk/ # write walk_report.json + contact sheet here
+Requires the owner player running with WORLDOS_QA_INPUT=1 (port 8971) + the engine on :8766.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent
+MANIFEST = REPO / "extensions" / "renderers" / "unity" / "plates_manifest.json"
+
+# --- the camera contract (MIRROR qa/greybox_render_headless — build_room_unified's rig) ------------
+PITCH_DEG, YAW_DEG, PULLBACK = 30.0, 45.0, 80.0
+
+
+def _forward() -> tuple:
+    """Camera forward in the greybox/Unity convention (== Quaternion.Euler(30,45,0)*Vector3.forward)."""
+    p, y = math.radians(PITCH_DEG), math.radians(YAW_DEG)
+    return (math.sin(y) * math.cos(p), -math.sin(p), math.cos(y) * math.cos(p))
+
+
+def contract_cam_pos() -> tuple:
+    """The build_room_unified camera position: pulled back PULLBACK units along -forward, aim at origin."""
+    fx, fy, fz = _forward()
+    return (-fx * PULLBACK, -fy * PULLBACK, -fz * PULLBACK)
+
+
+# --- PURE assertion helpers (no I/O; unit-tested in qa/test_walk_test.py) --------------------------
+def check_camera_pose(dbg: dict, ortho: float, *, deg_tol: float = 1.5,
+                      vp_tol: float = 0.03, pos_tol: float = 1.5) -> list:
+    """Return a list of failure strings; EMPTY == the runtime camera matches the plate's render rig.
+
+    `dbg` is the /debug JSON (extended with the camera fields, issue #1583). If those fields are
+    absent (an old player build) we return a single 'unavailable' failure so the gate is loud, never
+    silently green. This is the check that turns RED on the shipped-2026-07-15 broken build and GREEN
+    after the ApplyPlate camera-rig fix.
+    """
+    if dbg.get("camOrtho") is None:
+        return ["camera pose unavailable — rebuild the player with the /debug camera extension "
+                "(issue #1583); the walkability gate cannot verify projection without it"]
+    fails: list = []
+    # (a) orthographic size matches the pinned plate ortho
+    if abs(float(dbg["camOrtho"]) - ortho) > 0.05:
+        fails.append(f"camOrtho {float(dbg['camOrtho']):.4f} != pinned {ortho:.4f}")
+    # (b) rotation is the frozen dimetric rig
+    for axis, want in (("camRx", PITCH_DEG), ("camRy", YAW_DEG), ("camRz", 0.0)):
+        got = ((float(dbg.get(axis, 0.0)) + 180.0) % 360.0) - 180.0
+        w = ((want + 180.0) % 360.0) - 180.0
+        if abs(got - w) > deg_tol:
+            fails.append(f"{axis} {got:.2f} != {want} (deg_tol {deg_tol})")
+    # (c) THE aim-at-origin check (the one broken now): world origin projects to viewport CENTER.
+    ox, oy = dbg.get("originVX"), dbg.get("originVY")
+    if ox is None or oy is None:
+        fails.append("originVX/originVY missing from /debug (camera-aim check impossible)")
+    elif abs(float(ox) - 0.5) > vp_tol or abs(float(oy) - 0.5) > vp_tol:
+        fails.append(f"camera NOT aimed at world origin: origin projects to viewport "
+                     f"({float(ox):.3f},{float(oy):.3f}), want (0.500,0.500) — actors+occluders "
+                     f"will project offset from the painted plate")
+    # (d) belt-and-suspenders: raw position matches the pulled-back contract (if reported)
+    cx, cy, cz = dbg.get("camPx"), dbg.get("camPy"), dbg.get("camPz")
+    if None not in (cx, cy, cz):
+        wx, wy, wz = contract_cam_pos()
+        if (abs(float(cx) - wx) > pos_tol or abs(float(cy) - wy) > pos_tol
+                or abs(float(cz) - wz) > pos_tol):
+            fails.append(f"camera position ({float(cx):.1f},{float(cy):.1f},{float(cz):.1f}) != "
+                         f"contract ({wx:.1f},{wy:.1f},{wz:.1f})")
+    return fails
+
+
+def walkmask_from_surface(surf: dict) -> dict:
+    """Derive the walkable / impassable / door sets from a /combat-surface payload (engine truth)."""
+    grid = surf["grid"]
+    cols, rows = int(grid["cols"]), int(grid["rows"])
+    default_walkable = bool(grid.get("cellDefault", {}).get("walkable", True))
+    blocked = set()
+    for cell in grid.get("cells", []):
+        if not cell.get("walkable", default_walkable):
+            blocked.add((int(cell["c"]), int(cell["r"])))
+    doors = {(int(d["cell"][0]), int(d["cell"][1])) for d in surf.get("doors", [])}
+    interior = [(c, r) for r in range(rows) for c in range(cols)]
+    walkable = [cell for cell in interior if cell not in blocked or cell in doors]
+    return {"cols": cols, "rows": rows, "walkable": set(walkable),
+            "blocked": blocked - doors, "doors": doors}
+
+
+def _sample(cells: list, stride: int) -> list:
+    """A deterministic representative sample (every `stride`-th cell) — bounds a big room's runtime."""
+    return cells if stride <= 1 else cells[::stride]
+
+
+# --- live I/O helpers ------------------------------------------------------------------------------
+def _get(url: str, timeout: float = 5.0):
+    with urllib.request.urlopen(url, timeout=timeout) as r:
+        return json.loads(r.read().decode())
+
+
+def _post(url: str, body: dict, timeout: float = 5.0):
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(url, data=data, method="POST",
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read().decode())
+
+
+def _token_cell(surf: dict):
+    toks = surf.get("tokens") or []
+    if not toks:
+        return None
+    t = toks[0]
+    return (int(t["x"]), int(t["y"]))
+
+
+def _room_ortho(room: str) -> float:
+    man = json.loads(MANIFEST.read_text())
+    plates = man.get("plates", man)
+    entry = plates.get(room)
+    if not entry:
+        raise SystemExit(f"[walk_test] room '{room}' not in {MANIFEST} (have: {sorted(plates)[:8]})")
+    return float(entry["cameraPin"]["ortho"])
+
+
+def run_gate(room: str, engine: str, qa: str, *, stride: int, out: Path,
+             settle: float, move_timeout: float) -> dict:
+    """Drive the live player through `room` and return a walk_report dict. Never raises on a cell
+    failure — records it — so the report is complete; the caller decides the exit code."""
+    ortho = _room_ortho(room)
+    surf = _get(f"{engine}/combat-surface")
+    scene = surf.get("grid", {}).get("sceneId", "")
+    if room not in scene:
+        print(f"[walk_test] WARNING: live sceneId '{scene}' does not name room '{room}' — the player "
+              f"may be in a different room; cross a door first or pass the matching --room.")
+    mask = walkmask_from_surface(surf)
+    report = {"room": room, "ortho": ortho, "sceneId": scene,
+              "grid": {"cols": mask["cols"], "rows": mask["rows"]},
+              "camera": {}, "reachable": {"pass": 0, "fail": 0, "cases": []},
+              "impassable": {"pass": 0, "fail": 0, "cases": []},
+              "doors": {"pass": 0, "fail": 0, "cases": []}, "shots": [], "verdict": "PENDING"}
+
+    # 1) CAMERA POSE — the root-cause gate.
+    try:
+        dbg = _post(f"{qa}/debug", {})
+    except Exception as e:  # noqa: BLE001
+        dbg = {"_error": str(e)}
+    cam_fails = check_camera_pose(dbg, ortho)
+    report["camera"] = {"dbg": dbg, "fails": cam_fails, "ok": not cam_fails}
+
+    interior = [(c, r) for (c, r) in mask["walkable"]
+                if 0 < c < mask["cols"] - 1 and 0 < r < mask["rows"] - 1]
+    interior.sort()
+    doors = sorted(mask["doors"])
+    blocked = sorted(mask["blocked"])
+
+    # 2) REACHABLE — click each sampled reachable cell; token must resolve TO it (engine truth).
+    for (c, r) in _sample(interior, stride):
+        ok, landed = _drive_and_check(qa, engine, c, r, settle, move_timeout, expect_move=True)
+        report["reachable"]["cases"].append({"cell": [c, r], "landed": landed, "ok": ok})
+        report["reachable"]["pass" if ok else "fail"] += 1
+
+    # 3) IMPASSABLE — click each sampled blocked cell; token must NOT move onto it.
+    for (c, r) in _sample(blocked, max(1, stride)):
+        ok, landed = _drive_and_check(qa, engine, c, r, settle, move_timeout, expect_move=False)
+        report["impassable"]["cases"].append({"cell": [c, r], "landed": landed, "ok": ok})
+        report["impassable"]["pass" if ok else "fail"] += 1
+
+    # 4) DOORS — each door cell must be walkable (reachable). Cross-door + arch-overlay: orchestrator.
+    for (c, r) in doors:
+        ok, landed = _drive_and_check(qa, engine, c, r, settle, move_timeout, expect_move=True)
+        report["doors"]["cases"].append({"cell": [c, r], "landed": landed, "ok": ok})
+        report["doors"]["pass" if ok else "fail"] += 1
+
+    # 5) OCCLUSION evidence — a /shot near an occluder for the human contact sheet (non-gating here).
+    shot = _capture_shot(qa, out, f"{room}_final")
+    if shot:
+        report["shots"].append(shot)
+
+    hard_fail = bool(cam_fails) or report["reachable"]["fail"] or report["impassable"]["fail"] \
+        or report["doors"]["fail"]
+    report["verdict"] = "RED" if hard_fail else "GREEN"
+    return report
+
+
+def _drive_and_check(qa: str, engine: str, c: int, r: int, settle: float, timeout: float,
+                     *, expect_move: bool):
+    """Click (c,r); poll the engine token. expect_move: token must reach (c,r). else: must not."""
+    try:
+        before = _token_cell(_get(f"{engine}/combat-surface"))
+        _post(f"{qa}/click", {"c": c, "r": r})
+    except Exception as e:  # noqa: BLE001
+        return False, f"drive-error:{e}"
+    deadline = time.time() + timeout
+    landed = before
+    while time.time() < deadline:
+        time.sleep(settle)
+        try:
+            landed = _token_cell(_get(f"{engine}/combat-surface"))
+        except Exception:  # noqa: BLE001
+            continue
+        if expect_move and landed == (c, r):
+            return True, list(landed)
+        if not expect_move and landed == (c, r):
+            return False, list(landed)  # moved onto an impassable cell — a real failure
+    if expect_move:
+        return (landed == (c, r)), (list(landed) if landed else None)
+    # impassable: pass iff the token never became (c,r)
+    return (landed != (c, r)), (list(landed) if landed else None)
+
+
+def _capture_shot(qa: str, out: Path, label: str):
+    try:
+        resp = _post(f"{qa}/shot", {})
+        time.sleep(2.2)
+        src = Path(resp.get("path", "")) if resp.get("path") else None
+        if src and src.exists():
+            out.mkdir(parents=True, exist_ok=True)
+            dst = out / f"shot_{label}.png"
+            shutil.copy(src, dst)
+            return str(dst)
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--room", required=True, help="manifest room key (crypt/tavern/throne_hall/…)")
+    ap.add_argument("--engine", default="http://127.0.0.1:8766")
+    ap.add_argument("--qa", default="http://127.0.0.1:8971")
+    ap.add_argument("--exhaustive", action="store_true", help="click EVERY cell (default: stride sample)")
+    ap.add_argument("--stride", type=int, default=3, help="sample every Nth cell unless --exhaustive")
+    ap.add_argument("--settle", type=float, default=0.6, help="poll interval while a move resolves")
+    ap.add_argument("--move-timeout", type=float, default=6.0)
+    ap.add_argument("--out", default=str(HERE / "evidence" / "walk"))
+    args = ap.parse_args(argv)
+
+    out = Path(args.out) / args.room
+    stride = 1 if args.exhaustive else max(1, args.stride)
+    report = run_gate(args.room, args.engine, args.qa, stride=stride, out=out,
+                      settle=args.settle, move_timeout=args.move_timeout)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "walk_report.json").write_text(json.dumps(report, indent=2) + "\n")
+
+    cam = report["camera"]
+    print(f"\n=== WALK_TEST {args.room} — {report['verdict']} ===")
+    print(f"camera: {'OK' if cam['ok'] else 'FAIL'}"
+          + ("" if cam["ok"] else "".join(f"\n    - {m}" for m in cam["fails"])))
+    for k in ("reachable", "impassable", "doors"):
+        s = report[k]
+        print(f"{k:11s}: {s['pass']} pass / {s['fail']} fail")
+    print(f"report: {out / 'walk_report.json'}")
+    return 0 if report["verdict"] == "GREEN" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What
`qa/walk_test.py` — the missing **WALKABILITY gate** (epic #1581, issue #1582). Drives the live player (`:8971` /click,/shot,/debug) + the engine surface (`:8766`) and asserts, with NO human, that a room is actually walkable. Plus `qa/test_walk_test.py`, the red-first unit proof.

## The asserts
- **CAMERA POSE == build_room_unified's contract** (the root-cause check): `camOrtho == pinned`, rotation `== Euler(30,45,0)`, and **world origin projects to viewport centre (0.5,0.5)** = aim-at-origin. If the runtime camera ≠ the plate's render rig, actors AND occluders project offset from the plate — the whole 2026-07-15 walkability failure in one check. Consumes the `/debug` camera extension (issue #1583).
- **ENGINE TRUTH**: every clicked reachable cell → `token == click`; every impassable cell → move REJECTED. GEOMETRY IS GROUND TRUTH.
- **DOORS** reachable; **/shot** occlusion-evidence contact sheet.

## Red-first (the gate has teeth — deterministic, no rebuild)
`qa/test_walk_test.py` (7/7 green): a broken camera snapshot (wrong aim / ortho / rotation, or the **current build's missing `/debug` fields**) FAILS; the contract snapshot PASSES. Verified live: the current player's `/debug` returns no camera fields → the gate correctly refuses to certify it (RED). Live-GREEN proof follows the camera-rig fix + box rebuild (#1583, Step 4).

New file, nothing calls it yet — zero behavior change to existing code.

Refs #1581 #1582 #1583