### PR TITLE
generate_town: narrative FOCAL dressing (beauty-floor lever from the dwing panel negatives)

### DIFF
--- a/qa/test_generate_town.py
+++ b/qa/test_generate_town.py
@@ -107,7 +107,11 @@ def test_flat_rooms_get_pillar_anchors(town):
     # room_2 already carries a cylinder->pillar, so it must NOT get anchors.
     for rid in ("room_0", "room_1"):
         anchors = [p for p in town[rid]["props"] if p.get("id") in ("anchor_a", "anchor_b")]
-        assert anchors, f"{rid} needs at least one pillar anchor"
+        # >=1 is the HARD bar (one tall mass clears the flat-interior class; check_dressing_bars +
+        # test_every_room_has_a_tall_prop enforce it end-to-end). Two anchors is BEST-EFFORT under
+        # focal occupancy: dress_focal runs first and may consume the second connectivity-safe pair,
+        # so pinning ==2 here would make the suite flake on legitimate focal layouts (evaOS P3).
+        assert len(anchors) >= 1, f"{rid} needs at least one pillar anchor"
         for p in anchors:
             assert p["kind"] == "pillar"
             (c0, r0), (c1, r1) = p["cells"]
@@ -195,6 +199,8 @@ def test_plates_fragment_pins_carry_the_full_camera_contract(tmp_path):
     """Sidecar round-4 catch: ortho-only pins were the 2026-07-15 camera-bug SHAPE. The client now
     defaults pitch/yaw (#1591) so they're safe — but every emitter must still stamp the full
     contract (provenance; walk_static lints pitch/yaw==30/45 when present)."""
+    pytest.importorskip("PIL")  # generate_town imports greybox_render_headless -> PIL; skip in the
+    # minimal engine venv exactly like test_generator_self_gate_passes does for the same subprocess.
     import json
     import subprocess
     out = tmp_path / "frag"

--- a/qa/test_generate_town.py
+++ b/qa/test_generate_town.py
@@ -188,3 +188,22 @@ def test_every_generated_room_has_a_narrative_focal(town):
                        for c in p["cells"]}
         assert not (focal_cells & landings), f"{rid}: focal on a door landing"
         assert check_geometry(rid, geo) == [], f"{rid}: static gate regressed after focal dressing"
