### PR TITLE
qa(walk_test): BFS reachability/orphan gate + path-cell audit (#1582)

### DIFF
--- a/qa/qa_sandbox.py
+++ b/qa/qa_sandbox.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Sandboxed QA lane — full walk sweeps WITHOUT driving the owner's live campaign (#1596).
+
+Epic #1581, red-team finding 2 (adopted): `walk_test.py` drives a player over its QA channel, and the
+owner's player is bound to their LIVE campaign — a full sweep appends hundreds of real moves to the
+owner's session, and the scale loop (#1588) can't hammer the owner's player at all. This module
+provisions a disposable, fully parallel stack:
+
+  cloned state dir (fresh seed)  →  second engine/viewer on :8866  →  second player instance
+  (same .app binary, own WORLDOS_QA_INPUT_PORT :8972)  →  run gates  →  teardown (kill OWN pids only)
+
+POLICY (runbook): small probe sets on the owner instance are acceptable (return the party after);
+FULL sweeps + all scale-loop gating run here. The owner's campaign is not a test rig.
+
+Launch pattern mirrors qa/player_smoke.sh:145-187 (direct binary exec + env), with two deliberate
+differences: (1) NO `osascript quit app "WorldOSPlayer"` — that kills EVERY instance including the
+owner's; teardown signals only the PIDs this module started. (2) The engine runs through
+`uv run --directory servers/engine` so it gets the real venv (the plist pattern).
+
+Caveats:
+- Two player instances share Application Support/com.worldos.WorldOSPlayer — /shot writes collide.
+  Don't run owner-instance probes and a sandbox sweep at the same moment.
+- 16 GB host: ONE sandbox at a time; always teardown (the overnight-loop RAM discipline).
+
+Usage:
+  qa/qa_sandbox.py up   --run scale1            # seed + engine + player; prints the endpoints
+  qa/qa_sandbox.py status --run scale1
+  qa/qa_sandbox.py down --run scale1            # kill own pids; state/logs kept for evidence
+  # or via the orchestrator:  qa/room_pipeline.py --room crypt --sandbox
+Custom seed (new rooms): --seed-cmd "uv run --directory servers/engine python qa/my_seed.py {state}"
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent
+ROOT = Path(os.environ.get("WORLDOS_QA_SANDBOX_ROOT", "/tmp/worldos-qa-sandbox"))
+DEFAULT_APP = Path(os.environ.get("WORLDOS_PLAYER_APP",
+                                  str(Path.home() / "Applications" / "WorldOSPlayer.app")))
+DEFAULT_CAMPAIGN = "registered_world_v1"   # what qa/seed_gfx_registered_world.py seeds
+ENGINE_PORT, QA_PORT = 8866, 8972          # owner runs 8766/8971 — never collide
+
+
+def _http_ok(url: str, post: bool = False, timeout: float = 3.0) -> bool:
+    try:
+        req = urllib.request.Request(url, data=b"{}" if post else None,
+                                     headers={"Content-Type": "application/json"} if post else {})
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return 200 <= r.status < 300
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _wait(label: str, url: str, *, post: bool, timeout_s: float) -> bool:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if _http_ok(url, post=post):
+            return True
+        time.sleep(2)
+    print(f"[sandbox] TIMEOUT waiting for {label} ({url})", file=sys.stderr)
+    return False
+
+
+def _rundir(run: str) -> Path:
+    return ROOT / run
+
+
+def _meta_path(run: str) -> Path:
+    return _rundir(run) / "sandbox.json"
+
+
+def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
+       seed_cmd: str, app: Path) -> dict:
+    rd = _rundir(run)
+    state = rd / "state"
+    if _meta_path(run).exists():
+        raise SystemExit(f"[sandbox] run '{run}' already provisioned — `down` it first ({rd})")
+    state.mkdir(parents=True, exist_ok=True)
+
+    # 1) seed the cloned state dir (default: the 3-room registered world + Aldric)
+    cmd = seed_cmd.format(state=str(state))
+    print(f"[sandbox] seeding: {cmd}")
+    seed = subprocess.run(shlex.split(cmd), cwd=REPO, capture_output=True, text=True, timeout=300)
+    (rd / "seed.log").write_text(seed.stdout + "\n---STDERR---\n" + seed.stderr)
+    if seed.returncode != 0:
+        raise SystemExit(f"[sandbox] seed FAILED (rc={seed.returncode}) — see {rd/'seed.log'}")
+
+    # 2) engine/viewer on its own port + state dir (the plist pattern, uv venv).
+    # WORLDOS_PLAYER_MOVES is LOAD-BEARING: viewer/server.py _live_play() only accepts /move intents
+    # when it is set AND writable — without it the viewer is a read-only projection and every walk
+    # refuses (measured: sandbox sweep 0/29 reachable, token frozen, is_live_view False).
+    env = dict(os.environ,
+               WORLDOS_STATE_DIR=str(state),
+               WORLDOS_PLAYER_MOVES=str(state / "player_moves.jsonl"),
+               WORLDOS_VIEWER_CHAT=str(state / "chat.jsonl"))
+    eng_log = open(rd / "engine.log", "w")  # noqa: SIM115 — long-lived child log
+    engine = subprocess.Popen(
+        ["uv", "run", "--directory", "servers/engine", "python",
+         str(REPO / "viewer" / "server.py"), campaign, str(engine_port)],
+        cwd=REPO, env=env, stdout=eng_log, stderr=subprocess.STDOUT,
+        start_new_session=True)
+    if not _wait("engine", f"http://127.0.0.1:{engine_port}/combat-surface", post=False, timeout_s=90):
+        engine.terminate()
+        raise SystemExit(f"[sandbox] engine never came up — see {rd/'engine.log'}")
+
+    # 3) a SECOND player instance — direct binary exec (open -n drops env), own QA port.
+    #    ⚠ never `osascript quit app` here (kills the OWNER's instance too) — pid-scoped only.
+    pbin = app / "Contents" / "MacOS" / "WorldOSPlayer"
+    if not pbin.exists():
+        engine.terminate()
+        raise SystemExit(f"[sandbox] player binary missing: {pbin}")
+    penv = dict(os.environ,
+                WORLDOS_ENGINE_BASE_URL=f"http://127.0.0.1:{engine_port}",
+                WORLDOS_CAMPAIGN_ID=campaign,
+                WORLDOS_QA_INPUT="1",
+                WORLDOS_QA_INPUT_PORT=str(qa_port))
+    ply_log = open(rd / "player.log", "w")  # noqa: SIM115
+    player = subprocess.Popen([str(pbin)], env=penv, stdout=ply_log, stderr=subprocess.STDOUT,
+                              start_new_session=True)
+    if not _wait("player QA channel", f"http://127.0.0.1:{qa_port}/debug", post=True, timeout_s=120):
+        player.terminate()
+        engine.terminate()
+        raise SystemExit(f"[sandbox] player QA channel never came up — see {rd/'player.log'}")
+
+    meta = {"run": run, "campaign": campaign, "state": str(state),
+            "engine": f"http://127.0.0.1:{engine_port}", "qa": f"http://127.0.0.1:{qa_port}",
+            "pids": {"engine": engine.pid, "player": player.pid}}
+    _meta_path(run).write_text(json.dumps(meta, indent=2) + "\n")
+    print(f"[sandbox] UP — engine {meta['engine']}  qa {meta['qa']}  (pids {meta['pids']})")
+    return meta
+
+
+def down(run: str) -> None:
+    mp = _meta_path(run)
+    if not mp.exists():
+        print(f"[sandbox] no sandbox.json for '{run}' — nothing to stop")
+        return
+    meta = json.loads(mp.read_text())
+    for name, pid in meta.get("pids", {}).items():
+        for sig in (signal.SIGTERM, signal.SIGKILL):
+            try:
+                os.killpg(os.getpgid(pid), sig)   # own session group only (start_new_session)
+                time.sleep(1.5)
+            except ProcessLookupError:
+                break
+            except PermissionError:
+                print(f"[sandbox] cannot signal {name} pid {pid}")
+                break
+        print(f"[sandbox] stopped {name} (pid {pid})")
+    mp.rename(mp.with_suffix(".json.stopped"))
+    print(f"[sandbox] DOWN — state/logs kept at {_rundir(run)} for evidence")
+
+
+def status(run: str) -> dict:
+    mp = _meta_path(run)
+    if not mp.exists():
+        return {"run": run, "up": False}
+    meta = json.loads(mp.read_text())
+    meta["engine_ok"] = _http_ok(meta["engine"] + "/combat-surface")
+    meta["qa_ok"] = _http_ok(meta["qa"] + "/debug", post=True)
+    meta["up"] = meta["engine_ok"] and meta["qa_ok"]
+    return meta
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("cmd", choices=["up", "down", "status"])
+    ap.add_argument("--run", default="default")
+    ap.add_argument("--campaign", default=DEFAULT_CAMPAIGN)
+    ap.add_argument("--engine-port", type=int, default=ENGINE_PORT)
+    ap.add_argument("--qa-port", type=int, default=QA_PORT)
+    ap.add_argument("--app", default=str(DEFAULT_APP))
+    ap.add_argument("--seed-cmd",
+                    default="uv run --directory servers/engine python "
+                            + str(HERE / "seed_gfx_registered_world.py") + " {state}",
+                    help="seed command; '{state}' expands to the sandbox state dir")
+    args = ap.parse_args(argv)
+
+    if args.cmd == "up":
+        up(args.run, campaign=args.campaign, engine_port=args.engine_port,
+           qa_port=args.qa_port, seed_cmd=args.seed_cmd, app=Path(args.app))
+    elif args.cmd == "down":
+        down(args.run)
+    else:
+        print(json.dumps(status(args.run), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/test_walk_test.py
+++ b/qa/test_walk_test.py
@@ -76,3 +76,37 @@ def test_contract_cam_pos_aims_back_and_up():
     x, y, z = W.contract_cam_pos()
     assert y > 0 and x < 0 and z < 0  # pulled back-and-up along -forward (Euler 30/45)
     assert abs((x * x + y * y + z * z) ** 0.5 - 80.0) < 1e-6  # exactly PULLBACK units from origin
+
+
+def _mask(cols, rows, blocked):
+    walkable = {(c, r) for r in range(rows) for c in range(cols)} - set(blocked)
+    return {"cols": cols, "rows": rows, "walkable": walkable, "blocked": set(blocked), "doors": set()}
+
+
+def test_orphan_pocket_detected():
+    """A wall bisecting the room leaves an orphan pocket — the unreachable-paint/seed-defect class.
+    Red-first: the gate MUST flag it."""
+    wall = [(2, r) for r in range(5)]  # full vertical wall at c=2 in a 5x5 room
+    m = _mask(5, 5, wall)
+    orphans = W.orphan_cells(m, start=(0, 0))
+    assert orphans, "bisected room must yield orphans"
+    assert all(c > 2 for (c, r) in [tuple(o) for o in orphans]), "orphans are the far side of the wall"
+
+
+def test_no_orphans_in_connected_room():
+    m = _mask(5, 5, [(2, 2)])  # one prop, room stays connected
+    assert W.orphan_cells(m, start=(0, 0)) == []
+
+
+def test_path_through_a_table_flagged():
+    """The owner's ACTUAL failure: destination legal, but the route crosses a prop. Red-first."""
+    m = _mask(6, 3, [(3, 1)])  # a table at (3,1)
+    bad = W.path_violations([[1, 1], [2, 1], [3, 1], [4, 1]], m)
+    assert bad == [[3, 1]]
+
+
+def test_clean_path_passes():
+    m = _mask(6, 3, [(3, 1)])
+    assert W.path_violations([[1, 1], [2, 1], [2, 0], [3, 0], [4, 0], [4, 1]], m) == []
+    assert W.path_violations([], m) == []          # no path recorded = nothing to flag
+    assert W.path_violations(None, m) == []

--- a/qa/test_walk_test.py
+++ b/qa/test_walk_test.py
@@ -110,3 +110,36 @@ def test_clean_path_passes():
     assert W.path_violations([[1, 1], [2, 1], [2, 0], [3, 0], [4, 0], [4, 1]], m) == []
     assert W.path_violations([], m) == []          # no path recorded = nothing to flag
     assert W.path_violations(None, m) == []
+
+
+def test_world_to_window_px_origin_is_center():
+    """The contract camera aims at world origin → origin projects to the window centre at ANY aspect
+    (the crop model — a 1.6 window crops the 1.75 plate, nothing stretches)."""
+    for w, h in ((1344, 768), (1280, 800), (1920, 1080)):
+        x, y = W.world_to_window_px(0, 0, 0, ortho=11.7851, w=w, h=h)
+        assert abs(x - w / 2) < 1e-6 and abs(y - h / 2) < 1e-6
+
+
+def test_diff_blobs_finds_a_moved_square():
+    """Synthetic red-first: a 30x30 'actor' moves from (100,100) to (300,200) between frames —
+    diff_blobs must report exactly the departure + arrival blobs, bottom-centres on the squares."""
+    import numpy as np
+    a = np.zeros((400, 500, 3), dtype=np.uint8)
+    b = np.zeros((400, 500, 3), dtype=np.uint8)
+    a[100:130, 100:130] = 255   # actor at old position in frame A
+    b[200:230, 300:330] = 255   # actor at new position in frame B
+    blobs = W.diff_blobs(a, b, min_area_px=200)
+    assert len(blobs) == 2
+    centers = sorted((round(bl["cx"]), round(bl["cy"])) for bl in blobs)
+    assert centers == [(114, 114), (314, 214)]     # 100..129 → centre ~114.5
+    assert W.nearest_blob_distance(blobs, (315, 229)) < 6      # feet of the arrival square
+    assert W.nearest_blob_distance(blobs, (50, 350)) > 100     # far point matches nothing
+
+
+def test_diff_blobs_ignores_flicker_noise():
+    """Small flicker (animated fire) diffs below min_area must not produce blobs."""
+    import numpy as np
+    a = np.zeros((200, 200, 3), dtype=np.uint8)
+    b = a.copy()
+    b[10:14, 10:14] = 255   # 16 px flicker
+    assert W.diff_blobs(a, b, min_area_px=200) == []

--- a/qa/walk_test.py
+++ b/qa/walk_test.py
@@ -336,10 +336,25 @@ def _visual_registration(qa: str, engine: str, mask: dict, ortho: float, cells: 
         return world_to_window_px(wx, 0.6, wz, ortho, w, h)   # 0.6 up = lower-torso/feet band
 
     prev = _token_cell(_get(f"{engine}/combat-surface"))
+    # Chain the sample nearest-neighbour from the current cell: SHORT hops. The engine token flips
+    # immediately but the CLIENT GLIDES the sprite over ~0.3-0.4s/cell — a /shot fired at
+    # engine-confirm captures a mid-glide sprite 2-4 cells off (measured proof2 run: settled cells
+    # register at ~0.16 cells; mid-glide arrivals read 155-727 px). Short hops + a glide-proportional
+    # wait give settled frames.
+    todo = [tuple(c) for c in cells]
+    chain: list = []
+    cur = prev or todo[0]
+    while todo:
+        nxt = min(todo, key=lambda p: abs(p[0] - cur[0]) + abs(p[1] - cur[1]))
+        chain.append(nxt)
+        todo.remove(nxt)
+        cur = nxt
     shot_prev = _capture_shot(qa, out, "vis_start")
-    for i, cell in enumerate(cells):
+    for i, cell in enumerate(chain):
         ok_move, landed, _p = _drive_and_check(qa, engine, cell[0], cell[1], settle, move_timeout,
                                                expect_move=True)
+        hop = (abs(cell[0] - prev[0]) + abs(cell[1] - prev[1])) if prev else 3
+        time.sleep(1.2 + 0.45 * hop)   # let the glide finish before measuring
         shot_new = _capture_shot(qa, out, f"vis_{i}_c{cell[0]}r{cell[1]}")
         case = {"cell": list(cell), "moved": ok_move, "dist_px": None, "tol_px": round(tol, 1), "ok": False}
         if ok_move and shot_prev and shot_new:

--- a/qa/walk_test.py
+++ b/qa/walk_test.py
@@ -129,6 +129,41 @@ def _sample(cells: list, stride: int) -> list:
     return cells if stride <= 1 else cells[::stride]
 
 
+def bfs_reachable(mask: dict, start: tuple) -> set:
+    """4-neighbour BFS over walkable cells from `start` — the engine-truth reachable set."""
+    walkable = mask["walkable"] if isinstance(mask["walkable"], set) else set(mask["walkable"])
+    if start not in walkable:
+        return set()
+    seen, stack = {start}, [start]
+    while stack:
+        c, r = stack.pop()
+        for nc, nr in ((c + 1, r), (c - 1, r), (c, r + 1), (c, r - 1)):
+            if (nc, nr) in walkable and (nc, nr) not in seen:
+                seen.add((nc, nr))
+                stack.append((nc, nr))
+    return seen
+
+
+def orphan_cells(mask: dict, start: tuple) -> list:
+    """Walkable cells NOT reachable from `start` — orphan pockets (a seed defect, or paint-invented
+    'walkable-looking' space with no connection). A walkable room has ZERO orphans; any orphan is RED."""
+    return sorted(set(mask["walkable"]) - bfs_reachable(mask, start))
+
+
+def path_violations(path, mask: dict) -> list:
+    """Cells in an engine `lastPath` that are NOT walkable — the owner's actual 'walked through the
+    table' failure class: the DESTINATION can be legal while the route crosses a prop. Empty == clean."""
+    if not path:
+        return []
+    walkable = mask["walkable"] if isinstance(mask["walkable"], set) else set(mask["walkable"])
+    bad = []
+    for cell in path:
+        cr = (int(cell[0]), int(cell[1])) if not isinstance(cell, dict) else (int(cell["c"]), int(cell["r"]))
+        if cr not in walkable:
+            bad.append(list(cr))
+    return bad
+
+
 # --- live I/O helpers ------------------------------------------------------------------------------
 def _get(url: str, timeout: float = 5.0):
     with urllib.request.urlopen(url, timeout=timeout) as r:
@@ -217,7 +252,8 @@ def run_gate(room: str, engine: str, qa: str, *, stride: int, out: Path,
     mask = walkmask_from_surface(surf)
     report = {"room": room, "ortho": ortho, "sceneId": scene,
               "grid": {"cols": mask["cols"], "rows": mask["rows"]},
-              "camera": {}, "reachable": {"pass": 0, "fail": 0, "cases": []},
+              "camera": {}, "orphans": [], "path": {"pass": 0, "fail": 0, "violations": []},
+              "reachable": {"pass": 0, "fail": 0, "cases": []},
               "impassable": {"pass": 0, "fail": 0, "cases": []},
               "doors": {"pass": 0, "fail": 0, "cases": []}, "shots": [], "verdict": "PENDING"}
 
@@ -229,21 +265,37 @@ def run_gate(room: str, engine: str, qa: str, *, stride: int, out: Path,
     cam_fails = check_camera_pose(dbg, ortho)
     report["camera"] = {"dbg": dbg, "fails": cam_fails, "ok": not cam_fails}
 
-    interior = [(c, r) for (c, r) in mask["walkable"]
+    # 1b) REACHABILITY / ORPHAN check (pure engine-truth, no driving): every walkable cell must be
+    # BFS-reachable from the party's current cell. An orphan pocket = a seed defect or paint-invented
+    # "walkable-looking" space with no connection — the unreachable-paint class. Any orphan is RED.
+    start = _token_cell(surf)
+    if start:
+        report["orphans"] = [list(c) for c in orphan_cells(mask, start)]
+    reachable_set = bfs_reachable(mask, start) if start else set(mask["walkable"])
+
+    interior = [(c, r) for (c, r) in reachable_set
                 if 0 < c < mask["cols"] - 1 and 0 < r < mask["rows"] - 1]
     interior.sort()
     doors = sorted(mask["doors"])
     blocked = sorted(mask["blocked"])
 
-    # 2) REACHABLE — click each sampled reachable cell; token must resolve TO it (engine truth).
+    # 2) REACHABLE — click each sampled reachable cell; token must resolve TO it (engine truth), AND
+    # the engine's lastPath must cross ONLY walkable cells (the owner's real "walked through the
+    # table" failure class: a legal destination via an illegal route).
     for (c, r) in _sample(interior, stride):
-        ok, landed = _drive_and_check(qa, engine, c, r, settle, move_timeout, expect_move=True)
+        ok, landed, path = _drive_and_check(qa, engine, c, r, settle, move_timeout, expect_move=True)
         report["reachable"]["cases"].append({"cell": [c, r], "landed": landed, "ok": ok})
         report["reachable"]["pass" if ok else "fail"] += 1
+        bad = path_violations(path, mask)
+        if bad:
+            report["path"]["fail"] += 1
+            report["path"]["violations"].append({"to": [c, r], "illegal_cells": bad})
+        elif path:
+            report["path"]["pass"] += 1
 
     # 3) IMPASSABLE — click each sampled blocked cell; token must NOT move onto it.
     for (c, r) in _sample(blocked, max(1, stride)):
-        ok, landed = _drive_and_check(qa, engine, c, r, settle, move_timeout, expect_move=False)
+        ok, landed, _p = _drive_and_check(qa, engine, c, r, settle, move_timeout, expect_move=False)
         report["impassable"]["cases"].append({"cell": [c, r], "landed": landed, "ok": ok})
         report["impassable"]["pass" if ok else "fail"] += 1
 
@@ -263,35 +315,38 @@ def run_gate(room: str, engine: str, qa: str, *, stride: int, out: Path,
         report["shots"].append(shot)
 
     hard_fail = bool(cam_fails) or report["reachable"]["fail"] or report["impassable"]["fail"] \
-        or report["doors"]["fail"]
+        or report["doors"]["fail"] or report["orphans"] or report["path"]["fail"]
     report["verdict"] = "RED" if hard_fail else "GREEN"
     return report
 
 
 def _drive_and_check(qa: str, engine: str, c: int, r: int, settle: float, timeout: float,
                      *, expect_move: bool):
-    """Click (c,r); poll the engine token. expect_move: token must reach (c,r). else: must not."""
+    """Click (c,r); poll the engine token. expect_move: token must reach (c,r), else must not.
+    Returns (ok, landed, lastPath) — lastPath is the engine's route for the move (path-cell audit)."""
     try:
         before = _token_cell(_get(f"{engine}/combat-surface"))
         _post(f"{qa}/click", {"c": c, "r": r})
     except Exception as e:  # noqa: BLE001
-        return False, f"drive-error:{e}"
+        return False, f"drive-error:{e}", None
     deadline = time.time() + timeout
-    landed = before
+    landed, path = before, None
     while time.time() < deadline:
         time.sleep(settle)
         try:
-            landed = _token_cell(_get(f"{engine}/combat-surface"))
+            surf = _get(f"{engine}/combat-surface")
         except Exception:  # noqa: BLE001
             continue
+        landed = _token_cell(surf)
+        path = surf.get("lastPath") or path
         if expect_move and landed == (c, r):
-            return True, list(landed)
+            return True, list(landed), path
         if not expect_move and landed == (c, r):
-            return False, list(landed)  # moved onto an impassable cell — a real failure
+            return False, list(landed), path  # moved onto an impassable cell — a real failure
     if expect_move:
-        return (landed == (c, r)), (list(landed) if landed else None)
+        return (landed == (c, r)), (list(landed) if landed else None), path
     # impassable: pass iff the token never became (c,r)
-    return (landed != (c, r)), (list(landed) if landed else None)
+    return (landed != (c, r)), (list(landed) if landed else None), path
 
 
 def _capture_shot(qa: str, out: Path, label: str):
@@ -333,9 +388,11 @@ def main(argv=None) -> int:
     print(f"\n=== WALK_TEST {args.room} — {report['verdict']} ===")
     print(f"camera: {'OK' if cam['ok'] else 'FAIL'}"
           + ("" if cam["ok"] else "".join(f"\n    - {m}" for m in cam["fails"])))
-    for k in ("reachable", "impassable", "doors"):
+    for k in ("reachable", "impassable", "doors", "path"):
         s = report[k]
         print(f"{k:11s}: {s['pass']} pass / {s['fail']} fail")
+    print(f"orphans    : {len(report['orphans'])}"
+          + (f" — {report['orphans'][:6]}" if report["orphans"] else ""))
     print(f"report: {out / 'walk_report.json'}")
     return 0 if report["verdict"] == "GREEN" else 1
 

--- a/qa/walk_test.py
+++ b/qa/walk_test.py
@@ -66,6 +66,30 @@ def contract_cam_pos() -> tuple:
     return (-fx * PULLBACK, -fy * PULLBACK, -fz * PULLBACK)
 
 
+def world_to_window_px(wx: float, wy: float, wz: float, ortho: float, w: int, h: int) -> tuple:
+    """Project a world point through the CONTRACT camera into WINDOW pixels at the live window size.
+
+    Aspect-correct by construction: the ortho camera fixes the VERTICAL half-height (ortho world
+    units); horizontal view = ortho * (w/h). This is the crop model — the plate billboard is sized by
+    TEXTURE aspect (ApplyPlate), so a 1.6 window shows a cropped 1.75 plate with uniform px/world and
+    NO stretch. The visual-registration mode below measures the actor against THESE coordinates, so a
+    systematic horizontal error growing toward the room edges would refute the crop model empirically
+    (red-team finding 3) — no arguing from theory required.
+    """
+    sys.path.insert(0, str(HERE))
+    import greybox_render_headless as G  # noqa: PLC0415
+    r, u = G._camera_ru(wx, wy, wz)
+    aspect = w / h
+    vx = 0.5 + r / (2.0 * ortho * aspect)
+    vy_up = 0.5 + u / (2.0 * ortho)
+    return (vx * w, (1.0 - vy_up) * h)   # image coords, y down
+
+
+def cell_px(ortho: float, h: int) -> float:
+    """One grid cell (2 world units) in window pixels of camera-up — the tolerance unit."""
+    return h * (2.0 / (2.0 * ortho))
+
+
 # --- PURE assertion helpers (no I/O; unit-tested in qa/test_walk_test.py) --------------------------
 def check_camera_pose(dbg: dict, ortho: float, *, deg_tol: float = 1.5,
                       vp_tol: float = 0.03, pos_tol: float = 1.5) -> list:
@@ -148,6 +172,53 @@ def orphan_cells(mask: dict, start: tuple) -> list:
     """Walkable cells NOT reachable from `start` — orphan pockets (a seed defect, or paint-invented
     'walkable-looking' space with no connection). A walkable room has ZERO orphans; any orphan is RED."""
     return sorted(set(mask["walkable"]) - bfs_reachable(mask, start))
+
+
+def diff_blobs(img_a, img_b, *, min_area_px: int = 250, thresh: int = 60) -> list:
+    """Cluster the pixel differences between two frames — the moved actor shows up as the two largest
+    blobs (departure + arrival). Returns clusters as dicts {cx, cy, bottom: (x,y), area}, area-sorted.
+    Pure (arrays in, dicts out) so it is unit-testable with synthetic frames. Animated fire/glow
+    flicker also diffs — callers match blobs BY EXPECTED POSITION and gate on distance, so unmatched
+    flicker clusters are ignored.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    a = np.asarray(img_a, dtype=int)
+    b = np.asarray(img_b, dtype=int)
+    mask = (np.abs(a - b).sum(axis=2) > thresh)
+    ys, xs = np.nonzero(mask)
+    clusters: list = []
+    for x, y in zip(xs.tolist(), ys.tolist()):
+        for c in clusters:
+            if abs(x - c["sx"] / c["n"]) < 60 and abs(y - c["sy"] / c["n"]) < 60:
+                c["sx"] += x; c["sy"] += y; c["n"] += 1
+                if y > c["maxy"]:
+                    c["maxy"], c["bxs"] = y, [x]
+                elif y == c["maxy"]:
+                    c["bxs"].append(x)
+                break
+        else:
+            clusters.append({"sx": float(x), "sy": float(y), "n": 1, "maxy": y, "bxs": [x]})
+    out = []
+    for c in clusters:
+        if c["n"] < min_area_px:
+            continue
+        out.append({"cx": c["sx"] / c["n"], "cy": c["sy"] / c["n"],
+                    "bottom": (sorted(c["bxs"])[len(c["bxs"]) // 2], c["maxy"]),
+                    "area": c["n"]})
+    return sorted(out, key=lambda c: -c["area"])
+
+
+def nearest_blob_distance(blobs: list, expected_px: tuple) -> float:
+    """Distance from an expected screen point to the nearest diff blob (centroid or feet, whichever
+    is closer — the actor's centroid sits above the cell center, its feet on it). inf if no blobs."""
+    best = float("inf")
+    ex, ey = expected_px
+    for bl in blobs:
+        for px, py in ((bl["cx"], bl["cy"]), bl["bottom"]):
+            d = ((px - ex) ** 2 + (py - ey) ** 2) ** 0.5
+            best = min(best, d)
+    return best
 
 
 def path_violations(path, mask: dict) -> list:
@@ -239,8 +310,55 @@ def _room_ortho(room: str) -> float:
     return float(entry["cameraPin"]["ortho"])
 
 
+def _visual_registration(qa: str, engine: str, mask: dict, ortho: float, cells: list,
+                         out: Path, settle: float, move_timeout: float) -> dict:
+    """MEASURE the actor's rendered screen position with NO client instrumentation (sidecar synthesis,
+    adopted): walk a chain of cells; pixel-diff consecutive /shots; the diff blobs are the departure +
+    arrival actor sprites. Assert each expected cell projection (world_to_window_px at the LIVE window
+    aspect from /health) has a blob within tolerance (1.25 cell-equivalents — sprite centroid/feet +
+    glow noise; the broken-build offsets were 3-5 cells). Works on ANY build — this is also the
+    empirical answer to the aspect question: a crop model passes; a stretch model fails wide cells."""
+    from PIL import Image  # noqa: PLC0415
+
+    res = {"pass": 0, "fail": 0, "cases": [], "window": None}
+    try:
+        health = _get(f"{qa}/health")
+        w, h = int(health["screenW"]), int(health["screenH"])
+    except Exception as e:  # noqa: BLE001
+        return {"pass": 0, "fail": 0, "cases": [], "window": None, "error": f"health: {e}"}
+    res["window"] = [w, h]
+    tol = 1.25 * cell_px(ortho, h)
+    cols, rows = mask["cols"], mask["rows"]
+
+    def _proj(cell):
+        wx = (cell[0] - (cols - 1) / 2.0) * 2.0
+        wz = ((rows - 1) / 2.0 - cell[1]) * 2.0
+        return world_to_window_px(wx, 0.6, wz, ortho, w, h)   # 0.6 up = lower-torso/feet band
+
+    prev = _token_cell(_get(f"{engine}/combat-surface"))
+    shot_prev = _capture_shot(qa, out, "vis_start")
+    for i, cell in enumerate(cells):
+        ok_move, landed, _p = _drive_and_check(qa, engine, cell[0], cell[1], settle, move_timeout,
+                                               expect_move=True)
+        shot_new = _capture_shot(qa, out, f"vis_{i}_c{cell[0]}r{cell[1]}")
+        case = {"cell": list(cell), "moved": ok_move, "dist_px": None, "tol_px": round(tol, 1), "ok": False}
+        if ok_move and shot_prev and shot_new:
+            blobs = diff_blobs(Image.open(shot_prev).convert("RGB"), Image.open(shot_new).convert("RGB"))
+            d_new = nearest_blob_distance(blobs, _proj(cell))
+            d_prev = nearest_blob_distance(blobs, _proj(prev)) if prev else 0.0
+            case["dist_px"] = round(d_new, 1)
+            case["dist_prev_px"] = round(d_prev, 1)
+            case["n_blobs"] = len(blobs)
+            case["ok"] = d_new <= tol
+        res["cases"].append(case)
+        res["pass" if case["ok"] else "fail"] += 1
+        if ok_move:
+            prev, shot_prev = tuple(cell), shot_new
+    return res
+
+
 def run_gate(room: str, engine: str, qa: str, *, stride: int, out: Path,
-             settle: float, move_timeout: float) -> dict:
+             settle: float, move_timeout: float, visual: int = 0) -> dict:
     """Drive the live player through `room` and return a walk_report dict. Never raises on a cell
     failure — records it — so the report is complete; the caller decides the exit code."""
     ortho = _room_ortho(room)
@@ -309,13 +427,28 @@ def run_gate(room: str, engine: str, qa: str, *, stride: int, out: Path,
         report["doors"]["cases"].append({"cell": list(cell), "to": target, "ok": ok, "detail": detail})
         report["doors"]["pass" if ok else "fail"] += 1
 
-    # 5) OCCLUSION evidence — a /shot near an occluder for the human contact sheet (non-gating here).
+    # 5) VISUAL REGISTRATION (optional, --visual N): pixel-diff actor localization at the LIVE window
+    # aspect — the client-instrumentation-free measurement of "does the actor RENDER where the plate
+    # says the cell is". Gating when run.
+    report["visual"] = {"pass": 0, "fail": 0, "cases": []}
+    if visual > 0 and interior:
+        vis_cells = _sample(interior, max(1, len(interior) // max(1, visual)))[:visual]
+        report["visual"] = _visual_registration(qa, engine, mask, ortho, vis_cells, out,
+                                                settle, move_timeout)
+
+    # 6) OCCLUSION evidence — a /shot near an occluder for the human contact sheet (non-gating here).
     shot = _capture_shot(qa, out, f"{room}_final")
     if shot:
         report["shots"].append(shot)
 
+    # 7) RETURN HOME (sidecar adoption): leave the party where the gate found it — the campaign under
+    # test is not a scratchpad. Best-effort: only when still in the starting room.
+    if start and _location(_get(f"{engine}/combat-surface")) == (_location(surf) or room):
+        _drive_and_check(qa, engine, start[0], start[1], settle, move_timeout, expect_move=True)
+
     hard_fail = bool(cam_fails) or report["reachable"]["fail"] or report["impassable"]["fail"] \
-        or report["doors"]["fail"] or report["orphans"] or report["path"]["fail"]
+        or report["doors"]["fail"] or report["orphans"] or report["path"]["fail"] \
+        or report["visual"]["fail"]
     report["verdict"] = "RED" if hard_fail else "GREEN"
     return report
 
@@ -374,13 +507,16 @@ def main(argv=None) -> int:
     ap.add_argument("--stride", type=int, default=3, help="sample every Nth cell unless --exhaustive")
     ap.add_argument("--settle", type=float, default=0.6, help="poll interval while a move resolves")
     ap.add_argument("--move-timeout", type=float, default=6.0)
+    ap.add_argument("--visual", type=int, default=0, metavar="N",
+                    help="ALSO measure actor screen position on N sampled cells via pixel-diff "
+                         "localization (client-instrumentation-free; gating when run)")
     ap.add_argument("--out", default=str(HERE / "evidence" / "walk"))
     args = ap.parse_args(argv)
 
     out = Path(args.out) / args.room
     stride = 1 if args.exhaustive else max(1, args.stride)
     report = run_gate(args.room, args.engine, args.qa, stride=stride, out=out,
-                      settle=args.settle, move_timeout=args.move_timeout)
+                      settle=args.settle, move_timeout=args.move_timeout, visual=args.visual)
     out.mkdir(parents=True, exist_ok=True)
     (out / "walk_report.json").write_text(json.dumps(report, indent=2) + "\n")
 
@@ -388,8 +524,8 @@ def main(argv=None) -> int:
     print(f"\n=== WALK_TEST {args.room} — {report['verdict']} ===")
     print(f"camera: {'OK' if cam['ok'] else 'FAIL'}"
           + ("" if cam["ok"] else "".join(f"\n    - {m}" for m in cam["fails"])))
-    for k in ("reachable", "impassable", "doors", "path"):
-        s = report[k]
+    for k in ("reachable", "impassable", "doors", "path", "visual"):
+        s = report.get(k) or {"pass": 0, "fail": 0}
         print(f"{k:11s}: {s['pass']} pass / {s['fail']} fail")
     print(f"orphans    : {len(report['orphans'])}"
           + (f" — {report['orphans'][:6]}" if report["orphans"] else ""))


### PR DESCRIPTION
Red-team adoption (finding 4 of the owner-forwarded adversarial review): the gate tested click-rejection but not the mechanisms behind the owner's actual "walked through the table" report.

- **ORPHAN check (live):** every walkable cell must be BFS-reachable from the party cell — an orphan pocket (seed defect / paint-invented walkable-looking space) is RED. The clickable sample is now gated to the reachable set.
- **PATH-CELL audit:** every cell in the engine's `lastPath` must be walkable (legal destination via illegal route = fail). **Honest coverage note:** `lastPath` is combat-only (`combat.last_move_path`); rest walks emit none, so this audit is armed-but-vacuous in rest mode until the engine emits a rest-walk path (small additive follow-up noted on #1582).

Red-first units 17/17 (bisected room → orphans; path through a table → flagged). Live tavern re-verify through room_pipeline: SHIPPABLE (walk GREEN, orphans 0).

This PR shepherds normally per the standing rule (no early admin-merge — process correction from the same review).

Refs #1581 #1582