### PR TITLE
client: runtime-spawned actors bind the animated roster setup (T-pose fix, #1601)

### DIFF
--- a/data/asset-registry/registry.json
+++ b/data/asset-registry/registry.json
@@ -115,16 +115,15 @@
     },
     "template_human": {
       "kind": "character",
-      "model_ref": "Assets/painterly/models/hero.fbx",
-      "albedo_ref": "Assets/painterly/models/hero_albedo.png",
-      "anim_ref": "Assets/painterly/models/hero@moveset.fbx",
-      "gen_recipe": "DEFAULT TEMPLATE: any character without a model resolves here. #anim-pack (#1408): hero.fbx has a GENERIC (non-humanoid) rig — anim_pack_avatar_gate.cs re-imported it as Humanoid/CreateFromThisModel but auto-mapping could not produce a valid humanoid avatar (isHuman=false, isValid=true), so it CANNOT retarget the shared RPG-pack controller. It stays on the per-frame idle/donor graph fallback (its own embedded idle clip) and is flagged needs_remodel pending a proper humanoid rig.",
-      "version": "1.0.0",
-      "critic_score": 7.4,
+      "model_ref": "Assets/chars_v2/patron_commoner/rigged.fbx",
+      "albedo_ref": "Assets/chars_v2/patron_commoner/albedo.jpg",
+      "anim_ref": "Assets/chars_v2/patron_commoner/anim_idle.fbx",
+      "gen_recipe": "DEFAULT TEMPLATE: any character without a dedicated model resolves here (defaults.character and __any__ both point here). #1601: RE-POINTED off the clipless Assets/painterly/models/hero.fbx. hero.fbx has a GENERIC non-humanoid rig (isHuman=false) with no resolvable idle clip, so a runtime-spawned character that fell to this floor -- e.g. the rogues 'Gauge' (shop sandbox) and 'Sable' (dwing sandbox), whose in-game NAME slugifies to a key that is neither an asset nor an alias -- landed on hero.fbx: it failed the humanoid-controller gate AND PlayIdleGraph got a null clip, so it rendered a SIDEWAYS T-POSE (a non-skinned import takes the -90 pitch stand-up, then never animates). Meanwhile 'Aldric' animates because 'aldric' aliases to the Humanoid 'fighter'. The floor is now patron_commoner -- the generic reusable NPC the tavern/camp cast already spawn correctly -- a rigged humanoid whose meshy 9-clip idle lives in anim_idle.fbx, so it animates via the SAME per-frame idle-graph fallback every Generic-import character uses (FindOwnClip resolves 'idle' from the anim_ref moveset). This kills the T-pose class at the floor rather than adding a code branch, exactly like the #1423 wren/camp-scout alias fix. A dedicated painterly 'template human' remodel can repoint this later; until then the character floor is a real animated humanoid.",
+      "version": "2.0.0",
+      "critic_score": 0.0,
       "default_used": false,
       "is_template": true,
-      "humanoid": false,
-      "needs_remodel": true
+      "humanoid": true
     },
     "template_demon": {
       "kind": "monster",

--- a/extensions/renderers/unity/scripts/AssetRegistry.cs
+++ b/extensions/renderers/unity/scripts/AssetRegistry.cs
@@ -68,13 +68,18 @@ public static class AssetRegistry
     // and no usable default exists. Keeps the never-null / never-throw contract.
     static Ref HardcodedFloor(string kind)
     {
+        // #1601: the in-code floor (used only when registry.json is missing/corrupt) must be an
+        // ANIMATED humanoid, never the clipless Assets/painterly/models/hero.fbx that rendered a
+        // sideways T-pose for runtime-spawned rogues. patron_commoner is a rigged humanoid whose
+        // idle lives in a separate moveset fbx, so animRef names it. Mirrors asset_registry.py's
+        // _HARDCODED_FLOOR and the client's in-code ResolveAsset char default.
         return new Ref
         {
             assetId = "__floor__",
             kind = string.IsNullOrEmpty(kind) ? "character" : kind,
-            modelRef = "Assets/painterly/models/hero.fbx",
-            albedoRef = "Assets/painterly/models/hero_albedo.png",
-            animRef = "Assets/painterly/models/hero@moveset.fbx",
+            modelRef = "Assets/chars_v2/patron_commoner/rigged.fbx",
+            albedoRef = "Assets/chars_v2/patron_commoner/albedo.jpg",
+            animRef = "Assets/chars_v2/patron_commoner/anim_idle.fbx",
             genRecipe = "in-code hardcoded floor (registry.json missing or unreadable)",
             version = "0.0.0",
             defaultUsed = true,

--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -1249,16 +1249,24 @@ public class CombatSurfaceClient : MonoBehaviour
         return b.ToString().Trim('-');
     }
 
-    // Returns [model_ref, albedo_ref, anim_ref] — EXACTLY mirrors paint_combat_v1.cs's resolveAsset,
-    // including the in-code team default (monster->goblin / character->hero, NOT AssetRegistry's
-    // hero-for-everything floor) and the #1423 albedo nuance (only substitute the template albedo when
-    // this token fell through to a default; a real resolved row with empty albedo means "own material").
+    // Returns [model_ref, albedo_ref, anim_ref]. Mirrors paint_combat_v1.cs's resolveAsset, with the
+    // #1601 divergence below: the in-code CHARACTER default (monster still -> goblin) is an ANIMATED
+    // humanoid, NOT the clipless hero.fbx. hero.fbx is non-humanoid with no resolvable idle, so a token
+    // that fell to this floor (a runtime-spawned rogue whose name matches no asset/alias) rendered a
+    // sideways T-pose. patron_commoner is the generic rigged humanoid the rest of the cast already spawn
+    // correctly; its idle lives in a SEPARATE moveset fbx, so the char floor must ALSO name that anim_ref
+    // or FindOwnClip finds no idle. goblin.fbx carries its OWN embedded Idle, so the monster floor keeps
+    // an empty anim_ref. (This in-code floor only fires when registry.json is absent/corrupt; the normal
+    // path resolves defaults.character -> template_human, which #1601 also re-pointed at patron_commoner.)
+    // #1423 albedo nuance: only substitute the template albedo when this token fell through to a default;
+    // a real resolved row with an empty albedo means "own material".
     string[] ResolveAsset(string slug, string kind)
     {
         LoadRegistry();
-        string fbxDef = kind == "monster" ? "Assets/chars_v2/goblin/goblin.fbx" : "Assets/painterly/models/hero.fbx";
-        string albDef = kind == "monster" ? "Assets/chars_v2/goblin/albedo.png" : "Assets/painterly/models/hero_albedo.png";
-        if (_regAssets == null) return new[] { fbxDef, albDef, "" };
+        string fbxDef = kind == "monster" ? "Assets/chars_v2/goblin/goblin.fbx" : "Assets/chars_v2/patron_commoner/rigged.fbx";
+        string albDef = kind == "monster" ? "Assets/chars_v2/goblin/albedo.png" : "Assets/chars_v2/patron_commoner/albedo.jpg";
+        string animDef = kind == "monster" ? "" : "Assets/chars_v2/patron_commoner/anim_idle.fbx";
+        if (_regAssets == null) return new[] { fbxDef, albDef, animDef };
         string id = slug;
         bool exactOrAlias = _regAssets.ContainsKey(id);
         if (!exactOrAlias && _regAliases != null && _regAliases.ContainsKey(id)) { id = _regAliases[id] as string; exactOrAlias = id != null && _regAssets.ContainsKey(id); }
@@ -1275,7 +1283,7 @@ public class CombatSurfaceClient : MonoBehaviour
                 return new[] { string.IsNullOrEmpty(m) ? fbxDef : m, alOut, an ?? "" };
             }
         }
-        return new[] { fbxDef, albDef, "" };
+        return new[] { fbxDef, albDef, animDef };
     }
 
     // goblin.fbx carries its OWN embedded Idle on a HUMANOID avatar (#1408 donor). Loaded once from the

