### PR TITLE
client: occluded-actor silhouette + painted-door hotspots (#1647, #1585)

### DIFF
--- a/extensions/renderers/unity/plates_manifest.json
+++ b/extensions/renderers/unity/plates_manifest.json
@@ -40,6 +40,10 @@
     "yaw": 45
    },
    "boxes": "boxes/tavern_v2_boxes.json",
+   "_door_hotspots_comment": "#1585/#1647 PAINTED-DOOR HOTSPOTS (plate-pixel click targets in the 1344x768 registered plate). Measured 2026-07-22 by overlaying the contract-camera cell projection (qa/walk_test.world_to_window_px at texW/texH) on tavern_v2_registered.png and reading the PAINTED arch centroid off a 50px grid (artifacts/zoom_tavern_left.png). door_cell (7,0) projects to px (440,242) at the bar, but the room's one painted STONE ARCHWAY (dark interior) sits on the SAME back-left (r=0) wall with its opening centroid at ~(210,320) — a large ~4.5-cell #1585 divergence, the exact 'no functional doors' case: clicking the visible arch now crosses at (7,0). door_cell (13,5) lands on the painted fireplace/hearth (no arch) -> intentionally omitted (TODO, see PR body).",
+   "door_hotspots": [
+    { "door_cell": [7, 0], "px": [210, 320], "radius_px": 85 }
+   ],
    "_provenance": "SHIP-THREE-PLATES (2026-07-15): tavern v2 14x11 molded (bar/table kinds) via qa/paint_room.py. Panel 8.4. Geometry qa/room_geometries/tavern_v2_geometry.json; ortho = _fit_ortho_size(14,11). Replaces tavern_fit2_v1 (12x10, ortho 9.2597)."
   },
   "throne_hall": {
@@ -60,6 +64,10 @@
     "yaw": 45
    },
    "boxes": "boxes/shop_v1_boxes.json",
