### PR TITLE
engine: get_quests read RPC — full quest set for the adventure-eval telemetry (A-series A0.1)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1082,6 +1082,39 @@ def get_state(campaign_id: str) -> dict:
 
 
 @mcp.tool()
+def get_quests(campaign_id: str) -> dict:
+    """Read the FULL quest set, machine-readably — every quest regardless of status
+    (active | completed | failed), not just the active ones get_state projects. This
+    is the poll surface for external telemetry (the adventure-eval quest_trace stage):
+    it lets an eval watch an objective advance -> the quest progress -> the resolution,
+    which get_state's active-only slice hides the moment a quest completes or fails.
+
+    READ-ONLY — pure projection, no state mutation or side effects. Each entry mirrors
+    the quest fields get_state projects plus the resolution/progress fields an eval needs
+    to compute progress: id, title, status, objectives, completed_objectives, giver_id,
+    location_id, milestone_awarded, last_progress_day, last_progress_beat.
+    """
+    c = _require(campaign_id)
+    return {
+        "quests": [
+            {
+                "id": q.id,
+                "title": q.title,
+                "status": q.status,
+                "objectives": list(q.objectives),
+                "completed_objectives": list(q.completed_objectives),
+                "giver_id": q.giver_id,
+                "location_id": q.location_id,
+                "milestone_awarded": q.milestone_awarded,
+                "last_progress_day": q.last_progress_day,
+                "last_progress_beat": q.last_progress_beat,
+            }
+            for q in c.quests.values()
+        ]
+    }
+
+
+@mcp.tool()
 def look_around(campaign_id: str) -> dict:
     """Describe the party's current location and the exits they can take."""
     c = _require(campaign_id)

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1083,16 +1083,9 @@ def get_state(campaign_id: str) -> dict:
 
 @mcp.tool()
 def get_quests(campaign_id: str) -> dict:
