### PR TITLE
ci: drop pull_request from woodpecker (Actions owns PR checks)

### DIFF
--- a/.woodpecker/license-check.yml
+++ b/.woodpecker/license-check.yml
@@ -1,5 +1,5 @@
 when:
-  - event: [push, pull_request, manual]
+  - event: [push, manual]
 
 steps:
   - name: license-check

--- a/.woodpecker/paint-drift-gate.yml
+++ b/.woodpecker/paint-drift-gate.yml
@@ -1,5 +1,5 @@
 when:
-  - event: [push, pull_request, manual]
+  - event: [push, manual]
 
 steps:
   - name: paint-drift-gate

--- a/.woodpecker/qa-release-gate-tests.yml
+++ b/.woodpecker/qa-release-gate-tests.yml
@@ -1,5 +1,5 @@
 when:
-  - event: [push, pull_request, manual]
+  - event: [push, manual]
 
 steps:
   - name: qa-release-gate-tests

--- a/.woodpecker/server-contracts.yml
+++ b/.woodpecker/server-contracts.yml
@@ -1,5 +1,5 @@
 when:
-  - event: [push, pull_request, manual]
+  - event: [push, manual]
 
 steps:
   - name: server-contracts

--- a/.woodpecker/test.yml
+++ b/.woodpecker/test.yml
@@ -1,5 +1,5 @@
 when:
-  - event: [push, pull_request, manual]
+  - event: [push, manual]
 
 steps:
   - name: test

--- a/.woodpecker/viewer-tests.yml
+++ b/.woodpecker/viewer-tests.yml
@@ -1,5 +1,5 @@
 when:
-  - event: [push, pull_request, manual]
+  - event: [push, manual]
 
 steps:
   - name: viewer-tests


### PR DESCRIPTION
Owner-sanctioned. The six woodpecker pr/* lanes fail identically on every PR (runner infra, apt-get stage) while push-side passes and Actions ci.yml runs the same six jobs on every PR — pure duplicated noise (6 false ci-monitor alarms per PR head, filtered by every agent). Push+manual triggers retained for main-branch redundancy.