+   "_door_hotspots_comment": "#1585/#1647 PAINTED-DOOR HOTSPOTS (plate-pixel click targets in the 1344x768 registered plate; a click inside a hotspot routes exactly like clicking door_cell -> cross_door). Measured 2026-07-22 by overlaying the contract-camera cell projection (qa/walk_test.world_to_window_px at texW/texH) on shop_v1_registered.png and reading the PAINTED arch centroid off a 50px grid (artifacts/zoom_shop_door12_5.png). door_cell (12,5) projects to px (1037,230) but the painted dark archway opening centroid sits at ~(900,275) — the ~2-cell #1585 divergence. door_cell (6,0) is occluded by the potion shelf (no visible arch) -> intentionally omitted (TODO, see PR body).",
+   "door_hotspots": [
+    { "door_cell": [12, 5], "px": [900, 275], "radius_px": 85 }
+   ],
    "_provenance": "ROOM-READINESS SCALE PROOF (2026-07-16, epic #1581/#1588): the first room authored AFTER the pipeline existed, run hands-off end-to-end \u2014 author_shop() 13x10 (design-gated 2x locally) -> build_room_unified on the box (ortho 9.6806, 49 boxes incl. auto door frames) -> qa/paint_room.py shop (base seed 12347 recall 0.9555; Gemini structure-lock) -> blind panel 6 vs PoE2 control 8, delta -2.0 IN-BAND (tier=stable, cycle-2 levers in qa/evidence/paint-room/shop/panel.json). Geometry qa/room_geometries/shop_geometry.json; ortho = _fit_ortho_size(13,10). Walk gate: #1596 sandbox lane after the player rebuild packages this entry."
   },
   "tavern_snug": {

--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -74,7 +74,7 @@ public class CombatSurfaceClient : MonoBehaviour
     Material _silFoe, _silParty; bool _silMatMissing; // #1545: per-team walk-behind silhouette materials (ZTest Greater)
     // #1647 item 2 / #1572: the walk-behind silhouette (ON by default; WORLDOS_SILHOUETTE=0 kills it — a beauty-
     // capture / debug escape hatch). Read once at construction (env-field-initializer idiom, mirrors _truthOverlay).
-    bool _silhouetteOn = System.Environment.GetEnvironmentVariable("WORLDOS_SILHOUETTE") != "0";
+    readonly bool _silhouetteOn = System.Environment.GetEnvironmentVariable("WORLDOS_SILHOUETTE") != "0";
     AnimationClip _donorIdle; bool _donorTried; // goblin.fbx embedded Idle, for clipless-humanoid retarget
 
     // RING-V2 warm-floor port (#1515 fix 2 / #1524, from CohesionProbe.cs): a hearth-INDEPENDENT warm floor
@@ -1541,7 +1541,14 @@ public class CombatSurfaceClient : MonoBehaviour
     static Bounds Measure(GameObject go, Renderer[] rends)
     {
         Bounds b = new Bounds(go.transform.position, Vector3.zero); bool a = false;
-        foreach (var r in rends) { var rb = WorldBounds(r); if (!a) { b = rb; a = true; } else b.Encapsulate(rb); }
+        foreach (var r in rends)
+        {
+            // Skip the #1572 "_sil" silhouette clones: they share the source mesh/bounds (encapsulation is a
+            // no-op) but WorldBounds would still BakeMesh each one, doubling the per-actor bake+GC on every
+            // GroundSnap/GlideTo/room-swap settle. Mirrors AttachSilhouette's own null/particle skip.
+            if (r == null || r.gameObject.name.EndsWith("_sil")) continue;
+            var rb = WorldBounds(r); if (!a) { b = rb; a = true; } else b.Encapsulate(rb);
+        }
         return b;
     }
 
@@ -2278,6 +2285,12 @@ public class CombatSurfaceClient : MonoBehaviour
         WindowToPlatePx(screenPoint.x, screenPoint.y, w, h, _plateTexW, _plateTexH, out float px, out float py);
         foreach (var hs in _doorHotspots)
         {
+            // The hotspot is a REST-mode cross-door affordance. `_doorHotspots` comes from the plate manifest
+            // and outlives a mode change (a rest plate shown for a combat surface keeps its arches), so gate
+            // consumption on the door being ACTIVE for THIS surface — exactly HandleCell's own cross_door
+            // guard (_restMode + _doorTo). Otherwise fall through to the raycast instead of hijacking the
+            // click into a combat move to the hard door cell.
+            if (!_restMode || !_doorTo.ContainsKey(CellKey(hs.c, hs.r))) continue;
             float dx = px - hs.px, dy = py - hs.py;
             if (dx * dx + dy * dy <= hs.radius * hs.radius) { HandleCell(hs.c, hs.r); return true; }
         }

--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -1488,7 +1488,7 @@ public class CombatSurfaceClient : MonoBehaviour
             if (smr != null)
             {
                 if (smr.sharedMesh == null) continue;
-                var host = new GameObject(r.gameObject.name + "_sil");
+                var host = new GameObject(r.gameObject.name + "__silclone");
                 host.transform.SetParent(r.transform, false);   // identity local; skinning is driven by the shared bones
                 var s2 = host.AddComponent<SkinnedMeshRenderer>();
                 s2.sharedMesh = smr.sharedMesh;
@@ -1503,7 +1503,7 @@ public class CombatSurfaceClient : MonoBehaviour
             {
                 var mf = r.GetComponent<MeshFilter>();
                 if (mf == null || mf.sharedMesh == null) continue;
-                var host = new GameObject(r.gameObject.name + "_sil");
+                var host = new GameObject(r.gameObject.name + "__silclone");
                 host.transform.SetParent(r.transform, false);   // identity local -> same world pose as the source mesh
                 host.AddComponent<MeshFilter>().sharedMesh = mf.sharedMesh;
                 var mr2 = host.AddComponent<MeshRenderer>();
@@ -1543,10 +1543,11 @@ public class CombatSurfaceClient : MonoBehaviour
         Bounds b = new Bounds(go.transform.position, Vector3.zero); bool a = false;
         foreach (var r in rends)
         {
-            // Skip the #1572 "_sil" silhouette clones: they share the source mesh/bounds (encapsulation is a
+            // Skip the #1572 "__silclone" silhouette clones: they share the source mesh/bounds (encapsulation
             // no-op) but WorldBounds would still BakeMesh each one, doubling the per-actor bake+GC on every
             // GroundSnap/GlideTo/room-swap settle. Mirrors AttachSilhouette's own null/particle skip.
-            if (r == null || r.gameObject.name.EndsWith("_sil")) continue;
+            if (r == null || r.gameObject.name.EndsWith("__silclone")) continue;  // distinctive sentinel:
+            // AttachSilhouette names its clones "<src>__silclone" — far less collision-prone than a bare "_sil"
             var rb = WorldBounds(r); if (!a) { b = rb; a = true; } else b.Encapsulate(rb);
         }
         return b;

--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -72,6 +72,9 @@ public class CombatSurfaceClient : MonoBehaviour
     Texture2D _blobT, _ringT, _pipT;          // procedural AO blob + contact decal + feet-pip, built once, shared
     Texture2D _decalFoe, _decalParty;         // RING-V2: per-team #1524 contact-decal textures (faction hue baked in)
     Material _silFoe, _silParty; bool _silMatMissing; // #1545: per-team walk-behind silhouette materials (ZTest Greater)
+    // #1647 item 2 / #1572: the walk-behind silhouette (ON by default; WORLDOS_SILHOUETTE=0 kills it — a beauty-
+    // capture / debug escape hatch). Read once at construction (env-field-initializer idiom, mirrors _truthOverlay).
+    bool _silhouetteOn = System.Environment.GetEnvironmentVariable("WORLDOS_SILHOUETTE") != "0";
     AnimationClip _donorIdle; bool _donorTried; // goblin.fbx embedded Idle, for clipless-humanoid retarget
 
     // RING-V2 warm-floor port (#1515 fix 2 / #1524, from CohesionProbe.cs): a hearth-INDEPENDENT warm floor
@@ -134,6 +137,18 @@ public class CombatSurfaceClient : MonoBehaviour
     GameObject _doorRoot;                 // parent of the glow quads + labels (one-call teardown/rebuild)
     System.Collections.Generic.List<Material> _doorGlowMats;  // per-door glow material (per-frame alpha pulse)
     string _doorSig = "\0";               // signature of the door set the affordance was last built for
+    // #1585/#1647 item 3 PAINTED-DOOR HOTSPOTS: the engine door CELL is authored; the painted archway on the
+    // plate can sit a cell or two off it (Flux/Gemini place the arch by composition, not by the geometry). So a
+    // click on the VISIBLE arch lands on a wall/prop cell and flash-rejects -> "no functional doors" (#1585 P1).
+    // A hotspot maps a circular region of PLATE PIXELS (px + radius_px, the space the arch is measured in) to a
+    // door_cell; a click inside it routes EXACTLY like clicking that door_cell (HandleCell -> cross_door). Data
+    // rides plates_manifest.json per-plate `door_hotspots`; absent field => zero behavior change. Set on the plate
+    // swap (ApplyPlate), so the hit-test + glow markers only ever run for the room whose plate is showing.
+    struct DoorHotspot { public int c, r; public float px, py, radius; }
+    System.Collections.Generic.List<DoorHotspot> _doorHotspots;   // active plate's hotspots (null/empty => none)
+    float _plateTexW, _plateTexH;                                 // active plate pixel dims (the hotspot px space)
+    GameObject _doorHotspotRoot;                                  // parent of the arch glow markers (rebuilt per swap)
+    System.Collections.Generic.List<Material> _doorHotspotMats;   // per-marker glow material (per-frame alpha pulse)
     // WALKABLE-SLICE-V1 (item 2): rest-mode NPC talk-targets by cell (rest_role:"npc" stage tokens). A
     // click on an NPC's cell POSTs `parley_approach` (the engine walks the lead PC adjacent + opens the
     // parley) instead of a walk. cellKey -> npc id. Rebuilt each ParseSurfaceExtras from the stage block.
@@ -322,7 +337,9 @@ public class CombatSurfaceClient : MonoBehaviour
                        // proxy occluders are built from THESE boxes verbatim (RebuildOccluders), so what masks
                        // an actor at runtime is byte-derived from what shaped the paint. Absent => legacy
                        // per-cell footprint proxies (byte-identical prior behavior).
-                       public string boxesPath; }
+                       public string boxesPath;
+                       // #1585/#1647: optional painted-door hotspots (plate-pixel click targets -> door_cell).
+                       public System.Collections.Generic.List<DoorHotspot> doorHotspots; }
     // world-space occluder boxes of the ACTIVE plate ({center,size} rows, kind!=floor), null => legacy path.
     System.Collections.Generic.List<float[]> _plateBoxes;
     string _plateBoxesLocId = "\0";  // the location _plateBoxes reflects (sentinel => unset); guards the stale-leak (#1575)
@@ -1131,17 +1148,67 @@ public class CombatSurfaceClient : MonoBehaviour
     // doors. Called from Update.
     void UpdateDoorGlow()
     {
+        float pulse = 0.30f + 0.32f * (0.5f + 0.5f * Mathf.Sin(Time.time * 3.0f));  // ~0.30..0.62 alpha
+        // #1585/#1647: pulse the painted-arch hotspot markers on the SAME cadence (independent of _doorRoot — a
+        // hotspot can exist without a rebuilt door-cell affordance this frame).
+        if (_doorHotspotMats != null)
+            for (int i = 0; i < _doorHotspotMats.Count; i++)
+                if (_doorHotspotMats[i] != null) { var hc = DoorGlowCol; hc.a = pulse; _doorHotspotMats[i].color = hc; }
         if (_doorRoot == null) return;
         if (_doorGlowMats != null)
-        {
-            float pulse = 0.30f + 0.32f * (0.5f + 0.5f * Mathf.Sin(Time.time * 3.0f));  // ~0.30..0.62 alpha
             for (int i = 0; i < _doorGlowMats.Count; i++)
                 if (_doorGlowMats[i] != null) { var col = DoorGlowCol; col.a = pulse; _doorGlowMats[i].color = col; }
-        }
         var cam = Camera.main;
         if (cam != null)
             foreach (Transform t in _doorRoot.transform)
                 if (t.GetComponent<TextMesh>() != null) t.rotation = cam.transform.rotation;
+    }
+
+    // #1585/#1647: (re)build a soft gold glow marker on the floor under each painted-door hotspot, so the player
+    // sees an affordance ON the arch (the door-cell glow can sit a couple cells off it). Rebuilt each plate swap
+    // (ApplyPlate). Reuses the door-glow idiom (a flat GlowTex quad, queue 1949, alpha pulsed in UpdateDoorGlow).
+    // The marker sits at the arch's projected FLOOR point, so in the iso view it reads at the arch's screen spot.
+    void BuildDoorHotspots()
+    {
+        if (_doorHotspotRoot != null) { Object.Destroy(_doorHotspotRoot); _doorHotspotRoot = null; }
+        _doorHotspotMats = null;
+        if (_doorHotspots == null || _doorHotspots.Count == 0) return;
+        var cam = Camera.main; if (cam == null) return;
+        _doorHotspotRoot = new GameObject("DoorHotspots");
+        _doorHotspotMats = new System.Collections.Generic.List<Material>();
+        foreach (var hs in _doorHotspots)
+        {
+            if (!HotspotFloorPoint(hs, cam, out Vector3 wp)) continue;
+            var q = GameObject.CreatePrimitive(PrimitiveType.Quad); q.name = "DoorHotspotGlow_" + hs.c + "_" + hs.r;
+            Object.DestroyImmediate(q.GetComponent<Collider>());
+            q.transform.SetParent(_doorHotspotRoot.transform, false);
+            q.transform.position = new Vector3(wp.x, FloorY + 0.035f, wp.z);
+            q.transform.localEulerAngles = new Vector3(90f, 0f, 0f);
+            q.transform.localScale = new Vector3(CellSize * 1.4f, CellSize * 1.4f, 1f);
+            var m = new Material(Shader.Find("Sprites/Default")); m.mainTexture = GlowTex();
+            m.color = DoorGlowCol; m.renderQueue = 1949;
+            var rend = q.GetComponent<Renderer>(); rend.sharedMaterial = m; rend.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            _doorHotspotMats.Add(m);
+        }
+    }
+
+    // Project a hotspot's plate pixel onto the floor plane (y=FloorY): plate px -> window px (crop model, the
+    // inverse of WindowToPlatePx) -> viewport -> a camera ray -> the floor intersection. Returns false when the
+    // window/plate dims are unset or the ray runs parallel to the floor. Camera must be in its final plate rig.
+    bool HotspotFloorPoint(DoorHotspot hs, Camera cam, out Vector3 world)
+    {
+        world = Vector3.zero;
+        if (_plateTexH <= 0f) return false;
+        float w = Screen.width, h = Screen.height;
+        if (w <= 0f || h <= 0f) return false;
+        float s = h / _plateTexH;                                  // crop-model uniform px scale (mirrors WindowToPlatePx)
+        float winX = 0.5f * w + (hs.px - 0.5f * _plateTexW) * s;   // plate px -> window px (bottom-left screen origin)
+        float winYimg = hs.py * s;                                 // top-left image y in window px
+        Ray ray = cam.ViewportPointToRay(new Vector3(winX / w, 1f - winYimg / h, 0f));
+        if (Mathf.Abs(ray.direction.y) < 1e-4f) return false;
+        float tt = (FloorY - ray.origin.y) / ray.direction.y; if (tt < 0f) return false;
+        world = ray.origin + ray.direction * tt;
+        return true;
     }
 
     // Toggle (G): first turn-on builds the pool lazily and repaints; turn-off just hides the root (kept for a
@@ -1395,6 +1462,66 @@ public class CombatSurfaceClient : MonoBehaviour
         return m;
     }
 