+
+
+def test_plates_fragment_pins_carry_the_full_camera_contract(tmp_path):
+    """Sidecar round-4 catch: ortho-only pins were the 2026-07-15 camera-bug SHAPE. The client now
+    defaults pitch/yaw (#1591) so they're safe — but every emitter must still stamp the full
+    contract (provenance; walk_static lints pitch/yaw==30/45 when present)."""
+    import json
+    import subprocess
+    out = tmp_path / "frag"
+    out.mkdir()
+    r = subprocess.run(
+        [sys.executable, str(_ROOT / "tools" / "generate_town.py"), str(_LAYOUT),
+         "--rooms", "room_0", "--town-id", "pin", "--out-dir", str(out), "--material", "stone"],
+        capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr[-500:]
+    frag = json.loads((out / "pin_plates_fragment.json").read_text())
+    for rid, entry in frag["plates"].items():
+        pin = entry["cameraPin"]
+        assert pin.get("pitch") == 30 and pin.get("yaw") == 45, f"{rid}: ortho-only pin {pin}"

--- a/qa/test_generate_town.py
+++ b/qa/test_generate_town.py
@@ -187,7 +187,8 @@ def test_every_generated_room_has_a_narrative_focal(town):
         focal_cells = {tuple(c) for p in geo["props"] if p["kind"] in d2f._FOCAL_KINDS
                        for c in p["cells"]}
         assert not (focal_cells & landings), f"{rid}: focal on a door landing"
-        assert check_geometry(rid, geo) == [], f"{rid}: static gate regressed after focal dressing"
+        assert check_geometry(f"{_TOWN}_{rid}", geo) == [], (
+            f"{rid}: static gate regressed after focal dressing")
 
 
 def test_plates_fragment_pins_carry_the_full_camera_contract(tmp_path):
@@ -207,3 +208,21 @@ def test_plates_fragment_pins_carry_the_full_camera_contract(tmp_path):
     for rid, entry in frag["plates"].items():
         pin = entry["cameraPin"]
         assert pin.get("pitch") == 30 and pin.get("yaw") == 45, f"{rid}: ortho-only pin {pin}"
+
+
+def test_dressing_bars_fail_loud_when_a_pass_places_nothing():
+    """codex P2 pair (#1611): a narrow/dense crop can defeat dress_focal (returns silently) or leave
+    dress_tall_anchors no connectivity-safe pair AFTER focal placement — either silent miss re-ships
+    the exact drift/generic class the dressing exists to fix. check_dressing_bars is the emit-time
+    enforcement generate_town folds into its self-gate (escape hatch: --allow-undressed)."""
+    base = {"cols": 5, "rows": 5, "door_cells": [[0, 2]], "walls": [],
+            "props": [{"id": "w", "kind": "wall_run", "cells": [[0, 0]]}]}
+    both_missing = d2f.check_dressing_bars(dict(base, props=list(base["props"])), name="bare")
+    assert len(both_missing) == 2 and any("tall" in f for f in both_missing)         and any("focal" in f for f in both_missing)
+    tall_only = dict(base, props=base["props"] + [
+        {"id": "a", "kind": "pillar", "cells": [[2, 2], [2, 3]]}])
+    fails = d2f.check_dressing_bars(tall_only, name="tallonly")
+    assert len(fails) == 1 and "focal" in fails[0]
+    dressed = dict(base, props=tall_only["props"] + [
+        {"id": "b", "kind": "brazier", "cells": [[3, 2]]}])
+    assert d2f.check_dressing_bars(dressed, name="ok") == []

--- a/qa/test_generate_town.py
+++ b/qa/test_generate_town.py
@@ -72,6 +72,7 @@ def _build_town_geometries() -> dict:
     geos = {}
     for rid in _ROOMS:
         geo = _stamp_room(d2f.build_geometry(ctx, room=rid))
+        geo = d2f.dress_focal(geo, name=f"{_TOWN}_{rid}")
         geo = d2f.dress_tall_anchors(geo, name=f"{_TOWN}_{rid}")
         geo["location"] = f"{_TOWN}_{rid}"
         geos[rid] = geo
@@ -99,18 +100,20 @@ def test_every_room_has_a_tall_prop(town):
             f"{rid} tallest interior mass {tallest} < {d2f._ANCHOR_MIN_TALL} (flat-interior class)")
 
 
-def test_flat_rooms_get_two_pillar_anchors(town):
-    # room_0 and room_1 are all-crate DunGen rooms -> dressing must author two pillar anchors each;
-    # room_2 already carries a cylinder->pillar, so it must NOT be dressed.
+def test_flat_rooms_get_pillar_anchors(town):
+    # room_0 and room_1 are all-crate DunGen rooms -> the anchor pass must author AT LEAST ONE
+    # pillar anchor each (with the focal pass running first, brazier/altar occupancy can leave room
+    # for only one connectivity-safe pair — one tall anchor still clears the flat-interior bar);
+    # room_2 already carries a cylinder->pillar, so it must NOT get anchors.
     for rid in ("room_0", "room_1"):
         anchors = [p for p in town[rid]["props"] if p.get("id") in ("anchor_a", "anchor_b")]
-        assert {p["id"] for p in anchors} == {"anchor_a", "anchor_b"}, f"{rid} needs both anchors"
+        assert anchors, f"{rid} needs at least one pillar anchor"
         for p in anchors:
             assert p["kind"] == "pillar"
             (c0, r0), (c1, r1) = p["cells"]
             assert c0 == c1 and abs(r0 - r1) == 1, "each anchor is two vertically-adjacent cells"
     assert not [p for p in town["room_2"]["props"] if p.get("id", "").startswith("anchor")], \
-        "room_2 already has a tall pillar and must not be dressed"
+        "room_2 already has a tall pillar and must not get anchors"
 
 
 # ── (c) an on-perimeter door is not moved by the snap ─────────────────────────────────────────────────
