### PR TITLE
fix(seed): party spawns on the open-floor centroid, not a corner/barrel (#1584)

### DIFF
--- a/qa/seed_gfx_town.py
+++ b/qa/seed_gfx_town.py
@@ -24,6 +24,42 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 CID = "camp_townslice01"
 
 
+def choose_spawns(cols: int, rows: int, blocked: set, door_cells: list,
+                  n_party: int = 2, n_npc: int = 1) -> dict:
+    """Place the party on the OPEN-FLOOR CENTROID as a compact cluster, clear of prop footprints and
+    door landing rings — NOT the naive first-N-free interior cells (which land the party jammed in a
+    back corner or inside a barrel: the 2026-07-15 'spawn in a barrel' bug, epic #1581 / issue #1584).
+
+    Deterministic + pure so it is unit-testable (qa/test_seed_spawns.py). GEOMETRY IS GROUND TRUTH:
+    `blocked` and `door_cells` come from the room's authored geometry, so the spawn is walkable by
+    construction. Returns {"party": [(c,r),...], "npcs": [(c,r),...]}.
+    """
+    door_ring = {(dc + dx, dr + dy) for (dc, dr) in door_cells
+                 for dx in (-1, 0, 1) for dy in (-1, 0, 1)}
+    door_set = set(door_cells)
+
+    def _free(exclude_ring: bool) -> list:
+        return [(c, r) for r in range(1, rows - 1) for c in range(1, cols - 1)
+                if (c, r) not in blocked and (c, r) not in door_set
+                and (not exclude_ring or (c, r) not in door_ring)]
+
+    free = _free(exclude_ring=True) or _free(exclude_ring=False)  # tiny rooms: relax the door ring
+    if not free:
+        return {"party": [], "npcs": []}
+    cx = sum(c for c, _ in free) / len(free)
+    cy = sum(r for _, r in free) / len(free)
+    # anchor = the open cell nearest the floor centroid (skips a blocked central monument automatically)
+    free.sort(key=lambda p: ((p[0] - cx) ** 2 + (p[1] - cy) ** 2, p[1], p[0]))
+    chosen: list = [free[0]]
+    remaining = free[1:]
+    while len(chosen) < n_party + n_npc and remaining:
+        nxt = min(remaining, key=lambda p: (min((p[0] - q[0]) ** 2 + (p[1] - q[1]) ** 2 for q in chosen),
+                                            (p[0] - cx) ** 2 + (p[1] - cy) ** 2, p[1], p[0]))
+        chosen.append(nxt)
+        remaining.remove(nxt)
+    return {"party": chosen[:n_party], "npcs": chosen[n_party:n_party + n_npc]}
+
+
 def build_grid_from_geometry(geo: dict, location_id: str, town_id: str, room: str,
                              door_pairs: list) -> "SceneGrid":
     """SceneGrid from a generate_town room geometry: perimeter/prop cells impassable, door cells
@@ -53,8 +89,6 @@ def build_grid_from_geometry(geo: dict, location_id: str, town_id: str, room: st
 
     blocked = wall_cells | {tuple(c) for p in geo.get("props", []) if p.get("kind") != "wall_run"
                             for c in p["cells"]}
-    free = [(c, r) for r in range(1, rows - 1) for c in range(1, cols - 1)
-            if (c, r) not in blocked][:4]
 
     grid = SceneGrid(
         scene_id=f"{CID}:{town_id}_{room}", location_id=location_id, kind="town_room",
@@ -66,7 +100,7 @@ def build_grid_from_geometry(geo: dict, location_id: str, town_id: str, room: st
                                mood="lantern-lit stone district"),
     )
     grid.door_cells = door_cells
-    grid.spawns = {"party": free[:2], "npcs": free[2:3]}
+    grid.spawns = choose_spawns(cols, rows, blocked, door_cells)
     grid.art.layout_hash = _layout_hash(grid)
     return grid
 

--- a/qa/test_seed_spawns.py
+++ b/qa/test_seed_spawns.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Unit proof for choose_spawns — the party spawns on open floor, never in a barrel/corner/door.
+
+Epic #1581, issue #1584. The 2026-07-15 bug: build_grid_from_geometry placed the party at the first
+free interior cells in row-major order → a back-wall corner or right next to a barrel ("spawn in a
+barrel"). choose_spawns places a compact cluster on the open-floor centroid, clear of prop footprints
+and door landing rings. Pure + deterministic, so it is unit-testable here (no engine).
+
+Run: python3 -m pytest qa/test_seed_spawns.py -q -p no:xdist
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from seed_gfx_town import choose_spawns  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+GEO = REPO / "qa" / "room_geometries"
+ROOMS = [("crypt", "crypt_v36_geometry.json", [(7, 0), (15, 5)]),
+         ("tavern", "tavern_v2_geometry.json", [(7, 0)]),
+         ("throne", "throne_hall_geometry.json", [(8, 11)])]
+
+
+def _blocked(geo, door_cells):
+    walls = {tuple(c) for c in geo.get("walls", [])} - set(door_cells)
+    props = {tuple(c) for p in geo.get("props", []) if p.get("kind") != "wall_run" for c in p["cells"]}
+    return walls | props
+
+
+def test_synthetic_spawn_avoids_a_barrel_cluster():
+    """A prop (barrel) sitting on the geometric centre must NOT get a spawn on it."""
+    cols, rows = 9, 9
+    barrel = {(4, 4), (4, 5)}  # a prop at dead centre
+    sp = choose_spawns(cols, rows, blocked=set(barrel), door_cells=[(0, 4)])
+    for cell in sp["party"] + sp["npcs"]:
+        assert tuple(cell) not in barrel, f"spawned in the barrel: {cell}"
+        assert 0 < cell[0] < cols - 1 and 0 < cell[1] < rows - 1  # interior
+
+
+def test_spawn_not_in_a_corner():
+    """The centroid cluster must be central, never jammed at (1,1) like the old first-free rule."""
+    sp = choose_spawns(16, 12, blocked=set(), door_cells=[(7, 0)])
+    ax, ay = sp["party"][0]
+    assert 4 <= ax <= 11 and 3 <= ay <= 8, f"party anchor {sp['party'][0]} is not central"
+
+
+def test_real_rooms_spawn_on_open_floor():
+    for room, geofile, doors in ROOMS:
+        geo = json.loads((GEO / geofile).read_text())
+        blocked = _blocked(geo, doors)
+        sp = choose_spawns(geo["cols"], geo["rows"], blocked, doors)
+        assert sp["party"], f"{room}: no party spawn"
+        for cell in sp["party"] + sp["npcs"]:
+            assert tuple(cell) not in blocked, f"{room}: spawn {cell} on a wall/prop"
+            assert tuple(cell) not in set(doors), f"{room}: spawn {cell} on a door cell"
+
+
+def test_party_members_cluster_together():
+    """Party members stand together — the 2 party cells are within 2 Chebyshev cells of each other."""
+    sp = choose_spawns(16, 12, blocked=set(), door_cells=[])
+    (ax, ay), (bx, by) = sp["party"][0], sp["party"][1]
+    assert max(abs(ax - bx), abs(ay - by)) <= 2
+
+
+def test_spawns_are_distinct():
+    sp = choose_spawns(16, 12, blocked=set(), door_cells=[(7, 0)])
+    cells = [tuple(c) for c in sp["party"] + sp["npcs"]]
+    assert len(cells) == len(set(cells)), "duplicate spawn cells"
+
+
+def test_avoids_door_landing_ring():
+    """No spawn on a cell adjacent to a door (so the party never blocks/overlaps a doorway)."""
+    doors = [(7, 0)]
+    ring = {(7 + dx, 0 + dy) for dx in (-1, 0, 1) for dy in (-1, 0, 1)}
+    sp = choose_spawns(16, 12, blocked=set(), door_cells=doors)
+    for cell in sp["party"] + sp["npcs"]:
+        assert tuple(cell) not in ring, f"spawn {cell} in the door landing ring"


### PR DESCRIPTION
## What
`build_grid_from_geometry` placed the party at the first free interior cells in row-major order → a back-wall corner or right next to a barrel (the 2026-07-15 **spawn-in-a-barrel** bug, epic #1581). `choose_spawns()` now places a compact cluster on the **open-floor centroid**, clear of prop footprints + door landing rings.

## Why it's correct
GEOMETRY IS GROUND TRUTH: `blocked` + `door_cells` come from the authored geometry, so the spawn is walkable by construction. Verified on the 3 shipped geometries — crypt party (7,7)/(8,7) in front of the central tomb, tavern (6,5)/(7,5), throne (7,6)/(8,6): all open floor near centre, clustered.

## Tests (6/6, `qa/test_seed_spawns.py`)
avoids a barrel cluster · not a corner · clusters together · distinct cells · off the door landing ring · all real rooms spawn on open floor.

This builder also feeds `seed_gfx_registered_world.py` (the owner's live campaign), so re-seeding at reinstall picks up the fix.

Refs #1581 #1584