### PR TITLE
qa: dead zero-hop guard removal + caffeinate for the sandbox player

### DIFF
--- a/qa/qa_sandbox.py
+++ b/qa/qa_sandbox.py
@@ -125,8 +125,10 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
                 WORLDOS_QA_INPUT="1",
                 WORLDOS_QA_INPUT_PORT=str(qa_port))
     ply_log = open(rd / "player.log", "w")  # noqa: SIM115
-    player = subprocess.Popen([str(pbin)], env=penv, stdout=ply_log, stderr=subprocess.STDOUT,
-                              start_new_session=True)
+    # caffeinate -disu: a background/occluded sandbox player can App-Nap -> throttled rendering ->
+    # delayed /shot frames and glide stalls mid-sweep (sidecar review). caffeinate exits with the child.
+    player = subprocess.Popen(["/usr/bin/caffeinate", "-disu", str(pbin)], env=penv, stdout=ply_log,
+                              stderr=subprocess.STDOUT, start_new_session=True)
     if not _wait("player QA channel", f"http://127.0.0.1:{qa_port}/debug", post=True, timeout_s=120):
         player.terminate()
         engine.terminate()

--- a/qa/walk_test.py
+++ b/qa/walk_test.py
@@ -351,8 +351,6 @@ def _visual_registration(qa: str, engine: str, mask: dict, ortho: float, cells: 
         cur = nxt
     shot_prev = _capture_shot(qa, out, "vis_start")
     for i, cell in enumerate(chain):
-        if tuple(cell) == prev:
-            continue   # no-op move (party already there — e.g. the door stage's return landing)
         ok_move, landed, _p = _drive_and_check(qa, engine, cell[0], cell[1], settle, move_timeout,
                                                expect_move=True)
         hop = (abs(cell[0] - prev[0]) + abs(cell[1] - prev[1])) if prev else 3


### PR DESCRIPTION
Two promised review follow-ups: the unreachable in-loop zero-hop guard in walk_test's visual chain (evaOS P3 on #1602 — the todo filter + cur guard are the load-bearing parts, untouched; units 14/14) and `caffeinate -disu` around the sandbox player so an occluded window can't App-Nap into throttled rendering at sweep scale (sidecar finding). Refs #1581 #1582 #1596