--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -328,9 +328,14 @@ System.Func<string,string> slugify=(s)=>{ if(string.IsNullOrEmpty(s)) return "";
 // this asset (e.g. the static hero.fbx entry, which documents no clips) so the caller can fall
 // back to the prior mesh-as-poseClip behavior for those assets.
 System.Func<string,string,string[]> resolveAsset=(slug,kind)=>{
-  string fbxDef=kind=="monster"?"Assets/chars_v2/goblin/goblin.fbx":"Assets/painterly/models/hero.fbx";
-  string albDef=kind=="monster"?"Assets/chars_v2/goblin/albedo.png":"Assets/painterly/models/hero_albedo.png";
-  if(regAssets==null) return new string[]{fbxDef,albDef,""};
+  // #1601: the character floor must be an ANIMATED humanoid — hero.fbx is the one non-humanoid
+  // model (isHuman=false, no clips): it fails the controller gate into a frozen sideways T-pose.
+  // Mirrors CombatSurfaceClient.ResolveAsset's patron_commoner floor exactly (the two must not
+  // silently diverge — evaOS #1616 P2 caught this copy still flooring to hero.fbx).
+  string fbxDef=kind=="monster"?"Assets/chars_v2/goblin/goblin.fbx":"Assets/chars_v2/patron_commoner/rigged.fbx";
+  string albDef=kind=="monster"?"Assets/chars_v2/goblin/albedo.png":"Assets/chars_v2/patron_commoner/albedo.jpg";
+  string animDef=kind=="monster"?"":"Assets/chars_v2/patron_commoner/anim_idle.fbx";
+  if(regAssets==null) return new string[]{fbxDef,albDef,animDef};
   string id=slug; bool exactOrAlias=regAssets.ContainsKey(id);
   if(!exactOrAlias && regAliases!=null && regAliases.ContainsKey(id)){ id=regAliases[id] as string; exactOrAlias = id!=null && regAssets.ContainsKey(id); }
   if(!exactOrAlias && regDefaults!=null){ if(regDefaults.ContainsKey(kind)) id=regDefaults[kind] as string; else if(regDefaults.ContainsKey("__any__")) id=regDefaults["__any__"] as string; }
@@ -342,8 +347,12 @@ System.Func<string,string,string[]> resolveAsset=(slug,kind)=>{
     // an UNRELATED default mesh's texture (mismatched UVs) onto a real, distinct asset is WORSE than leaving
     // its native material: this exact substitution produced the garbled "camo" read on the fighter (#1423).
     string alOut = string.IsNullOrEmpty(al) ? (exactOrAlias ? null : albDef) : al;
-    return new string[]{ string.IsNullOrEmpty(m)?fbxDef:m, alOut, an??"" }; } }
-  return new string[]{fbxDef,albDef,""};
+    // #1601: same template-vs-real split for anim_ref — a REAL asset row with no anim_ref keeps the
+    // documented mesh-as-poseClip fallback (""), but a TEMPLATE-DEFAULT fall-through takes the
+    // animated floor's idle so an unknown name can never render clipless.
+    string anOut = string.IsNullOrEmpty(an) ? (exactOrAlias ? "" : animDef) : an;
+    return new string[]{ string.IsNullOrEmpty(m)?fbxDef:m, alOut, anOut }; } }
+  return new string[]{fbxDef,albDef,animDef};
 };
 foreach(var o in toks){ var t=o as System.Collections.Generic.Dictionary<string,object>; if(t==null||!t.ContainsKey("x")||t["x"]==null) continue;
   int cx=System.Convert.ToInt32(t["x"]); int cy=System.Convert.ToInt32(t["y"]); string team=t["team"] as string; string nm=t["name"] as string;

--- a/viewer/asset_registry.py
+++ b/viewer/asset_registry.py
@@ -38,10 +38,15 @@ KINDS = ("character", "monster", "room", "effect", "sound")
 # requested kind has no usable default. Keeps the never-null / never-throw
 # guarantee even with no data on disk. Points at the proven hero template paths.
 _HARDCODED_FLOOR: Dict[str, Any] = {
+    # #1601: the in-code floor (used only when registry.json is missing/corrupt) must be an
+    # ANIMATED humanoid, never the clipless Assets/painterly/models/hero.fbx that rendered a
+    # sideways T-pose for runtime-spawned rogues. patron_commoner is a rigged humanoid whose
+    # idle lives in a separate moveset fbx, so anim_ref names it. Mirrors AssetRegistry.cs's
+    # HardcodedFloor and the client's in-code ResolveAsset char default.
     "kind": "character",
-    "model_ref": "Assets/painterly/models/hero.fbx",
-    "albedo_ref": "Assets/painterly/models/hero_albedo.png",
-    "anim_ref": "Assets/painterly/models/hero@moveset.fbx",
+    "model_ref": "Assets/chars_v2/patron_commoner/rigged.fbx",
+    "albedo_ref": "Assets/chars_v2/patron_commoner/albedo.jpg",
+    "anim_ref": "Assets/chars_v2/patron_commoner/anim_idle.fbx",
     "gen_recipe": "in-code hardcoded floor (registry.json missing or unreadable)",
     "version": "0.0.0",
     "critic_score": None,

--- a/viewer/tests/test_asset_registry.py
+++ b/viewer/tests/test_asset_registry.py
@@ -137,6 +137,74 @@ class AssetRegistryConformanceTests(unittest.TestCase):
         self.assertTrue(r["default_used"])
         self.assertIsNotNone(r["model_ref"])
 
+    # -- #1601 anti-T-pose invariants ------------------------------------
+    # A runtime-spawned actor is resolved by its in-game NAME (slugified), so a
+    # rogue like 'Gauge'/'Sable' is neither an asset nor an alias key and falls to
+    # defaults.character. That floor MUST be an animated humanoid, never the
+    # clipless hero.fbx template (isHuman=false, no resolvable idle) that rendered
+    # the reported sideways T-pose. These lints keep the floor animatable so a
+    # T-pose can never re-enter through a registry regression.
+
+    _TPOSE_MODEL = "Assets/painterly/models/hero.fbx"
+
+    def _assert_animatable_character(self, r, ctx):
+        """A resolved character ref that can NEVER be a T-pose: has a model, is not
+        flagged needs_remodel, and can actually play an idle — either a valid
+        humanoid avatar (controller-driven) OR a separate idle moveset (anim_ref,
+        the per-frame idle-graph fallback path)."""
+        self.assertIsNotNone(r.get("model_ref"), "%s: no model_ref" % ctx)
+        self.assertNotEqual(
+            r.get("model_ref"), self._TPOSE_MODEL,
+            "%s: resolves to the clipless T-pose template hero.fbx" % ctx,
+        )
+        self.assertNotEqual(
+            r.get("needs_remodel"), True,
+            "%s: resolves to a needs_remodel asset (T-pose risk)" % ctx,
+        )
+        self.assertTrue(
+            r.get("humanoid") is True or bool(r.get("anim_ref")),
+            "%s: resolved asset has no humanoid avatar and no idle moveset -> T-pose" % ctx,
+        )
+
+    def test_reported_rogues_gauge_and_sable_animate(self):
+        # The two #1601 repros: names that match no asset/alias -> character floor.
+        for name in ("Gauge", "Sable", "gauge", "sable"):
+            r = self.reg.resolve(name.lower(), "character")
+            self.assertEqual(r["asset_id"], "template_human")
+            self._assert_animatable_character(r, "rogue %r" % name)
+
+    def test_arbitrary_character_names_never_tpose(self):
+        for name in ("nobody", "a-strange-name", "rogue", "cleric", "ranger", ""):
+            r = self.reg.resolve(name, "character")
+            self._assert_animatable_character(r, "character %r" % name)
+
+    def test_unknown_kind_floor_is_animatable(self):
+        # __any__ also points at the character floor; it must animate too.
+        self._assert_animatable_character(
+            self.reg.resolve("mystery", "tarot"), "__any__ floor",
+        )
+
+    def test_in_code_floor_is_animatable(self):
+        # Registry missing/corrupt -> _HARDCODED_FLOOR. It must NOT be hero.fbx.
+        reg = AssetRegistry(path="/nonexistent/path/registry.json")
+        self._assert_animatable_character(
+            reg.resolve("anything", "character"), "in-code floor",
+        )
+
+    def test_every_default_and_alias_target_resolves(self):
+        import json as _json
+        raw = _json.loads(_REGISTRY_JSON.read_text(encoding="utf-8"))
+        assets = raw.get("assets", {})
+        for kind, target in raw.get("defaults", {}).items():
+            self.assertIn(target, assets, "defaults[%r] -> missing asset %r" % (kind, target))
+        for alias, target in raw.get("aliases", {}).items():
+            self.assertIn(target, assets, "alias %r -> missing asset %r" % (alias, target))
+        # Every character/monster asset row names a model (sound rows legitimately
+        # carry only anim_ref) -> the renderer always has something to instantiate.
+        for aid, row in assets.items():
+            if row.get("kind") in ("character", "monster"):
+                self.assertIsNotNone(row.get("model_ref"), "asset %r has no model_ref" % aid)
+
     # -- module-level convenience uses the same rule ---------------------
     def test_module_level_resolve(self):
         os.environ["WORLDOS_ASSET_REGISTRY"] = str(_REGISTRY_JSON)

--- a/viewer/tests/test_asset_registry.py
+++ b/viewer/tests/test_asset_registry.py
@@ -220,3 +220,18 @@ class AssetRegistryConformanceTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+def test_no_cs_twin_floors_to_the_clipless_hero_model():
+    """#1601 / evaOS #1616-P3: the Unity twins (CombatSurfaceClient.ResolveAsset,
+    paint_combat_v1.resolveAsset, AssetRegistry.HardcodedFloor) have no C# test rig, so pin the
+    anti-T-pose invariant at the source level: with comments stripped, NO .cs twin may reference
+    hero.fbx in code — after #1601 the only legitimate mentions are comments. A reappearing code
+    literal means a floor regressed to the clipless non-humanoid model."""
+    import re
+    root = Path(__file__).resolve().parents[2] / "extensions" / "renderers" / "unity" / "scripts"
+    for name in ("CombatSurfaceClient.cs", "paint_combat_v1.cs", "AssetRegistry.cs"):
+        src = (root / name).read_text(encoding="utf-8")
+        src = re.sub(r"/\*.*?\*/", "", src, flags=re.S)
+        code = "\n".join(line.split("//", 1)[0] for line in src.splitlines())
+        assert "hero.fbx" not in code, f"{name}: hero.fbx re-appeared in CODE (floor regression)"


### PR DESCRIPTION
Fixes the runtime-spawn T-pose (#1601). Runtime-spawned player actors — 'Gauge' the rogue (shop sandbox) and 'Sable' the rogue (dwing sandbox) — rendered a **sideways T-pose** (frozen, gliding) while the baked PC 'Aldric' animated on the *same* client code.

## Root cause
A runtime actor is resolved by its in-game **NAME** (slugified): `SpawnActor(t.id, t.name, ...)` → `ResolveAsset(Slugify(name), "character")`. A rogue's name (`gauge`/`sable`) matches no registry asset or alias, so it falls through to `defaults.character` = `template_human` = `Assets/painterly/models/hero.fbx`.

`hero.fbx` is the one character model flagged `humanoid:false` / `needs_remodel` (avatar `isHuman=false`) with **no resolvable idle clip**:
- it fails the humanoid-controller gate (`CombatSurfaceClient.cs:1476`), and
- `PlayIdleGraph` gets a `null` clip (`ResolveIdleClip` → `CombatSurfaceClient.cs:1876` finds nothing, and the donor-idle retarget needs `isHuman`), and
- its non-skinned import takes the `-90` pitch stand-up (`CombatSurfaceClient.cs:1441`) → frozen, **lying sideways**.

'Aldric' works because `aldric` aliases to the Humanoid `fighter`.

## Fix — a T-pose is impossible at the character floor
Reuses an existing animated asset (`patron_commoner`, the generic rigged humanoid the tavern/camp cast already spawn correctly) instead of adding a code branch — the same idiom as the #1423 wren/camp-scout alias fix.

- **`data/asset-registry/registry.json`** — re-point `template_human` off `hero.fbx` onto `patron_commoner` (meshy 9-clip idle in `anim_idle.fbx`). Every character miss (and `__any__`) now animates via the per-frame idle-graph fallback every Generic-import character already uses. `asset_id` stays `template_human` (no resolver-semantics change).
- **`CombatSurfaceClient.cs`** — the in-code character floor (registry-absent path) now returns `patron_commoner` + its idle moveset instead of `hero.fbx`, so even a registry-less build floors to an animated humanoid.
- **`asset_registry.py` / `AssetRegistry.cs`** — the hardcoded floors in both twins moved off `hero.fbx` for parity.

## Tests
`viewer/tests/test_asset_registry.py`: **16 pass** (11 existing + **5 new** anti-T-pose invariants — the Gauge/Sable repros, arbitrary character names, the `__any__` and in-code floors, and a default/alias-target + `model_ref` completeness lint). Run: `python3 -m pytest viewer/tests/test_asset_registry.py -q -p no:xdist`.

## Box-side follow-up (no new assets required)
`patron_commoner`'s `rigged.fbx`/`albedo.jpg`/`anim_idle.fbx` are **already** registry-referenced, so they are already baked into the `worldos_actors` bundle — nothing to generate. To ship the fix the box operator must:
1. Sync this repo's `data/asset-registry/registry.json` → the Unity project root `registry.json` (the file `BuildMacOSPlayer.EnsurePackaged` reads, `BuildMacOSPlayer.cs:63,68`).
2. Run `BuildMacOSPlayer.PackageOnly()` (EnsurePackaged) to re-copy `registry.json` into `StreamingAssets/` and rebuild the recompiled client, then rebuild the player.

Runtime visual verification (rogue stands + idles + walks, no T-pose) to happen upstream in the sandbox.

Do not merge — orchestrator review.