### PR TITLE
generate_town: perimeter-snap doors, clear landings, tall-anchor dressing + generator self-gate

### DIFF
--- a/qa/test_generate_town.py
+++ b/qa/test_generate_town.py
@@ -1,0 +1,172 @@
+"""Regression for the multi-room TOWN generator gate (tools/generate_town.py + tools/dungen_to_fixtures.py).
+
+The generator crops a DunGen layout export into per-room greybox geometries for the registered-plate
+pipeline. Running it on the committed DunGen spike layout (rooms room_0/room_1/room_2) used to emit
+geometries that FAIL the static walkability gate (qa/walk_static.check_geometry) in three ways — the
+three DunGen defect classes this suite pins as fixed:
+
+  1. BOUNDARY DOORS — a doorway projects onto the room-tile boundary, landing one cell inside the crop's
+     padded wall ring (on the floor edge) instead of ON the grid perimeter. The door-perimeter-snap
+     moves it outward to the adjacent perimeter cell; the old floor-edge cell becomes the landing. An
+     already-on-perimeter door is left untouched (room_1's west door (0,3)).
+  2. BLOCKED LANDINGS — DunGen prop crates occupy a door's interior landing cell. Landing clearance
+     drops the prop cell(s) on every door's landing so it stays walkable.
+  3. FLAT-INTERIOR CLASS (#1588) — every interior mass is a low crate (height 1.4 < 2.6); the paint
+     stage drifts. dress_tall_anchors authors two `pillar` anchors when a room has no tall interior mass.
+
+Plus a red-first assertion that the committed rooms now pass check_geometry with ZERO failures, and that
+the door-perimeter-snap preserves door COUNT (never drops/merges a door — the door_cells[i] <->
+connections[i] world/seed contract depends on it).
+
+Deterministic, offline, stdlib + pytest only — NO live services (build the geometries in-process via
+convert()/build_geometry()/dress_tall_anchors()).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_QA_DIR = Path(__file__).resolve().parent
+_ROOT = _QA_DIR.parent
+for _p in (_ROOT / "tools", _QA_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import dungen_to_fixtures as d2f  # noqa: E402
+from author_room_geometry import _perimeter_wall_run_props  # noqa: E402
+from walk_static import check_geometry  # noqa: E402
+
+# the same command the RUNBOOK / dispatch drives, run in-process below.
+_LAYOUT = _QA_DIR / "evidence" / "dungen-spike" / "dungen_basic_layout.json"
+_ROOMS = ["room_0", "room_1", "room_2"]
+_TOWN = "dwing"
+
+
+def _stamp_room(geo: dict, *, material: str = "stone", wall_height: float = 5.0) -> dict:
+    """Mirror generate_town._stamp_room WITHOUT importing generate_town (its greybox_render_headless
+    import pulls in PIL, absent from the servers/engine test venv): perimeter wall runs split at doors,
+    walls/impassable recomputed, camera_fit/wall_height stamped."""
+    cols, rows = geo["cols"], geo["rows"]
+    doors = [tuple(d) for d in geo.get("door_cells", [])]
+    runs = _perimeter_wall_run_props(cols, rows, door_cells=doors)
+    wall_cells = {tuple(c) for (_id, _kind, cells) in runs for c in cells}
+    props = [{"id": rid, "kind": kind, "cells": [list(c) for c in cells]} for rid, kind, cells in runs]
+    props += [p for p in geo.get("props", []) if p.get("kind") != "wall_run"]
+    prop_cells = {tuple(c) for p in props for c in p["cells"] if p["kind"] != "wall_run"}
+    geo["props"] = props
+    geo["walls"] = sorted(wall_cells)
+    geo["impassable"] = sorted(wall_cells | prop_cells - {tuple(d) for d in doors})
+    geo["material"] = material
+    geo["camera_fit"] = True
+    geo["wall_height"] = wall_height
+    return geo
+
+
+def _build_town_geometries() -> dict:
+    import json  # noqa: PLC0415
+    layout = json.loads(_LAYOUT.read_text(encoding="utf-8"))
+    ctx = d2f.convert(layout, name=_TOWN, upc=2.0, material="stone")
+    geos = {}
+    for rid in _ROOMS:
+        geo = _stamp_room(d2f.build_geometry(ctx, room=rid))
+        geo = d2f.dress_tall_anchors(geo, name=f"{_TOWN}_{rid}")
+        geo["location"] = f"{_TOWN}_{rid}"
+        geos[rid] = geo
+    return geos
+
+
+@pytest.fixture(scope="module")
+def town():
+    return _build_town_geometries()
+
+
+# ── (a) red-first regression: the committed rooms now pass the static gate ────────────────────────────
+def test_committed_rooms_pass_static_gate(town):
+    for rid, geo in town.items():
+        fails = check_geometry(f"{_TOWN}_{rid}", geo)
+        assert fails == [], f"{rid} must pass check_geometry with zero failures, got: {fails}"
+
+
+# ── (b) every generated room has a tall interior mass (flat-interior class fixed) ─────────────────────
+def test_every_room_has_a_tall_prop(town):
+    for rid, geo in town.items():
+        interior = [p for p in geo["props"] if p.get("kind") != "wall_run"]
+        tallest = max((d2f._KIND_HEIGHT.get(p["kind"], 0.0) for p in interior), default=0.0)
+        assert tallest >= d2f._ANCHOR_MIN_TALL, (
+            f"{rid} tallest interior mass {tallest} < {d2f._ANCHOR_MIN_TALL} (flat-interior class)")
+
+
+def test_flat_rooms_get_two_pillar_anchors(town):
+    # room_0 and room_1 are all-crate DunGen rooms -> dressing must author two pillar anchors each;
+    # room_2 already carries a cylinder->pillar, so it must NOT be dressed.
+    for rid in ("room_0", "room_1"):
+        anchors = [p for p in town[rid]["props"] if p.get("id") in ("anchor_a", "anchor_b")]
+        assert {p["id"] for p in anchors} == {"anchor_a", "anchor_b"}, f"{rid} needs both anchors"
+        for p in anchors:
+            assert p["kind"] == "pillar"
+            (c0, r0), (c1, r1) = p["cells"]
+            assert c0 == c1 and abs(r0 - r1) == 1, "each anchor is two vertically-adjacent cells"
+    assert not [p for p in town["room_2"]["props"] if p.get("id", "").startswith("anchor")], \
+        "room_2 already has a tall pillar and must not be dressed"
+
+
+# ── (c) an on-perimeter door is not moved by the snap ─────────────────────────────────────────────────
+def test_on_perimeter_door_not_moved(town):
+    # room_1's west door (0,3) is already on the perimeter -> snap must leave it untouched.
+    assert [0, 3] in town["room_1"]["door_cells"], "on-perimeter door (0,3) must survive the snap"
+    # and the off-perimeter east door was snapped outward to the right edge.
+    assert [11, 3] in town["room_1"]["door_cells"], "off-perimeter door (10,3) must snap to (11,3)"
+
+
+def test_snapped_doors_land_on_perimeter(town):
+    for rid, geo in town.items():
+        cols, rows = geo["cols"], geo["rows"]
+        for (c, r) in (tuple(d) for d in geo["door_cells"]):
+            assert d2f._on_perimeter(c, r, cols, rows), f"{rid} door {(c, r)} not on perimeter after snap"
+
+
+# ── (d) every door's landing is walkable (not impassable) ─────────────────────────────────────────────
+def test_every_door_landing_is_walkable(town):
+    for rid, geo in town.items():
+        cols, rows = geo["cols"], geo["rows"]
+        impassable = {tuple(c) for c in geo["impassable"]}
+        for door in (tuple(d) for d in geo["door_cells"]):
+            landing = d2f._door_landing(door, cols, rows)
+            assert landing not in impassable, f"{rid} door {door} landing {landing} is blocked"
+
+
+# ── door count preserved (snap never drops/merges a door) ─────────────────────────────────────────────
+def test_snap_preserves_door_count():
+    import json  # noqa: PLC0415
+    layout = json.loads(_LAYOUT.read_text(encoding="utf-8"))
+    ctx = d2f.convert(layout, name=_TOWN, upc=2.0, material="stone")
+    for rid in _ROOMS:
+        # count the raw doorway cells that fall in this room's crop window (pre-snap intent)
+        room_floor = ctx["_room_cells"][rid]
+        cs = [c for (c, r) in room_floor]
+        rs = [r for (c, r) in room_floor]
+        c0, c1, r0, r1 = min(cs) - 1, max(cs) + 1, min(rs) - 1, max(rs) + 1
+        window = {(c, r) for r in range(r0, r1 + 1) for c in range(c0, c1 + 1)}
+        raw = {cr for cr in ctx["_door_set"] if cr in window}
+        geo = d2f.build_geometry(ctx, room=rid)
+        assert len(geo["door_cells"]) == len(raw), (
+            f"{rid}: snap changed door count {len(raw)} -> {len(geo['door_cells'])}")
+        # door cells stay sorted by row then col
+        rc = [(r, c) for (c, r) in (tuple(d) for d in geo["door_cells"])]
+        assert rc == sorted(rc), f"{rid} door_cells not sorted by (row, col)"
+
+
+# ── the generator self-gate exits 0 on the committed layout (integration, no live services) ───────────
+def test_generator_self_gate_passes(tmp_path):
+    # generate_town's main builds the plates fragment via greybox_render_headless (needs PIL/numpy);
+    # skip the end-to-end run where those render deps are absent (e.g. the minimal engine test venv).
+    pytest.importorskip("PIL")
+    cmd = [sys.executable, str(_ROOT / "tools" / "generate_town.py"), str(_LAYOUT),
+           "--rooms", ",".join(_ROOMS), "--town-id", _TOWN, "--out-dir", str(tmp_path),
+           "--material", "stone"]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    assert proc.returncode == 0, f"generator self-gate failed:\n{proc.stderr}"
+    assert "STATIC GATE RED" not in proc.stderr

--- a/tools/dungen_to_fixtures.py
+++ b/tools/dungen_to_fixtures.py
@@ -74,6 +74,13 @@ _KIND_HEIGHT = {
 # Fallback proxy per shape class when kind_hint names nothing known.
 _SHAPE_DEFAULT_KIND = {"box": "crate", "cylinder": "pillar", "cone": "large_tree"}
 
+# A prop whose exported bounds have (near-)zero vertical extent is a structural surface (floor/ceiling
+# plane), not an obstacle — see _prop_entries.
+_PLANE_EPS = 1e-3
+# Flat-interior-class threshold (#1588): a room whose tallest INTERIOR mass is below this drifts the
+# paint stage; a `pillar` (authored height 7.5) clears it — see dress_tall_anchors.
+_ANCHOR_MIN_TALL = 2.6
+
 
 def _resolve_kind(shape_class: str, kind_hint: str) -> str:
     hint = (kind_hint or "").lower()
@@ -157,6 +164,11 @@ def _prop_entries(layout: dict, proj: Projector, floor: set) -> list:
         if anchor not in cells:
             anchor = cells[0]
         band = _height_band(kind)
+        # A DunGen "Ground Plane"/"Ceiling Plane" is a zero-height rendered surface that covers the whole
+        # room footprint — never a collidable obstacle. Tag it so the per-room greybox crop can drop it
+        # (folding it into walls would crate the entire interior). Additive field; build_scenegrid picks
+        # its output keys explicitly, so the emitted SceneGrid fixture is unaffected.
+        y_extent = (float(bmax[1]) - float(bmin[1])) if (bmin and bmax) else 1.0
         entries.append({
             "id": str(p.get("id") or f"prop_{i}"),
             "kind": kind,
@@ -165,6 +177,7 @@ def _prop_entries(layout: dict, proj: Projector, floor: set) -> list:
             "height_band": band,
             "occluder": band in ("mid", "tall"),
             "kind_hint": p.get("kind_hint", ""),
+            "structural_plane": y_extent <= _PLANE_EPS,
         })
     return entries
 
@@ -285,6 +298,117 @@ def build_scenegrid(ctx: dict, *, location_id: str) -> dict:
     }
 
 
+# ── door perimeter snap + landing helpers (per-room crop path) ──────────────────────────────────────
+def _on_perimeter(c: int, r: int, cols: int, rows: int) -> bool:
+    return c in (0, cols - 1) or r in (0, rows - 1)
+
+
+def _snap_door_to_perimeter(cell: tuple, cols: int, rows: int, forward=None) -> tuple:
+    """A doorway that projects onto the room-tile boundary lands one cell inside the crop's padded wall
+    ring (on the floor edge), not on the grid perimeter check_geometry requires. Move it OUTWARD to the
+    adjacent perimeter cell: direction = the nearest grid edge; the doorway's world `forward` breaks a
+    tie. On-perimeter doors are returned unchanged. Col grows with +x, row grows with -z (row =
+    (max_z - wz)/upc), so the outward direction of each edge dots with forward as scored below."""
+    c, r = cell
+    if _on_perimeter(c, r, cols, rows):
+        return (c, r)
+    fx = float(forward[0]) if forward else 0.0
+    fz = float(forward[2]) if forward and len(forward) > 2 else 0.0
+    # (distance-to-edge, target perimeter cell, forward alignment) — nearest edge wins, best align breaks
+    cands = [
+        (c,            (0, r),         -fx),  # left  edge (outward -x)
+        (cols - 1 - c, (cols - 1, r),   fx),  # right edge (outward +x)
+        (r,            (c, 0),          fz),  # top   edge (outward +z -> row 0)
+        (rows - 1 - r, (c, rows - 1),  -fz),  # bottom edge (outward -z)
+    ]
+    _dist, target, _align = min(cands, key=lambda x: (x[0], -x[2]))
+    return target
+
+
+def _door_landing(cell: tuple, cols: int, rows: int) -> tuple:
+    """The interior cell a perimeter door opens onto (mirrors walk_static.check_geometry's `inward`)."""
+    c, r = cell
+    return (c + (1 if c == 0 else -1 if c == cols - 1 else 0),
+            r + (1 if r == 0 else -1 if r == rows - 1 else 0))
+
+
+def dress_tall_anchors(geo: dict, *, name: str = "room") -> dict:
+    """Flat-interior-class dressing (#1588): if a cropped room has NO interior prop kind with authored
+    height >= _ANCHOR_MIN_TALL (heights per _KIND_HEIGHT; `pillar` qualifies), author two `pillar`
+    anchors (`anchor_a`/`anchor_b`, each two vertically-adjacent cells, mirroring author_tavern_snug's
+    post_w/post_e convention) so the paint stage has a tall mass to anchor architecture on. Placement is
+    DETERMINISTIC (grid-derived candidate order, no random module): cells that are floor, not door cells,
+    not a door landing or adjacent to one, not already prop cells, ordered toward the interior
+    third-points. Each candidate is flood-fill-verified to keep the walkable floor fully connected with no
+    orphan pocket before it is kept; a candidate that breaks connectivity is skipped."""
+    interior = [p for p in geo.get("props", []) if p.get("kind") != "wall_run"]
+    if any(_KIND_HEIGHT.get(p.get("kind"), 0.0) >= _ANCHOR_MIN_TALL for p in interior):
+        return geo
+    cols, rows = int(geo["cols"]), int(geo["rows"])
+    doors = {tuple(d) for d in geo.get("door_cells", [])}
+    landings = {_door_landing(d, cols, rows) for d in doors}
+    landing_block = set(landings)
+    for (c, r) in landings:
+        landing_block |= {(c + 1, r), (c - 1, r), (c, r + 1), (c, r - 1)}
+
+    def free_set(extra_blocked: set) -> set:
+        prop_cells = {tuple(c) for p in geo.get("props", []) if p.get("kind") != "wall_run"
+                      for c in p.get("cells", [])} | extra_blocked
+        walls = ({tuple(c) for c in geo.get("walls", [])} | prop_cells) - doors
+        return {(c, r) for r in range(rows) for c in range(cols) if (c, r) not in walls}
+
+    base_free = free_set(set())
+
+    def connectivity_ok(blocked: set) -> bool:
+        free = free_set(blocked)
+        starts = [land for land in landings if land in free]
+        if not starts:
+            return False
+        seen, stack = {starts[0]}, [starts[0]]
+        while stack:
+            c, r = stack.pop()
+            for n in ((c + 1, r), (c - 1, r), (c, r + 1), (c, r - 1)):
+                if n in free and n not in seen:
+                    seen.add(n)
+                    stack.append(n)
+        if any(land not in seen for land in starts):
+            return False
+        interior_free = {(c, r) for (c, r) in free if 0 < c < cols - 1 and 0 < r < rows - 1}
+        return not (interior_free - seen)
+
+    def candidates(ideal: tuple) -> list:
+        pairs = []
+        for c in range(1, cols - 1):
+            for r in range(1, rows - 2):  # r and r+1 both strictly interior
+                pair = ((c, r), (c, r + 1))
+                if all(cell in base_free and cell not in doors and cell not in landing_block
+                       for cell in pair):
+                    d = sum(abs(cc - ideal[0]) + abs(rr - ideal[1]) for (cc, rr) in pair)
+                    pairs.append((d, r, c, pair))
+        pairs.sort()
+        return [p[3] for p in pairs]
+
+    ideals = [(cols // 3, rows // 3), (2 * cols // 3, 2 * rows // 3)]
+    placed: list = []
+    used: set = set()
+    for ideal in ideals:
+        for pair in candidates(ideal):
+            if any(cell in used for cell in pair):
+                continue
+            if connectivity_ok(used | set(pair)):
+                placed.append(pair)
+                used |= set(pair)
+                break
+    for pid, pair in zip(("anchor_a", "anchor_b"), placed):
+        geo["props"].append({"id": pid, "kind": "pillar", "cells": [list(pair[0]), list(pair[1])]})
+    # recompute impassable to fold in the new anchors (walls stay perimeter-only, matching _stamp_room)
+    wall_cells = {tuple(c) for c in geo.get("walls", [])}
+    prop_cells = {tuple(c) for p in geo.get("props", []) if p.get("kind") != "wall_run"
+                  for c in p.get("cells", [])}
+    geo["impassable"] = [list(c) for c in sorted(wall_cells | prop_cells - doors, key=lambda x: (x[1], x[0]))]
+    return geo
+
+
 # ── (b) greybox geometry json (whole dungeon or one cropped room) ───────────────────────────────────
 def build_geometry(ctx: dict, *, room: Optional[str] = None) -> dict:
     proj: Projector = ctx["_projector"]
@@ -310,9 +434,26 @@ def build_geometry(ctx: dict, *, room: Optional[str] = None) -> dict:
         window = {(c, r) for r in range(r0, r1 + 1) for c in range(c0, c1 + 1)}
         floor_w = {shift(cr) for cr in (room_floor | (door_set & window)) if cr in window}
         door_w = {shift(cr) for cr in door_set if cr in window}
-        props = [p for p in props_all if any(tuple(c) in room_floor for c in p["cells"])]
+        # Drop DunGen structural surface planes (zero-height Ground/Ceiling planes) — a rendered floor/
+        # ceiling covers the whole footprint and would crate the entire interior, orphaning it.
+        props = [p for p in props_all if not p.get("structural_plane")
+                 and any(tuple(c) in room_floor for c in p["cells"])]
         props_w = [{"kind": p["kind"], "cells": [list(shift(tuple(c))) for c in p["cells"]
                                                  if shift(tuple(c)) in floor_w]} for p in props]
+        props_w = [p for p in props_w if p["cells"]]
+        # DOOR PERIMETER SNAP: a doorway on the room-tile boundary projects one cell inside the padded
+        # wall ring (on the floor edge). Move each off-perimeter door OUTWARD to the adjacent perimeter
+        # cell (carved walkable, listed in door_cells); the old floor-edge cell stays floor and becomes
+        # the landing. On-perimeter doors are left untouched. Door count is preserved (1:1 snap), so the
+        # world/seed door_cells[i] <-> connections[i] contract is unchanged.
+        forward_of = {shift(gcell): tuple(d.get("forward") or (0, 0, 0))
+                      for (gcell, d) in ctx["_doors"] if gcell in window}
+        door_w = {_snap_door_to_perimeter(dc, cols, rows, forward_of.get(dc)) for dc in door_w}
+        floor_w |= door_w  # the snapped perimeter cell is carved walkable floor
+        # LANDING CLEARANCE: each door's interior landing must stay walkable — drop any prop cell on it.
+        landings = {_door_landing(dc, cols, rows) for dc in door_w}
+        for p in props_w:
+            p["cells"] = [c for c in p["cells"] if tuple(c) not in landings]
         props_w = [p for p in props_w if p["cells"]]
     else:
         cols, rows = proj.cols, proj.rows

--- a/tools/generate_town.py
+++ b/tools/generate_town.py
@@ -32,9 +32,10 @@ _TOOLS = Path(__file__).resolve().parent
 sys.path.insert(0, str(_TOOLS))
 sys.path.insert(0, str(_TOOLS.parent / "qa"))
 
-from dungen_to_fixtures import convert, build_geometry  # noqa: E402
+from dungen_to_fixtures import convert, build_geometry, dress_tall_anchors  # noqa: E402
 from author_room_geometry import _perimeter_wall_run_props  # noqa: E402
 from greybox_render_headless import _fit_ortho_size  # noqa: E402
+from walk_static import check_geometry  # noqa: E402
 
 
 def _stamp_room(geo: dict, *, material: str, wall_height: float) -> dict:
@@ -81,15 +82,27 @@ def main(argv=None) -> int:
     # per-room geometries, unified-painter-ready
     loc_of = {rid: f"{args.town_id}_{rid}" for rid in room_ids}
     geos: dict[str, dict] = {}
+    gate_fails: list[str] = []
     for rid in room_ids:
         geo = _stamp_room(build_geometry(ctx, room=rid),
                           material=args.material, wall_height=args.wall_height)
+        geo = dress_tall_anchors(geo, name=loc_of[rid])
         geo["location"] = loc_of[rid]
+        # ★ STATIC WALKABILITY GATE (mirrors qa/seed_gfx_registered_world.py): a room geometry that
+        # fails the static gate (off-perimeter door, blocked landing, orphan pocket, duplicate door)
+        # never ships — refuse the whole run. Caught here, the three DunGen defect classes (boundary
+        # doors, prop-blocked landings, flat-interior mass) are pre-render-impossible.
+        gate_fails += [f"{loc_of[rid]}: {f}" for f in check_geometry(loc_of[rid], geo)]
         path = out / f"{args.town_id}_{rid}_geometry.json"
         path.write_text(json.dumps(geo) + "\n", encoding="utf-8")
         geos[rid] = geo
         print(f"[generate_town] {loc_of[rid]}: {geo['cols']}x{geo['rows']}, "
               f"{len(geo['props'])} props, doors {geo.get('door_cells')} -> {path.name}", file=sys.stderr)
+    if gate_fails:
+        print("[generate_town] STATIC GATE RED:", file=sys.stderr)
+        for f in gate_fails:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
 
     # world wiring: per room, (door_cell, to_location) pairs matched GEOMETRICALLY — the engine
     # contract is door_cells[i] -> connections[i], and a positional zip can wire the north door to


### PR DESCRIPTION
## What

The DunGen town generator (`tools/generate_town.py` + `tools/dungen_to_fixtures.py`) crops a layout export into per-room greybox geometries for the registered-plate pipeline. Running it on the committed spike layout `qa/evidence/dungen-spike/dungen_basic_layout.json` (rooms `room_0`/`room_1`/`room_2`) produced geometries that **FAIL** the static walkability gate `qa/walk_static.check_geometry`. This fixes the three defect classes the gate caught and wires the generator to self-gate on them.

### Before (check_geometry on the committed rooms)
```
dwing_room_0: door (10, 6) not on the perimeter
dwing_room_1: door (0, 3) landing (1, 3) is blocked; door (10, 3) not on the perimeter
dwing_room_2: door (6,1)/(10,6)/(5,11) not on the perimeter; door (0,6) landing (1,6) is blocked
```
### After
```
dwing_room_0 / dwing_room_1 / dwing_room_2: GREEN (zero failures)
```

## The three defect classes the static gate caught

1. **Boundary doors → off-perimeter.** A doorway that projects onto the room-tile boundary lands one cell inside the crop's padded wall ring (on the floor edge), not on the grid perimeter `check_geometry` requires. New **door-perimeter-snap** in `build_geometry`'s room-crop path moves each off-perimeter door OUTWARD to the adjacent perimeter cell — direction = nearest grid edge, the doorway's world `forward` vector breaks a tie. The perimeter cell becomes the carved door; the old floor-edge cell stays floor and becomes the **landing**. On-perimeter doors (e.g. `room_1`'s west door `(0,3)`) are left untouched. The snap is 1:1, so the `door_cells[i] ↔ connections[i]` world/seed contract is preserved (verified: `dwing_world.json` reciprocity `room_0 ↔ room_1 ↔ room_2` intact).

2. **Blocked landings.** DunGen prop crates occupy door landing cells. **Landing clearance** drops any prop cell on every door's landing (dropping a prop that becomes empty) and recomputes `impassable`. Deterministic.

3. **Flat-interior class (#1588).** Every interior mass is a low `crate` (authored height 1.4 < 2.6), which drifts the paint stage. **`dress_tall_anchors`** authors two `pillar` anchors (`anchor_a`/`anchor_b`, each two vertically-adjacent cells, mirroring `author_tavern_snug`'s `post_w`/`post_e`) when a room has no interior kind with authored height ≥ 2.6. Placement is fully deterministic (grid-derived candidate order toward the interior third-points, no random module) and each candidate is flood-fill-verified to keep the walkable floor connected with no orphan pocket before it is kept. `room_2` already carries a cylinder→pillar and is left undressed.

## Required supporting change
To make the rooms walkable at all, the per-room crop now **excludes DunGen zero-height structural surface planes** (Ground/Ceiling planes). A rendered floor/ceiling covers the whole room footprint and would otherwise crate the entire interior (orphaning it). Scoped to `build_geometry`'s room path via an additive `structural_plane` flag on prop entries — `build_scenegrid` and the whole-dungeon geometry path stay byte-identical.

## Generator self-gate
`generate_town.py` now runs `walk_static.check_geometry` on every emitted room geometry and exits non-zero with the failure list if any room fails (mirrors the seed-boundary enforcement in `qa/seed_gfx_registered_world.py`).

## Tests
New `qa/test_generate_town.py` (stdlib + pytest only, no live services): red-first regression that the committed rooms pass with zero failures; every room has a prop kind with height ≥ 2.6; on-perimeter door not moved; every door landing walkable; door count preserved by the snap; plus a PIL-gated end-to-end self-gate run.

## Verification
- `uv run --directory servers/engine python -m pytest ../../qa/test_generate_town.py -q -p no:xdist` → **7 passed, 1 skipped** (PIL-gated integration test skips in the PIL-less engine venv; passes under full deps).
- Full generator run on the committed layout → exit 0, all three rooms GREEN.
- Existing `test_dungen_to_fixtures` / `test_tessera_to_fixtures` / `test_walk_static` → still 35 passed.