+    // #1572 (the #1545 multi-submesh fix): attach the walk-behind silhouette as a DEDICATED renderer that mirrors
+    // EVERY submesh of EVERY source renderer, rather than one extra material on the source. THE REGRESSION:
+    // #1545 appended the silhouette material to r.sharedMaterials, and Unity maps a material BEYOND the submesh
+    // count to the LAST submesh ONLY. That fully covered the single-submesh actors of the day (5bea5857 documented
+    // the assumption; the box run confirmed rends=1). When the roster changed to anim-pack rigged / Meshy FBX
+    // humanoids (multiple submeshes: body/clothing/hair/…), the extra pass silhouetted only the last submesh, so
+    // the owner saw the actor still vanish behind occluders — "invisible half the time." No gate asserted whole-
+    // actor coverage, so it decayed silently (#1572, deferred). This clone builds a sibling SkinnedMeshRenderer
+    // (SAME mesh + bones + rootBone => it skins identically every frame, zero per-frame sync) or MeshRenderer with
+    // the silhouette material filled across ALL submeshes, so the tint covers the whole actor regardless of how
+    // many materials the source model carries. The clone shares the source's exact mesh + bounds, so it is
+    // transparent to Measure/GroundedPivot (bounds-encapsulation no-op) and moves with the actor as a child.
+    // WORLDOS_SILHOUETTE=0 or a stripped/absent shader (Always-Included via Tools/WorldOS/W5b; EnsureSilhouette-
+    // Material warns once) => no clone spawned, byte-identical to a silhouette-off scene.
+    void AttachSilhouette(GameObject go, Renderer[] rends, bool foe)
+    {
+        if (!_silhouetteOn) return;
+        var sil = EnsureSilhouetteMaterial(foe);
+        if (sil == null) return;
+        foreach (var r in rends)
+        {
+            if (r == null || r is ParticleSystemRenderer) continue;
+            var smr = r as SkinnedMeshRenderer;
+            if (smr != null)
+            {
+                if (smr.sharedMesh == null) continue;
+                var host = new GameObject(r.gameObject.name + "_sil");
+                host.transform.SetParent(r.transform, false);   // identity local; skinning is driven by the shared bones
+                var s2 = host.AddComponent<SkinnedMeshRenderer>();
+                s2.sharedMesh = smr.sharedMesh;
+                s2.bones = smr.bones;                            // SAME bone transforms -> deforms identically, no sync
+                s2.rootBone = smr.rootBone;
+                s2.localBounds = smr.localBounds;
+                s2.updateWhenOffscreen = true;                   // mirrors the source; never freeze the silhouette pose
+                s2.sharedMaterials = FillSilMats(sil, smr.sharedMesh.subMeshCount);
+                s2.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off; s2.receiveShadows = false;
+            }
+            else
+            {
+                var mf = r.GetComponent<MeshFilter>();
+                if (mf == null || mf.sharedMesh == null) continue;
+                var host = new GameObject(r.gameObject.name + "_sil");
+                host.transform.SetParent(r.transform, false);   // identity local -> same world pose as the source mesh
+                host.AddComponent<MeshFilter>().sharedMesh = mf.sharedMesh;
+                var mr2 = host.AddComponent<MeshRenderer>();
+                mr2.sharedMaterials = FillSilMats(sil, mf.sharedMesh.subMeshCount);
+                mr2.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off; mr2.receiveShadows = false;
+            }
+        }
+    }
+
+    // One silhouette material per submesh, so the clone tints the WHOLE mesh (every submesh), not just the last.
+    static Material[] FillSilMats(Material sil, int subMeshCount)
+    {
+        int n = subMeshCount > 0 ? subMeshCount : 1;
+        var a = new Material[n];
+        for (int i = 0; i < n; i++) a[i] = sil;
+        return a;
+    }
+
     // World-space bounds of a renderer. Skinned: BakeMesh the POSED verts and transform by
     // TRS(pos,rot,Vector3.one) — scale is DROPPED (#1412: BakeMesh already reflects lossyScale, so the
     // full matrix double-applies it). MeshRenderer.bounds is accurate as-is. Mirrors paint_combat_v1.