-    """Read the FULL quest set, machine-readably — every quest regardless of status
-    (active | completed | failed), not just the active ones get_state projects. This
-    is the poll surface for external telemetry (the adventure-eval quest_trace stage):
-    it lets an eval watch an objective advance -> the quest progress -> the resolution,
-    which get_state's active-only slice hides the moment a quest completes or fails.
-
-    READ-ONLY — pure projection, no state mutation or side effects. Each entry mirrors
-    the quest fields get_state projects plus the resolution/progress fields an eval needs
-    to compute progress: id, title, status, objectives, completed_objectives, giver_id,
-    location_id, milestone_awarded, last_progress_day, last_progress_beat.
+    """Read EVERY quest regardless of status (get_state lists active only). Read-only
+    telemetry poll surface. Entries: id, title, status, objectives, completed_objectives,
+    giver_id, location_id, milestone_awarded, last_progress_day, last_progress_beat.
     """
     c = _require(campaign_id)
     return {

--- a/servers/engine/tests/test_f05_story_machinery.py
+++ b/servers/engine/tests/test_f05_story_machinery.py
@@ -408,3 +408,61 @@ class TestF05_10_PreludeMeetable:
                 bound.add(meeting.ref_id)
         # Both eligible npcs can still be bound (distribution unchanged / not collapsed).
         assert bound == {"npc-a", "npc-b"}
+
+
+# ── A0.1 — get_quests exposes the FULL quest set for the adventure-eval telemetry ─
+
+
+class TestA0_1_GetQuestsFullSet:
+    def test_returns_all_quests_regardless_of_status(self, cid):
+        # Seed two quests, then resolve one fully and advance one objective of the other.
+        done_qid = _add_active_quest(cid, "Deliver the Relic", ["reach the temple"])
+        active_qid = _add_active_quest(cid, "Two-Step Errand", ["step one", "step two"])
+        server.complete_quest(cid, done_qid, "completed")
+        server.complete_objective(cid, active_qid, "step one")
+
+        out = server.get_quests(cid)
+        assert set(out.keys()) == {"quests"}
+        by_id = {q["id"]: q for q in out["quests"]}
+
+        # BOTH quests are present — the completed one does NOT drop out (the get_state gap).
+        assert set(by_id) == {done_qid, active_qid}, \
+            "get_quests must return every quest regardless of status"
+
+        done = by_id[done_qid]
+        assert done["status"] == "completed"
+        # The milestone-award idempotency flag is exposed so an eval can read it (its value
+        # tracks leveling_mode — only stamped in xp-mode — so we assert presence, not value).
+        assert isinstance(done["milestone_awarded"], bool)
+
+        active = by_id[active_qid]
+        assert active["status"] == "active"
+        # The objective split lets an eval compute progress: one done, one outstanding.
+        assert active["objectives"] == ["step one", "step two"]
+        assert active["completed_objectives"] == ["step one"]
+
+    def test_get_state_active_quests_unchanged(self, cid):
+        # The pinned invariant: get_state still projects ONLY the active quest — get_quests
+        # is purely additive and does not alter get_state's active-only slice.
+        done_qid = _add_active_quest(cid, "Slay the Beast", ["find the lair"])
+        active_qid = _add_active_quest(cid, "Ongoing Watch", ["hold the line"])
+        server.complete_quest(cid, done_qid, "completed")
+
+        active_from_state = server.get_state(cid)["active_quests"]
+        assert [q["id"] for q in active_from_state] == [active_qid], \
+            "get_state.active_quests must still show only the active quest"
+
+    def test_read_only_no_mutation(self, cid):
+        # get_quests is pure projection — calling it must not mutate persisted state.
+        qid = _add_active_quest(cid, "Untouched", ["a", "b"])
+        before = store.load_campaign(cid).model_dump()
+        server.get_quests(cid)
+        after = store.load_campaign(cid).model_dump()
+        assert before == after, "get_quests must not mutate campaign state"
+        # Sanity: the projected entry carries the full field set an eval needs.
+        entry = next(q for q in server.get_quests(cid)["quests"] if q["id"] == qid)
+        assert set(entry) == {
+            "id", "title", "status", "objectives", "completed_objectives",
+            "giver_id", "location_id", "milestone_awarded",
+            "last_progress_day", "last_progress_beat",
+        }


### PR DESCRIPTION
## What

Additive, READ-ONLY MCP RPC **`get_quests(campaign_id) -> {"quests": [...]}`** in `servers/engine/server.py` (sibling to `get_state`), exposing the **FULL** quest set machine-readably.

## Why (A-series A0.1)

`get_state`'s `active_quests` projects **active quests only** — a quest drops out of the snapshot the moment it completes or fails. The adventure-eval `quest_trace` telemetry stage needs to watch **objective → progress → completion/failure**, which the active-only slice structurally hides. This RPC is that poll surface.

## Return shape

Each entry mirrors the quest fields `get_state` projects plus the resolution/progress fields an eval needs to compute progress:

```
{"quests": [
  {"id", "title", "status", "objectives", "completed_objectives",
   "giver_id", "location_id", "milestone_awarded",
   "last_progress_day", "last_progress_beat"}, ...
]}
```

Every quest regardless of status (`active | completed | failed`). Pure projection — **no state mutation, no side effects** (matches sibling read-RPC style; `_require` load only).

## Registration

Via `@mcp.tool()` exactly like `get_state` — the engine has no separate tool manifest / export list, so the decorator IS the surface. Additive only.

## Invariants held

- Does **not** touch `questgen.py` or any write path.
- The engine-never-evaluates-quest-predicates invariant (`questgen.py:7`) is untouched — this is pure projection.
- `get_state.active_quests` behavior is **unchanged** (pinned by a new test).

## Tests

3 new in `servers/engine/tests/test_f05_story_machinery.py` (`TestA0_1_GetQuestsFullSet`):
1. Seed 2 quests, complete one + advance one objective of the other → `get_quests` returns **both** with correct statuses and objective splits.
2. `get_state.active_quests` still shows **only** the active quest (unchanged behavior pinned).
3. Read-only / no-mutation (full snapshot equality before/after) + full field-set projection assertion.

`uv run --directory servers/engine --group dev python -m pytest servers/engine/tests/test_f05_story_machinery.py -q -p no:xdist` → **27 passed** (24 pre-existing + 3 new).

Refs the A-series plan (A0.1). Do not merge without review.