@@ -170,3 +173,18 @@ def test_generator_self_gate_passes(tmp_path):
     proc = subprocess.run(cmd, capture_output=True, text=True)
     assert proc.returncode == 0, f"generator self-gate failed:\n{proc.stderr}"
     assert "STATIC GATE RED" not in proc.stderr
+
+
+def test_every_generated_room_has_a_narrative_focal(town):
+    """Beauty-floor dressing (dwing panel lesson): pure-clutter rooms panel at 'clean but generic —
+    no narrative focal point' (6 vs 9, measured 2/2). Every generated room must carry at least one
+    focal kind, placed clear of door landings, with the static gate still green."""
+    for rid, geo in town.items():
+        kinds = {p["kind"] for p in geo["props"]}
+        assert kinds & d2f._FOCAL_KINDS, f"{rid}: no focal kind in {sorted(kinds)}"
+        cols, rows = geo["cols"], geo["rows"]
+        landings = {d2f._door_landing(tuple(d), cols, rows) for d in geo["door_cells"]}
+        focal_cells = {tuple(c) for p in geo["props"] if p["kind"] in d2f._FOCAL_KINDS
+                       for c in p["cells"]}
+        assert not (focal_cells & landings), f"{rid}: focal on a door landing"
+        assert check_geometry(rid, geo) == [], f"{rid}: static gate regressed after focal dressing"

--- a/tools/dungen_to_fixtures.py
+++ b/tools/dungen_to_fixtures.py
@@ -424,6 +424,26 @@ def dress_focal(geo: dict, *, name: str = "room") -> dict:
     return geo
 
 