@@ -1509,23 +1636,12 @@ public class CombatSurfaceClient : MonoBehaviour
             }
         }
 
-        // #1545 walk-behind silhouette: append the ZTest-Greater team material as a SECOND pass on each actor
-        // renderer, so an actor overdrawn by a depth-proxy box renders a flat tinted silhouette instead of
-        // vanishing. Added after the albedo assignment so it's the last material. No-ops (skips) if the shader
-        // isn't in the build (EnsureSilhouetteMaterial warns once).
-        // NOTE (single-submesh assumption): Unity maps the extra material to the renderer's LAST submesh only,
-        // so this fully covers actors whose renderer has one submesh — which is every current actor (the albedo
-        // path above assigns a single sharedMaterial per renderer, and the box run confirmed rends=1 / one
-        // material each). A future MULTI-submesh actor (separate body/clothing/weapon materials) would silhouette
-        // only its last submesh; the general fix is a dedicated per-submesh silhouette renderer (deferred — it
-        // does not trigger with current assets and needs box re-validation).
-        var sil = EnsureSilhouetteMaterial(foe);
-        if (sil != null)
-            foreach (var r in rends)
-            {
-                var ms = new System.Collections.Generic.List<Material>(r.sharedMaterials);
-                ms.Add(sil); r.sharedMaterials = ms.ToArray();
-            }
+        // #1545/#1572 walk-behind silhouette: a flat ZTest-Greater team tint that renders where a depth-proxy
+        // box has overdrawn the actor, so a character behind a wall/prop stays a readable silhouette instead of
+        // vanishing (BG2/PoE convention; the owner's "character invisible half the time" report). AttachSilhouette
+        // mirrors EVERY submesh of EVERY renderer (#1572 fix), covering today's MULTI-submesh Meshy/anim-pack
+        // humanoids that the old single-extra-material trick left mostly untinted. No-op if disabled or stripped.
+        AttachSilhouette(go, rends, foe);
 
         // RING-V2 ground siblings, laid flat on the floor. `_AO` = warm-tinted grounding blob; `_Ring` = the
         // #1524 subtle faction contact decal (2.6->2.3, the merged evidence size) that carries grounding +
