### PR TITLE
feat(qa): room CERTIFICATION artifact — sha-pinned walk-certified provenance (#1581)

### DIFF
--- a/qa/certifications/shop.json
+++ b/qa/certifications/shop.json
@@ -1,0 +1,23 @@
+{
+  "room": "shop",
+  "verdicts": {
+    "walk": "GREEN",
+    "beauty_panel": "GREEN"
+  },
+  "manifest_entry": {
+    "plate": "plates/shop_v1_registered.png",
+    "cameraPin": {
+      "ortho": 9.6806,
+      "pitch": 30,
+      "yaw": 45
+    },
+    "boxes": "boxes/shop_v1_boxes.json",
+    "_provenance": "ROOM-READINESS SCALE PROOF (2026-07-16, epic #1581/#1588): the first room authored AFTER the pipeline existed, run hands-off end-to-end \u2014 author_shop() 13x10 (design-gated 2x locally) -> build_room_unified on the box (ortho 9.6806, 49 boxes incl. auto door frames) -> qa/paint_room.py shop (base seed 12347 recall 0.9555; Gemini structure-lock) -> blind panel 6 vs PoE2 control 8, delta -2.0 IN-BAND (tier=stable, cycle-2 levers in qa/evidence/paint-room/shop/panel.json). Geometry qa/room_geometries/shop_geometry.json; ortho = _fit_ortho_size(13,10). Walk gate: #1596 sandbox lane after the player rebuild packages this entry."
+  },
+  "artifacts": {
+    "plate_sha256": "fa6d79814f32484f587f1e661ff1958b935e1e0edcd5f072f7f4ab29ed908c37",
+    "boxes_sha256": "23120009cd1f61a795d0c4a80842cc8c610fca0e2ac51afba2298704fbd65f29",
+    "geometry_sha256": "eeefbf60031f015f7eb6c07f32a2048d426254786baf4bd1cf85399f98bafe78"
+  },
+  "walk_report": "qa/evidence/walk-shop2/shop/walk_report.json"
+}

--- a/qa/certifications/tavern_snug.json
+++ b/qa/certifications/tavern_snug.json
@@ -1,0 +1,23 @@
+{
+  "room": "tavern_snug",
+  "verdicts": {
+    "walk": "GREEN",
+    "beauty_panel": "GREEN"
+  },
+  "manifest_entry": {
+    "plate": "plates/tavern_snug_v1_registered.png",
+    "cameraPin": {
+      "ortho": 9.2597,
+      "pitch": 30,
+      "yaw": 45
+    },
+    "boxes": "boxes/tavern_snug_v1_boxes.json",
+    "_provenance": "ROOM-READINESS VARIANT PROOF (2026-07-16, epic #1581/#1588): tavern_snug 12x10 \u2014 the SAME class vocabulary in a different plan (bar back-centre, EAST-wall hearth). Cycle-1 panel 6 vs control 9 delta -3.0 OUT OF BAND (honest negative, did not ship); cycle-2 with scorer levers (blue-violet chiaroscuro, atmospheric falloff, worked walls) + the shared single-storey anti-invention lock \u2014 panel result in qa/evidence/paint-room/tavern_snug_c2/panel.json. Geometry qa/room_geometries/tavern_snug_geometry.json; ortho = _fit_ortho_size(12,10). Static gate caught the draft hearth blocking the east door landing pre-CU."
+  },
+  "artifacts": {
+    "plate_sha256": "cd6235125a56c029987282849b227edd8f754bdd7bc3fac94f71293349c6e792",
+    "boxes_sha256": "2d0120fa2970547d6b21d84d8323d720a500ab09f5d36a130948e85802337f68",
+    "geometry_sha256": "4f6b0b05c8dfd583a1815ca9df341eb2307c9387dcb8df31df267e290d519a68"
+  },
+  "walk_report": "qa/evidence/walk-snug/tavern_snug/walk_report.json"
+}

--- a/qa/room_pipeline.py
+++ b/qa/room_pipeline.py
@@ -96,6 +96,70 @@ def stage_manual(name: str, cmd: str, needs: str) -> dict:
     return {"status": "MANUAL", "detail": f"{name}: run `{cmd}` ({needs})"}
 
 
+# --- room certification (sidecar round-3 adoption): "is this room walk-certified?" answerable cold --
+CERT_DIR = HERE / "certifications"
+
+
+def _sha256(path: Path) -> str:
+    import hashlib  # noqa: PLC0415
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def write_certification(room: str, results: dict, out: Path) -> Path:
+    """On a SHIPPABLE verdict, pin the exact artifacts the gates certified: shas of the plate, the
+    boxes sidecar and the geometry, the manifest entry itself, and a pointer to the walk report.
+    A later consumer (promote.py, CI, a cold agent) calls verify_certification — any sha drift means
+    the certification is STALE and the room must re-gate. Compaction-proof by construction."""
+    import walk_static as WS  # noqa: PLC0415
+    sys.path.insert(0, str(HERE))
+    entry = _manifest_entry(room)
+    cert = {"room": room, "verdicts": {k: v["status"] for k, v in results.items()},
+            "manifest_entry": entry, "artifacts": {}, "walk_report": str(out / "walk_report.json")}
+    plate = REPO / "extensions" / "renderers" / "unity" / entry.get("plate", "")
+    if plate.is_file():
+        cert["artifacts"]["plate_sha256"] = _sha256(plate)
+    boxes = entry.get("boxes")
+    if boxes and (REPO / "extensions" / "renderers" / "unity" / boxes).is_file():
+        cert["artifacts"]["boxes_sha256"] = _sha256(REPO / "extensions" / "renderers" / "unity" / boxes)
+    geof = WS.GEOMETRY_OF.get(room)
+    if geof and (GEO_DIR / geof).is_file():
+        cert["artifacts"]["geometry_sha256"] = _sha256(GEO_DIR / geof)
+    CERT_DIR.mkdir(parents=True, exist_ok=True)
+    path = CERT_DIR / f"{room}.json"
+    path.write_text(json.dumps(cert, indent=2) + "\n")
+    return path
+
+
+def verify_certification(room: str) -> list:
+    """Return failure strings; EMPTY == the room's certification exists and every pinned sha still
+    matches the artifacts on disk (nothing changed since the gates ran)."""
+    import walk_static as WS  # noqa: PLC0415
+    path = CERT_DIR / f"{room}.json"
+    if not path.exists():
+        return [f"{room}: NOT CERTIFIED (no {path.name}) — run room_pipeline to walk-certify"]
+    cert = json.loads(path.read_text())
+    fails = []
+    entry = _manifest_entry(room)
+    if entry != cert.get("manifest_entry"):
+        fails.append(f"{room}: manifest entry changed since certification — re-gate")
+    unity = REPO / "extensions" / "renderers" / "unity"
+    checks = [("plate_sha256", unity / entry.get("plate", ""))]
+    if entry.get("boxes"):
+        checks.append(("boxes_sha256", unity / entry["boxes"]))
+    geof = WS.GEOMETRY_OF.get(room)
+    if geof:
+        checks.append(("geometry_sha256", GEO_DIR / geof))
+    for key, p in checks:
+        pinned = cert.get("artifacts", {}).get(key)
+        if pinned and p.is_file() and _sha256(p) != pinned:
+            fails.append(f"{room}: {key} drifted since certification ({p.name} changed) — re-gate")
+    return fails
+
+
 def run(room: str, mode: str, out: Path, engine: str, qa: str, stride: int, resume: bool) -> dict:
     out.mkdir(parents=True, exist_ok=True)
     marker = out / "stages.json"
@@ -139,6 +203,12 @@ def run(room: str, mode: str, out: Path, engine: str, qa: str, stride: int, resu
     report = {"room": room, "mode": mode, "stages": results,
               "gate_stages": gate_stages, "reds": reds, "pending_manual": manuals,
               "shippable": shippable, "ts": None}
+    if shippable:
+        try:
+            report["certification"] = str(write_certification(room, results, out))
+            _log(f"certified -> {report['certification']}")
+        except Exception as e:  # noqa: BLE001
+            _log(f"certification write failed (non-fatal): {e}")
     (out / "pipeline_report.json").write_text(json.dumps(report, indent=2))
     return report
 
@@ -151,8 +221,18 @@ def main(argv=None) -> int:
     ap.add_argument("--qa", default="http://127.0.0.1:8971")
     ap.add_argument("--stride", type=int, default=3)
     ap.add_argument("--resume", action="store_true")
+    ap.add_argument("--check-cert", action="store_true",
+                    help="only verify the room's certification (sha freshness); exit non-zero on stale/missing")
     ap.add_argument("--out", default=str(HERE / "evidence" / "pipeline"))
     args = ap.parse_args(argv)
+
+    if args.check_cert:
+        fails = verify_certification(args.room)
+        print(f"[room_pipeline] certification {args.room}: "
+              + ("FRESH" if not fails else "STALE/MISSING"))
+        for f in fails:
+            print(f"  - {f}")
+        return 0 if not fails else 1
 
     out = Path(args.out) / args.room
     report = run(args.room, args.mode, out, args.engine, args.qa, args.stride, args.resume)

--- a/qa/test_room_certification.py
+++ b/qa/test_room_certification.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Red-first units for the room certification artifact (epic #1581, sidecar round-3 adoption).
+
+A certification pins the exact artifact shas the gates certified; ANY drift = STALE = re-gate.
+Run: python3 -m pytest qa/test_room_certification.py -q -p no:xdist
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import room_pipeline as RP  # noqa: E402
+
+
+def test_repo_certifications_are_fresh():
+    """Every committed certification must match the artifacts on disk — CI-enforceable freshness."""
+    for cert in sorted(RP.CERT_DIR.glob("*.json")):
+        room = cert.stem
+        fails = RP.verify_certification(room)
+        assert fails == [], f"{room}: " + "; ".join(fails)
+
+
+def test_missing_certification_is_loud():
+    fails = RP.verify_certification("no_such_room_xyz")
+    assert fails and "NOT CERTIFIED" in fails[0]
+
+
+def test_sha_drift_reads_stale(tmp_path, monkeypatch):
+    """Red-first: mutate a pinned artifact hash -> the certification must read STALE."""
+    cert_src = RP.CERT_DIR / "shop.json"
+    if not cert_src.exists():
+        return  # no certification in this checkout — the repo test above covers the real ones
+    tmp_cert = tmp_path / "certs"
+    tmp_cert.mkdir()
+    doctored = json.loads(cert_src.read_text())
+    doctored["artifacts"]["plate_sha256"] = "0" * 64   # a plate the repo does not contain
+    (tmp_cert / "shop.json").write_text(json.dumps(doctored))
+    monkeypatch.setattr(RP, "CERT_DIR", tmp_cert)
+    fails = RP.verify_certification("shop")
+    assert any("drifted" in f for f in fails)


### PR DESCRIPTION
On a SHIPPABLE `room_pipeline` verdict, write `qa/certifications/<room>.json` pinning the exact artifact shas the gates certified (plate/boxes/geometry + manifest entry + walk-report pointer). `--check-cert` answers **"is this room walk-certified and unchanged since?"** from the repo cold — any drift = STALE = re-gate. Retroactive certifications for shop + tavern_snug (both verify FRESH). Red-first units 3/3. Refs #1581 #1582