+def check_dressing_bars(geo: dict, *, name: str = "room") -> list:
+    """Emit-time enforcement of the two DRESSING bars the generator promises (codex P2 pair,
+    #1611): (1) FLAT-INTERIOR bar — at least one interior prop with authored height >=
+    _ANCHOR_MIN_TALL (a narrow crop can leave dress_tall_anchors no connectivity-safe pair AFTER
+    focal placement); (2) BEAUTY-FLOOR bar — at least one _FOCAL_KINDS prop (dress_focal returns
+    silently when every candidate is rejected). Returns failure strings; empty == both bars met.
+    A silent miss here would re-ship the exact drift/generic classes the dressing exists to fix —
+    the generator must fail LOUD instead so the crop gets deliberate attention."""
+    fails = []
+    interior = [p for p in geo.get("props", []) if p.get("kind") != "wall_run"]
+    tallest = max((_KIND_HEIGHT.get(p.get("kind"), 0.0) for p in interior), default=0.0)
+    if tallest < _ANCHOR_MIN_TALL:
+        fails.append(f"{name}: NO tall interior mass (tallest {tallest} < {_ANCHOR_MIN_TALL}) — "
+                     "flat-interior class; anchor placement found no connectivity-safe footprint")
+    if not any(p.get("kind") in _FOCAL_KINDS for p in interior):
+        fails.append(f"{name}: NO narrative focal prop ({sorted(_FOCAL_KINDS)}) — beauty-floor bar; "
+                     "focal placement found no connectivity-safe cell")
+    return fails
+
+
 def dress_tall_anchors(geo: dict, *, name: str = "room") -> dict:
     """Flat-interior-class dressing (#1588): if a cropped room has NO interior prop kind with authored
     height >= _ANCHOR_MIN_TALL (heights per _KIND_HEIGHT; `pillar` qualifies), author two `pillar`

--- a/tools/dungen_to_fixtures.py
+++ b/tools/dungen_to_fixtures.py
@@ -332,6 +332,98 @@ def _door_landing(cell: tuple, cols: int, rows: int) -> tuple:
             r + (1 if r == 0 else -1 if r == rows - 1 else 0))
 
 
+_FOCAL_KINDS = {"altar", "stone_well", "brazier", "sarcophagus", "campfire", "hearth"}
+
+
+def dress_focal(geo: dict, *, name: str = "room") -> dict:
+    """Beauty-floor dressing (the dwing panel lesson, 2026-07-16): a generated room whose interior
+    props are pure clutter (crates/rubble/barrels) panels at "clean but generic — no narrative focal
+    point" (6 vs control 9, measured 2/2 on structurally-honest plates). Give each room ONE
+    deterministic narrative focal set chosen by door count: 1 door -> an ALTAR flanked by two
+    BRAZIERS (a sealed shrine-store); 2 doors -> two BRAZIERS flanking the through-lane; 3+ doors ->
+    two BRAZIERS by the crossing centre. Fire doubles as the paint stage's warm-core chiaroscuro
+    anchor (the scorers' own lever) and the runtime's animated-VFX anchor. Skipped when the room
+    already carries any focal kind. Same safety machinery as dress_tall_anchors: deterministic
+    grid-derived candidates, never on/adjacent to a door landing, flood-fill connectivity-verified."""
+    interior = [p for p in geo.get("props", []) if p.get("kind") != "wall_run"]
+    if any(p.get("kind") in _FOCAL_KINDS for p in interior):
+        return geo
+    cols, rows = int(geo["cols"]), int(geo["rows"])
+    doors = {tuple(d) for d in geo.get("door_cells", [])}
+    landings = {_door_landing(d, cols, rows) for d in doors}
+    landing_block = set(landings)
+    for (c, r) in landings:
+        landing_block |= {(c + 1, r), (c - 1, r), (c, r + 1), (c, r - 1)}
+
+    def free_set(extra_blocked: set) -> set:
+        prop_cells = {tuple(c) for p in geo.get("props", []) if p.get("kind") != "wall_run"
+                      for c in p.get("cells", [])} | extra_blocked
+        walls = ({tuple(c) for c in geo.get("walls", [])} | prop_cells) - doors
+        return {(c, r) for r in range(rows) for c in range(cols) if (c, r) not in walls}
+
+    base_free = free_set(set())
+
+    def connectivity_ok(blocked: set) -> bool:
+        free = free_set(blocked)
+        starts = [land for land in landings if land in free]
+        if not starts:
+            return False
+        seen, stack = {starts[0]}, [starts[0]]
+        while stack:
+            c, r = stack.pop()
+            for n in ((c + 1, r), (c - 1, r), (c, r + 1), (c, r - 1)):
+                if n in free and n not in seen:
+                    seen.add(n)
+                    stack.append(n)
+        if any(land not in seen for land in starts):
+            return False
+        interior_free = {(c, r) for (c, r) in free if 0 < c < cols - 1 and 0 < r < rows - 1}
+        return not (interior_free - seen)
+
+    def shapes(ideal: tuple, footprint: int) -> list:
+        """Candidate footprints (1-cell, or a horizontal pair) ordered toward `ideal`."""
+        out = []
+        for c in range(1, cols - 1 - (footprint - 1)):
+            for r in range(1, rows - 1):
+                cells = tuple((c + i, r) for i in range(footprint))
+                if all(cell in base_free and cell not in doors and cell not in landing_block
+                       for cell in cells):
+                    d = sum(abs(cc - ideal[0]) + abs(rr - ideal[1]) for (cc, rr) in cells)
+                    out.append((d, r, c, cells))
+        out.sort()
+        return [o[3] for o in out]
+
+    n_doors = len(doors)
+    plan: list = []  # (id, kind, footprint, ideal)
+    if n_doors <= 1:
+        plan = [("focal_altar", "altar", 2, (cols // 2, rows // 3)),
+                ("focal_brazier_w", "brazier", 1, (cols // 2 - 2, rows // 3)),
+                ("focal_brazier_e", "brazier", 1, (cols // 2 + 2, rows // 3))]
+    elif n_doors == 2:
+        plan = [("focal_brazier_w", "brazier", 1, (cols // 3, rows // 2)),
+                ("focal_brazier_e", "brazier", 1, (2 * cols // 3, rows // 2))]
+    else:
+        plan = [("focal_brazier_w", "brazier", 1, (cols // 2 - 2, rows // 2)),
+                ("focal_brazier_e", "brazier", 1, (cols // 2 + 2, rows // 2))]
+
+    used: set = set()
+    for pid, kind, footprint, ideal in plan:
+        for cells in shapes(ideal, footprint):
+            if any(cell in used for cell in cells):
+                continue
+            if connectivity_ok(used | set(cells)):
+                geo["props"].append({"id": pid, "kind": kind, "cells": [list(c) for c in cells]})
+                used |= set(cells)
+                break
+    if used:
+        wall_cells = {tuple(c) for c in geo.get("walls", [])}
+        prop_cells = {tuple(c) for p in geo.get("props", []) if p.get("kind") != "wall_run"
+                      for c in p.get("cells", [])}
+        geo["impassable"] = [list(c) for c in
+                             sorted(wall_cells | prop_cells - doors, key=lambda x: (x[1], x[0]))]
+    return geo
+
+
 def dress_tall_anchors(geo: dict, *, name: str = "room") -> dict:
     """Flat-interior-class dressing (#1588): if a cropped room has NO interior prop kind with authored
     height >= _ANCHOR_MIN_TALL (heights per _KIND_HEIGHT; `pillar` qualifies), author two `pillar`

--- a/tools/generate_town.py
+++ b/tools/generate_town.py
@@ -32,7 +32,7 @@ _TOOLS = Path(__file__).resolve().parent
 sys.path.insert(0, str(_TOOLS))
 sys.path.insert(0, str(_TOOLS.parent / "qa"))
 
-from dungen_to_fixtures import convert, build_geometry, dress_tall_anchors  # noqa: E402
+from dungen_to_fixtures import convert, build_geometry, dress_focal, dress_tall_anchors  # noqa: E402
 from author_room_geometry import _perimeter_wall_run_props  # noqa: E402
 from greybox_render_headless import _fit_ortho_size  # noqa: E402
 from walk_static import check_geometry  # noqa: E402
@@ -86,6 +86,7 @@ def main(argv=None) -> int:
     for rid in room_ids:
         geo = _stamp_room(build_geometry(ctx, room=rid),
                           material=args.material, wall_height=args.wall_height)
+        geo = dress_focal(geo, name=loc_of[rid])  # narrative focal set FIRST (an altar also satisfies the tall-anchor bar)
         geo = dress_tall_anchors(geo, name=loc_of[rid])
         geo["location"] = loc_of[rid]
         # ★ STATIC WALKABILITY GATE (mirrors qa/seed_gfx_registered_world.py): a room geometry that

--- a/tools/generate_town.py
+++ b/tools/generate_town.py
@@ -32,7 +32,8 @@ _TOOLS = Path(__file__).resolve().parent
 sys.path.insert(0, str(_TOOLS))
 sys.path.insert(0, str(_TOOLS.parent / "qa"))
 
-from dungen_to_fixtures import convert, build_geometry, dress_focal, dress_tall_anchors  # noqa: E402
+from dungen_to_fixtures import (convert, build_geometry, check_dressing_bars, dress_focal,  # noqa: E402
+                                dress_tall_anchors)
 from author_room_geometry import _perimeter_wall_run_props  # noqa: E402
 from greybox_render_headless import _fit_ortho_size  # noqa: E402
 from walk_static import check_geometry  # noqa: E402
@@ -66,6 +67,10 @@ def main(argv=None) -> int:
     ap.add_argument("--material", default="stone", choices=["stone", "wood"])
     ap.add_argument("--wall-height", type=float, default=5.0)
     ap.add_argument("--world-units-per-cell", type=float, default=2.0)
+    ap.add_argument("--allow-undressed", action="store_true",
+                    help="skip the dressing bars (tall-mass + focal presence) for deliberate cases "
+                         "(e.g. a bare corridor class); default is FAIL LOUD when dressing found no "
+                         "connectivity-safe placement (codex P2 pair, #1611)")
     args = ap.parse_args(argv)
 
     layout = json.loads(Path(args.layout_json).read_text(encoding="utf-8"))
@@ -86,7 +91,9 @@ def main(argv=None) -> int:
     for rid in room_ids:
         geo = _stamp_room(build_geometry(ctx, room=rid),
                           material=args.material, wall_height=args.wall_height)
-        geo = dress_focal(geo, name=loc_of[rid])  # narrative focal set FIRST (an altar also satisfies the tall-anchor bar)
+        geo = dress_focal(geo, name=loc_of[rid])  # narrative focal set FIRST (braziers/altar are LOW kinds
+        # (2.0-2.2 < the 2.6 tall bar) — dress_tall_anchors still adds pillars after; the dressing-bar
+        # self-gate below fails LOUD if either pass found no connectivity-safe placement)
         geo = dress_tall_anchors(geo, name=loc_of[rid])
         geo["location"] = loc_of[rid]
         # ★ STATIC WALKABILITY GATE (mirrors qa/seed_gfx_registered_world.py): a room geometry that
@@ -94,6 +101,8 @@ def main(argv=None) -> int:
         # never ships — refuse the whole run. Caught here, the three DunGen defect classes (boundary
         # doors, prop-blocked landings, flat-interior mass) are pre-render-impossible.
         gate_fails += [f"{loc_of[rid]}: {f}" for f in check_geometry(loc_of[rid], geo)]
+        if not args.allow_undressed:
+            gate_fails += check_dressing_bars(geo, name=loc_of[rid])
         path = out / f"{args.town_id}_{rid}_geometry.json"
         path.write_text(json.dumps(geo) + "\n", encoding="utf-8")
         geos[rid] = geo

--- a/tools/generate_town.py
+++ b/tools/generate_town.py
@@ -164,7 +164,11 @@ def main(argv=None) -> int:
     # plates_manifest fragment — cameraPin.ortho from the SAME fit math as the unified render
     frag = {"plates": {loc_of[rid]: {
         "plate": f"plates/{loc_of[rid]}.png",
-        "cameraPin": {"ortho": round(_fit_ortho_size(geos[rid]["cols"], geos[rid]["rows"]), 4)},
+        "cameraPin": {"ortho": round(_fit_ortho_size(geos[rid]["cols"], geos[rid]["rows"]), 4),
+                      # pitch/yaw stamped explicitly (provenance + belt-and-suspenders): the client
+                      # DEFAULTS to the 30/45 contract rig when only ortho is pinned (#1591), but
+                      # every shipped manifest entry carries them and walk_static lints them.
+                      "pitch": 30, "yaw": 45},
         "boxes": f"boxes/{loc_of[rid]}_boxes.json",
     } for rid in room_ids}}
     (out / f"{args.town_id}_plates_fragment.json").write_text(json.dumps(frag, indent=1) + "\n", encoding="utf-8")


### PR DESCRIPTION
Cycle-2 of the generated dungeon wing produced STRUCTURALLY HONEST plates (the count/shape/door-wall
locks from the same cycle killed the Gemini feature-multiplication + reshape classes) — and the blind
control-anchored panels still returned 6-vs-9, Δ−3.0 OUT OF BAND, 2/2, with a unanimous critique:
"clean but generic — boxy symmetric composition, generic asset-kit clutter, empty floor, no narrative
focal point". Per the geometry-richness principle (CRYPT-REPLICATE; the snug c3 +1-median geometry
lever), the fix belongs in the GENERATOR, not the prompt.

`dress_focal` (tools/dungen_to_fixtures.py) gives every generated room one deterministic narrative
focal set chosen by door count: dead-end → ALTAR flanked by two BRAZIERS; through-room → two BRAZIERS
flanking the lane; hub → two BRAZIERS at the crossing. Fire also hands the paint stage its warm-core
chiaroscuro anchor (the panel's own lever) and the runtime its animated-VFX anchor. It runs BEFORE
dress_tall_anchors (an altar can satisfy the tall-mass bar) and reuses the same safety machinery:
deterministic candidates, door/landing/adjacency exclusion, flood-fill connectivity verification, and
the generator self-gate re-checks every room.

Wing regeneration: room_0 = altar + 2 braziers + 2 pillars; room_1 = 2 braziers + pillar; room_2 =
2 braziers + native pillar — all three `check_geometry` GREEN. Tests: new focal unit (presence, off-
landing, gate-green) + the anchor test relaxed to ≥1 pillar (focal occupancy can leave one
connectivity-safe pair; one tall mass clears the flat-interior bar). 9/9 + walk_static suite green.