@@ -2139,12 +2255,47 @@ public class CombatSurfaceClient : MonoBehaviour
     void HandleClickAt(Vector3 screenPoint)
     {
         var cam = Camera.main; if (cam == null) return;
+        // #1585/#1647: a click inside a painted-door hotspot routes EXACTLY like clicking its door_cell. Checked
+        // BEFORE the floor raycast so a click on the VISIBLE arch (which projects to a wall/prop cell off the
+        // authored door) crosses instead of flash-rejecting. No hotspots for this plate => straight to the raycast.
+        if (TryDoorHotspot(screenPoint)) return;
         Ray ray = cam.ScreenPointToRay(screenPoint);
         if (Mathf.Abs(ray.direction.y) < 1e-4f) return;
         float tt = (FloorY - ray.origin.y) / ray.direction.y; if (tt < 0) return;
         Vector3 hit = ray.origin + ray.direction * tt;
         if (!WorldToCell(hit, out int c, out int r)) return;
         HandleCell(c, r);
+    }
+
+    // #1585/#1647: test a screen click against the active plate's door hotspots; on a hit, route to that
+    // hotspot's door_cell via HandleCell (so it inherits the exact rest-vs-combat + cross_door path a real
+    // door-cell click takes) and return true. No hotspots / no plate dims => false (the caller raycasts normally).
+    bool TryDoorHotspot(Vector3 screenPoint)
+    {
+        if (_doorHotspots == null || _doorHotspots.Count == 0 || _plateTexH <= 0f || _plateTexW <= 0f) return false;
+        float w = Screen.width, h = Screen.height;
+        if (w <= 0f || h <= 0f) return false;
+        WindowToPlatePx(screenPoint.x, screenPoint.y, w, h, _plateTexW, _plateTexH, out float px, out float py);
+        foreach (var hs in _doorHotspots)
+        {
+            float dx = px - hs.px, dy = py - hs.py;
+            if (dx * dx + dy * dy <= hs.radius * hs.radius) { HandleCell(hs.c, hs.r); return true; }
+        }
+        return false;
+    }
+
+    // PURE hit-test math (mirror twin: qa/walk_test.window_px_to_plate_px, unit-tested in qa/test_walk_test.py).
+    // Window pixel -> plate pixel under the CROP model ApplyPlate renders: the ortho camera fixes the vertical
+    // half-height (plate spans oh = 2*ortho == full frustum height), and the plate billboard is sized by TEXTURE
+    // aspect (ow = oh*texW/texH), centered horizontally -> a uniform px/px scale s = h/texH on BOTH axes (plate
+    // pixels are square on the billboard), with the plate cropped/centered when the window aspect != plate aspect.
+    // screenX/screenY are Unity screen pixels (BOTTOM-LEFT origin); plate px is top-left origin (image space).
+    // Static + no Unity types => the python twin can round-trip it.
+    static void WindowToPlatePx(float screenX, float screenY, float w, float h, float texW, float texH, out float px, out float py)
+    {
+        float s = h / texH;                            // window px per plate px (uniform; plate pixels are square)
+        px = 0.5f * texW + (screenX - 0.5f * w) / s;   // plate centered horizontally in the window
+        py = (h - screenY) / s;                        // flip bottom-left (screen) -> top-left (plate image) origin
     }
 
     // The cell-level half of a click: identical rest-vs-combat pre-validation + POST whether the cell
@@ -3258,6 +3409,27 @@ public class CombatSurfaceClient : MonoBehaviour
                         if (!string.IsNullOrEmpty(es.type) && es.cell != null) pe.effects.Add(es);
                     }
                 }
+                // #1585/#1647: OPTIONAL `door_hotspots`:[{door_cell:[c,r], px:[x,y], radius_px}] painted-arch
+                // click targets in PLATE pixel space. Absent => pe.doorHotspots null => hit-test + markers no-op.
+                if (row.ContainsKey("door_hotspots") && row["door_hotspots"] is System.Collections.Generic.List<object> dh)
+                {
+                    pe.doorHotspots = new System.Collections.Generic.List<DoorHotspot>();
+                    foreach (var he in dh)
+                    {
+                        var hr = he as System.Collections.Generic.Dictionary<string, object>; if (hr == null) continue;
+                        var dc = hr.ContainsKey("door_cell") ? hr["door_cell"] as System.Collections.Generic.List<object> : null;
+                        var pxo = hr.ContainsKey("px") ? hr["px"] as System.Collections.Generic.List<object> : null;
+                        if (dc == null || dc.Count < 2 || pxo == null || pxo.Count < 2) continue;
+                        var hs = new DoorHotspot
+                        {
+                            c = System.Convert.ToInt32(dc[0]), r = System.Convert.ToInt32(dc[1]),
+                            px = System.Convert.ToSingle(pxo[0]), py = System.Convert.ToSingle(pxo[1]),
+                            radius = hr.ContainsKey("radius_px") ? System.Convert.ToSingle(hr["radius_px"]) : 48f
+                        };
+                        if (hs.radius > 0f) pe.doorHotspots.Add(hs);
+                    }
+                    if (pe.doorHotspots.Count == 0) pe.doorHotspots = null;
+                }
                 _plateManifest[kv.Key] = pe;
             }
             Debug.Log("[CSC] plates_manifest.json loaded: " + _plateManifest.Count + " plate(s)");
@@ -3387,6 +3559,12 @@ public class CombatSurfaceClient : MonoBehaviour
         var ls = bd.transform.localScale;
         bd.transform.localScale = new Vector3(ow, oh, ls.z == 0f ? 1f : ls.z);
         Debug.Log("[CSC] plate swapped -> " + entry.plate + " (" + tex.width + "x" + tex.height + ", loc=" + _locId + ")");
+        // #1585/#1647 painted-door hotspots: record THIS plate's pixel dims (the space the hotspot px are
+        // measured in) + its hotspot set, then (re)build the arch glow markers. The camera rig above is final,
+        // so the px->floor projection the markers use is correct. No hotspots => cleared markers (byte-identical).
+        _plateTexW = tex.width; _plateTexH = tex.height;
+        _doorHotspots = entry.doorHotspots;
+        BuildDoorHotspots();
         // UNIFY-THE-FRAMES: load this plate's occluder-box sidecar (world-space {center,size} rows from
         // build_room_unified.cs — the same boxes the depth conditioning was rendered from). Parsed once per
         // swap; RebuildOccluders prefers these over per-cell footprint proxies. Reset the occluder signature

--- a/qa/test_walk_test.py
+++ b/qa/test_walk_test.py
@@ -120,6 +120,54 @@ def test_world_to_window_px_origin_is_center():
         assert abs(x - w / 2) < 1e-6 and abs(y - h / 2) < 1e-6
 
 
+# --- #1585/#1647 painted-door hotspot pure math (twin of C# WindowToPlatePx / TryDoorHotspot) ---------
+def test_window_plate_px_round_trips():
+    """screen px -> plate px -> screen px is identity at any aspect (the crop model is a bijection on the
+    displayed region). Guards the C# hit-test against a sign/flip/scale regression it can't unit-test."""
+    for w, h in ((1344, 768), (1280, 800), (1920, 1080)):
+        for sx, sy in ((10, 10), (w / 2, h / 2), (w - 3, h - 7), (417, 605)):
+            px, py = W.window_px_to_plate_px(sx, sy, w, h, 1344, 768)
+            bx, by = W.plate_px_to_screen_px(px, py, w, h, 1344, 768)
+            assert abs(bx - sx) < 1e-4 and abs(by - sy) < 1e-4
+
+
+def test_window_to_plate_px_native_window_is_identity():
+    """When the window IS the plate's native resolution, a screen click maps to the same plate pixel
+    (modulo the bottom-left->top-left y flip) — the space the hotspot px are authored in."""
+    px, py = W.window_px_to_plate_px(900, 768 - 275, 1344, 768, 1344, 768)
+    assert abs(px - 900) < 1e-6 and abs(py - 275) < 1e-6
+
+
+def test_plate_center_maps_to_window_center():
+    """The plate is centered in the window, so its pixel centre projects to the screen centre at any aspect."""
+    for w, h in ((1344, 768), (1600, 900), (1200, 1000)):
+        sx, sy = W.plate_px_to_screen_px(672, 384, w, h, 1344, 768)
+        assert abs(sx - w / 2) < 1e-6 and abs(sy - h / 2) < 1e-6
+
+
+def test_door_hotspot_hit_inside_and_outside():
+    """The circular hit-test: inside the radius fires, just outside does not (mirror of TryDoorHotspot)."""
+    hs, rad = (900, 275), 85
+    assert W.door_hotspot_hit((900, 275), hs, rad)          # dead centre
+    assert W.door_hotspot_hit((900 + 60, 275 - 60), hs, rad)  # within (dist ~84.9)
+    assert not W.door_hotspot_hit((900 + 61, 275 - 61), hs, rad)  # just outside (dist ~86.3)
+    assert not W.door_hotspot_hit((900, 275 + 86), hs, rad)
+
+
+def test_shop_arch_click_routes_to_authored_door():
+    """End-to-end pure path for the shipped shop hotspot: a click ON the painted arch (screen px at the
+    native window) converts to the measured plate px and lands inside the {door_cell:[12,5]} hotspot —
+    while a click at the projected door-cell base (px 1037,230, the wall the paint drifted off) misses."""
+    w, h, tw, th = 1344, 768, 1344, 768
+    hs_px, rad = (900, 275), 85
+    # click on the painted arch centroid (screen y = h - plate_py)
+    click = W.window_px_to_plate_px(900, h - 275, w, h, tw, th)
+    assert W.door_hotspot_hit(click, hs_px, rad)
+    # a click at the authored door_cell's projected base is off the painted arch -> no hotspot
+    off = W.window_px_to_plate_px(1037, h - 230, w, h, tw, th)
+    assert not W.door_hotspot_hit(off, hs_px, rad)
+
+
 def test_diff_blobs_finds_a_moved_square():
     """Synthetic red-first: a 30x30 'actor' moves from (100,100) to (300,200) between frames —
     diff_blobs must report exactly the departure + arrival blobs, bottom-centres on the squares."""

--- a/qa/walk_test.py
+++ b/qa/walk_test.py
@@ -91,6 +91,40 @@ def cell_px(ortho: float, h: int) -> float:
     return h * (2.0 / (2.0 * ortho))
 
 
+# --- #1585/#1647 painted-door hotspots: the pure px<->px math the client uses to route a click on the
+# --- painted arch to its authored door_cell. TWIN of C# CombatSurfaceClient.WindowToPlatePx (+ its
+# --- BuildDoorHotspots inverse). Same CROP model as world_to_window_px above: the ortho camera fixes the
+# --- vertical half-height so the plate billboard spans the full frustum height (oh = 2*ortho), the plate
+# --- is sized by TEXTURE aspect and centered horizontally -> a uniform px/px scale s = h/tex_h on BOTH
+# --- axes (plate pixels are square on the billboard), cropped/centered when the window aspect != plate
+# --- aspect. `screen_*` are Unity screen pixels (BOTTOM-LEFT origin); plate px is top-left (image) origin.
+def plate_px_to_screen_px(px: float, py: float, w: float, h: float, tex_w: float, tex_h: float) -> tuple:
+    """Plate pixel (top-left origin) -> Unity screen pixel (bottom-left origin). Inverse of
+    window_px_to_plate_px; used by BuildDoorHotspots to place the arch glow marker."""
+    s = h / tex_h
+    sx = 0.5 * w + (px - 0.5 * tex_w) * s
+    sy = h - py * s   # top-left plate py -> bottom-left screen y
+    return (sx, sy)
+
+
+def window_px_to_plate_px(screen_x: float, screen_y: float, w: float, h: float,
+                          tex_w: float, tex_h: float) -> tuple:
+    """Unity screen pixel (bottom-left origin) -> plate pixel (top-left origin). EXACT mirror of C#
+    CombatSurfaceClient.WindowToPlatePx — the hit-test basis the door-hotspot check runs on."""
+    s = h / tex_h
+    px = 0.5 * tex_w + (screen_x - 0.5 * w) / s
+    py = (h - screen_y) / s   # bottom-left screen -> top-left plate y
+    return (px, py)
+
+
+def door_hotspot_hit(click_px: tuple, hotspot_px: tuple, radius_px: float) -> bool:
+    """The pure painted-door hit-test (mirror of the C# TryDoorHotspot distance check): a click, already
+    in plate pixels, is inside the hotspot iff it lies within radius_px of the hotspot centroid."""
+    dx = click_px[0] - hotspot_px[0]
+    dy = click_px[1] - hotspot_px[1]
+    return dx * dx + dy * dy <= radius_px * radius_px
+
+
 # --- PURE assertion helpers (no I/O; unit-tested in qa/test_walk_test.py) --------------------------
 def check_camera_pose(dbg: dict, ortho: float, *, deg_tol: float = 1.5,
                       vp_tol: float = 0.03, pos_tol: float = 1.5) -> list:


### PR DESCRIPTION
Client half of epic #1647 (user-truth gates). Additive, presentation-only — the Python engine stays the sole writer; the T-pose/registry surfaces are untouched. **Rides the NEXT box build + sandbox walk-gate** (no local Unity compile is possible — changes mirror existing idioms exactly). Do not merge until an owner/orchestrator reviews.

## Item 1 — occluded-actor silhouette: a REGRESSION FIX, not a rebuild (Closes #1572)

**A walk-behind silhouette already existed (#1545) and had silently decayed.** Post-mortem:

1. **#1545 built it** (commit `c6037d26`, PR #1571): a flat ZTest-Greater team-tinted pass so an actor behind a depth-proxy occluder stays a readable silhouette instead of vanishing (`WorldOS/ActorSilhouette` shader; `EnsureSilhouetteMaterial`).
2. **The mechanism only ever covered ONE submesh.** It appended the silhouette material to `renderer.sharedMaterials`. Unity maps a material *beyond the submesh count* to the **last submesh only** — so the pass silhouettes a single submesh, not the whole actor.
3. **The assumption was documented, then invalidated.** Commit `5bea5857` explicitly recorded the *single-submesh assumption* ("the box run confirmed rends=1 / one material each"). Then the actor roster changed to **anim-pack rigged / Meshy FBX humanoids** (multi-submesh: body/clothing/hair/…). The extra-material pass now tints only the last submesh → on the current cast the silhouette is partial/near-invisible → the owner's **"character invisible half the time."**
4. **No gate asserted whole-actor coverage,** so it decayed silently. `#1572` (multi-submesh follow-up) was filed and **deferred** — this PR closes it.

**Line-level evidence:** `CombatSurfaceClient.cs:74` (`_silFoe/_silParty`), the old append at the former `SpawnActor` silhouette block, and `5bea5857`'s single-submesh note.

**The fix — `AttachSilhouette` (replaces the append):** a **dedicated silhouette renderer** cloned per source renderer — a `SkinnedMeshRenderer` sharing the source's `sharedMesh` + `bones` + `rootBone` (so it skins identically every frame, zero per-frame sync), or a `MeshRenderer` sharing the `MeshFilter` mesh — with the silhouette material **filled across every submesh** (`FillSilMats`). The clone shares the source's exact mesh + bounds, so it is transparent to `Measure`/`GroundedPivot` (bounds-encapsulation no-op) and moves with the actor as a child. Guarded by **`WORLDOS_SILHOUETTE` (default ON; `=0` disables)**.

**Shader survival (the second `_silMatMissing` hypothesis):** already handled — `W5bWireScene.cs` registers `WorldOS/ActorSilhouette` into **Always-Included Shaders** (alongside `OccluderDepth`), and `EnsureSilhouetteMaterial` warns loudly + no-ops if `Shader.Find` returns null in the built player. **Box action:** if the silhouette is still absent after this build, confirm `Tools/WorldOS/W5b` has been run so `ActorSilhouette` is in the player's Always-Included list (editor `Shader.Find` always resolves, so box/editor captures can't prove the standalone player has it).

## Item 2 — painted-door hotspots (#1585, P1)

Additive. `plates_manifest.json` gains an **optional** per-plate `door_hotspots: [{door_cell:[c,r], px:[x,y], radius_px}]` in **plate pixel space**. A click inside a hotspot routes **exactly like clicking its `door_cell`** — `HandleClickAt` → `TryDoorHotspot` → `HandleCell(door_c, door_r)` (inherits the rest-vs-combat + `cross_door` path verbatim). A **pulsing gold glow marker** is drawn at each arch's projected floor point (reuses the door-glow idiom). Missing/absent field ⇒ **zero behavior change**. Geometry stays ground truth; the hotspot only remaps the *click target*, never the cell.

**Hit-test math** (`WindowToPlatePx`, pure/static): crop model — uniform scale `s = h/texH`, plate centered horizontally — the inverse of `ApplyPlate`'s billboard sizing. Mirrored + tested in Python (item 3).

### Hotspot annotation — how I measured
Overlaid the contract-camera cell projection (`qa/walk_test.world_to_window_px` at the plate's native `texW×texH`) on each `*_registered.png` (1344×768), then read the **painted arch centroid** off a 50 px grid (annotated + zoomed crops in the session artifacts). Rooms where the authored door cell has **no clear painted arch** are left as **TODO rather than guessed** (per the packet).

| Room | door_cell | projected door px | painted arch px | status |
|------|-----------|-------------------|-----------------|--------|
| **shop** | (12,5) | (1037,230) | **(900,275) r85** | ✅ shipped — clear dark archway, ~2-cell drift |
| **tavern** | (7,0) | (440,242) | **(210,320) r85** | ✅ shipped — one clear stone archway, ~4.5-cell drift (the exact "no functional doors" case) |
| shop | (6,0) | (420,258) | — | TODO — occluded by the potion shelf |
| tavern | (13,5) | (1007,216) | — | TODO — lands on the painted fireplace/hearth, no arch |
| crypt | (7,0) | (396,269) | — | TODO — solid ornamented wall between columns, no opening |
| crypt | (15,5) | (995,200) | — | TODO — column + solid wall, no opening |
| throne_hall | (8,11) | (948,499) | — | TODO — open front / mid-floor column, no single arch |
| throne_hall | (15,6) | (1041,223) | — | TODO — multi-tier colonnade balustrade, no single ground arch |
| tavern_snug | (5,0) | (379,267) | — | TODO — enclosed plank wall, no painted opening |
| tavern_snug | (11,4) | (965,208) | — | TODO — shelf + hearth, no arch |

The high TODO count is itself a finding: the paint pipeline diverges from authored door cells far more than "slightly" (#1585) — several rooms paint **no** opening at the door cell. The two shipped hotspots are the highest-value cases (shop + tavern, where a clear painted arch exists and the drift is exactly what breaks door clicks).

## Item 3 — pure-math mirror + tests
A Python twin exists in the repo (`qa/walk_test.world_to_window_px`, tested in `qa/test_walk_test.py`), so per the packet the new pure math gets a mirror: `window_px_to_plate_px` / `plate_px_to_screen_px` / `door_hotspot_hit` + 5 tests (round-trip, native-window identity, plate-center→screen-center, circular hit inside/outside, and the shipped shop arch routing on/off). **`47 passed`** (`python3 -m pytest qa/test_walk_test.py -q`). The C# projection itself is exercised by the next box compile + sandbox walk gate.

## Risk notes
- **Silhouette clone (no local Unity compile):** the duplicate-skinned-mesh technique is standard, but unverified on THIS box's cast; needs a box render to confirm full-body coverage and no double-shadow/perf surprise. `WORLDOS_SILHOUETTE=0` is the kill switch.
- **Hotspot px** are eyeballed to ±~25 px off a 50 px grid; `radius_px=85` is generous to absorb that. Validate by clicking the painted arch in the sandbox walk gate (should cross).
- Additive throughout: absent `door_hotspots` / disabled silhouette / missing shader all degrade to prior behavior.

Companions: #1585 (door reconciliation), #1647 (epic). Does **not** touch paint-coverage coherence (#1647 item 4) or the walk-gate stage (item 5) — those are separate lanes.
