### PR TITLE
qa: coherence-aware spawn placement (#1647 wave 1)

### DIFF
--- a/qa/seed_adventure_demo.py
+++ b/qa/seed_adventure_demo.py
@@ -84,7 +84,7 @@ def main() -> None:
     sys.path.insert(0, str(HERE.parent / "servers" / "engine"))
     import server  # noqa: PLC0415
     from models import Campaign  # noqa: PLC0415
-    from seed_gfx_town import build_grid_from_geometry  # noqa: PLC0415
+    from seed_gfx_town import DEFAULT_COHERENCE_DIR, build_grid_from_geometry  # noqa: PLC0415
     from walk_static import check_geometry, validate_seed_doors, validate_world  # noqa: PLC0415
 
     # --- full static gate (validate_world + validate_seed_doors + check_geometry) BEFORE seeding ---
@@ -117,7 +117,9 @@ def main() -> None:
         eid = handle[lid]["id"]
         c.locations[eid].connections = [handle[to]["id"] for _cell, to in doors]
         door_pairs = [{"cell": cell, "to": to} for cell, to in doors]
-        c.locations[eid].scene_grid = build_grid_from_geometry(geometries[lid], eid, CID, lid, door_pairs)
+        c.locations[eid].scene_grid = build_grid_from_geometry(
+            geometries[lid], eid, CID, lid, door_pairs,
+            coherence_reports_dir=DEFAULT_COHERENCE_DIR)  # #1647: party spawns on OPEN floor, not painted furniture
     server.save_campaign(c)
     server.start_session(CID, title="The Crypt Below")
 

--- a/qa/seed_gfx_registered_world.py
+++ b/qa/seed_gfx_registered_world.py
@@ -53,7 +53,7 @@ def main() -> None:
     sys.path.insert(0, str(HERE.parent / "servers" / "engine"))
     import server  # noqa: PLC0415
     from models import Campaign  # noqa: PLC0415
-    from seed_gfx_town import build_grid_from_geometry  # noqa: PLC0415
+    from seed_gfx_town import DEFAULT_COHERENCE_DIR, build_grid_from_geometry  # noqa: PLC0415
     from walk_static import check_geometry, validate_seed_doors, validate_world  # noqa: PLC0415
 
     # ★ STATIC GATE AT THE SEED BOUNDARY (epic #1581): an invalid world never enters a campaign —
@@ -94,7 +94,8 @@ def main() -> None:
         c.locations[eid].connections = [handle[to]["id"] for _cell, to in doors]
         geo = json.loads((GEO / geofile).read_text())
         door_pairs = [{"cell": cell, "to": lid} for cell, _to in doors]  # to= is unused by the builder
-        c.locations[eid].scene_grid = build_grid_from_geometry(geo, eid, CID, lid, door_pairs)
+        c.locations[eid].scene_grid = build_grid_from_geometry(
+            geo, eid, CID, lid, door_pairs, coherence_reports_dir=DEFAULT_COHERENCE_DIR)  # #1647: spawn on OPEN floor
         # re-key door_cells to the ENGINE ids in connection order (builder set them from door_pairs order)
     server.save_campaign(c)
     server.start_session(CID, title="Registered walkable world")

--- a/qa/seed_gfx_town.py
+++ b/qa/seed_gfx_town.py
@@ -23,9 +23,51 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.abspath(__file__))
 CID = "camp_townslice01"
 
+# The paint-coverage coherence reports (qa/paint_coherence.py, epic #1647): per-cell open/covered/
+# ambiguous verdicts a spawn can consult so the party is never placed on a cell the player SEES as
+# under painted furniture (grid-open yet visually covered — the crypt-sarcophagus / shop-counter bug).
+DEFAULT_COHERENCE_DIR = os.path.join(HERE, "evidence", "paint-coherence")
+
+
+def load_cell_verdicts(reports_dir, room: str) -> dict | None:
+    """The per-cell coherence verdicts for `room`, or None when no report exists (⇒ spawns fall back to
+    geometry-only placement, byte-identical to the pre-#1647 behaviour). Reads `<room>_coherence_report`
+    from `reports_dir` and returns {(c, r): "open"|"covered"|"ambiguous"} keyed by cell tuple."""
+    if reports_dir is None:
+        return None
+    path = Path(reports_dir) / f"{room}_coherence_report.json"
+    if not path.is_file():
+        return None
+    cells = json.loads(path.read_text(encoding="utf-8")).get("cells", {})
+    out: dict = {}
+    for key, verdict in cells.items():
+        c, r = key.split(",")
+        out[(int(c), int(r))] = verdict
+    return out
+
+
+def _prefer_open(free: list, cell_verdicts: dict) -> list:
+    """Restrict candidate spawn cells to those the coherence report classifies OPEN. Falls back to
+    ambiguous/unclassified cells (NEVER covered) with a loud warning when no open cell exists, and to
+    the full geometry-free list (still loud) only if every candidate is covered — so a mis-locked plate
+    degrades the spawn instead of crashing the seed."""
+    open_cells = [p for p in free if cell_verdicts.get(p) == "open"]
+    if open_cells:
+        return open_cells
+    non_covered = [p for p in free if cell_verdicts.get(p) != "covered"]
+    if non_covered:
+        print(f"WARNING [choose_spawns]: no OPEN cell among {len(free)} candidates — falling back to "
+              f"{len(non_covered)} ambiguous/unclassified cell(s) (paint coherence: relock this plate)",
+              file=sys.stderr)
+        return non_covered
+    print(f"WARNING [choose_spawns]: ALL {len(free)} candidate cells are paint-COVERED — falling back "
+          f"to bare geometry floor; the party will render inside furniture until this plate is relocked",
+          file=sys.stderr)
+    return free
+
 
 def choose_spawns(cols: int, rows: int, blocked: set, door_cells: list,
-                  n_party: int = 2, n_npc: int = 1) -> dict:
+                  n_party: int = 2, n_npc: int = 1, cell_verdicts: dict | None = None) -> dict:
     """Place the party on the OPEN-FLOOR CENTROID as a compact cluster, clear of prop footprints and
     door landing rings — NOT the naive first-N-free interior cells (which land the party jammed in a
     back corner or inside a barrel: the 2026-07-15 'spawn in a barrel' bug, epic #1581 / issue #1584).
@@ -33,6 +75,14 @@ def choose_spawns(cols: int, rows: int, blocked: set, door_cells: list,
     Deterministic + pure so it is unit-testable (qa/test_seed_spawns.py). GEOMETRY IS GROUND TRUTH:
     `blocked` and `door_cells` come from the room's authored geometry, so the spawn is walkable by
     construction. Returns {"party": [(c,r),...], "npcs": [(c,r),...]}.
+
+    When `cell_verdicts` is supplied (a paint-coherence report, #1647), candidates are restricted to
+    cells the player SEES as OPEN floor — a grid-open cell that sits under a tall prop's painted
+    silhouette (crypt sarcophagus, shop counter) is `covered` and must never host a spawn. The
+    open-floor-centroid + door-clear ranking then runs AMONG the open cells. If a room has NO open
+    candidate the placement falls back to ambiguous (never covered) with a loud warning, and only if
+    even that is empty does it fall back to bare geometry floor — it warns rather than crashing.
+    `cell_verdicts=None` ⇒ behaviour unchanged (additive).
     """
     door_ring = {(dc + dx, dr + dy) for (dc, dr) in door_cells
                  for dx in (-1, 0, 1) for dy in (-1, 0, 1)}
@@ -46,6 +96,8 @@ def choose_spawns(cols: int, rows: int, blocked: set, door_cells: list,
     free = _free(exclude_ring=True) or _free(exclude_ring=False)  # tiny rooms: relax the door ring
     if not free:
         return {"party": [], "npcs": []}
+    if cell_verdicts is not None:
+        free = _prefer_open(free, cell_verdicts)
     cx = sum(c for c, _ in free) / len(free)
     cy = sum(r for _, r in free) / len(free)
     # anchor = the open cell nearest the floor centroid (skips a blocked central monument automatically)
@@ -61,9 +113,13 @@ def choose_spawns(cols: int, rows: int, blocked: set, door_cells: list,
 
 
 def build_grid_from_geometry(geo: dict, location_id: str, town_id: str, room: str,
-                             door_pairs: list) -> "SceneGrid":
+                             door_pairs: list, coherence_reports_dir=None) -> "SceneGrid":
     """SceneGrid from a generate_town room geometry: perimeter/prop cells impassable, door cells
-    punched walkable, door_cells ORDERED to match the room's connection pair order."""
+    punched walkable, door_cells ORDERED to match the room's connection pair order.
+
+    When `coherence_reports_dir` is given and holds a `<room>_coherence_report.json`, the party spawn
+    is placed only on cells that report classifies as OPEN floor (#1647) — otherwise spawn placement is
+    geometry-only, unchanged."""
     from scene_grid import (  # noqa: PLC0415
         SceneGrid, SceneGridSpec, SceneCell, SceneCellDefault, SceneProp, SceneLighting, _layout_hash,
     )
@@ -100,7 +156,8 @@ def build_grid_from_geometry(geo: dict, location_id: str, town_id: str, room: st
                                mood="lantern-lit stone district"),
     )
     grid.door_cells = door_cells
-    grid.spawns = choose_spawns(cols, rows, blocked, door_cells)
+    grid.spawns = choose_spawns(cols, rows, blocked, door_cells,
+                                cell_verdicts=load_cell_verdicts(coherence_reports_dir, room))
     grid.art.layout_hash = _layout_hash(grid)
     return grid
 

--- a/qa/test_seed_spawns.py
+++ b/qa/test_seed_spawns.py
@@ -13,7 +13,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from seed_gfx_town import choose_spawns  # noqa: E402
+from seed_gfx_town import choose_spawns, load_cell_verdicts  # noqa: E402
 
 REPO = Path(__file__).resolve().parent.parent
 GEO = REPO / "qa" / "room_geometries"
@@ -76,3 +76,77 @@ def test_avoids_door_landing_ring():
     sp = choose_spawns(16, 12, blocked=set(), door_cells=doors)
     for cell in sp["party"] + sp["npcs"]:
         assert tuple(cell) not in ring, f"spawn {cell} in the door landing ring"
+
+
+# ── coherence-aware spawn placement (#1647): a cell the player SEES as under painted furniture is
+# grid-open yet must never host a spawn. choose_spawns consults a paint_coherence report's per-cell
+# verdicts when one is supplied; absent verdicts, behaviour is byte-identical to the geometry path. ──
+def _all_verdicts(cols, rows, default="covered", **overrides):
+    """A dense verdict map for every interior cell (default `covered`) with per-cell `overrides` — e.g.
+    _all_verdicts(9, 9, open_={(2, 2)}) marks (2,2) open and everything else covered."""
+    v = {(c, r): default for r in range(1, rows - 1) for c in range(1, cols - 1)}
+    for verdict, cells in overrides.items():
+        for cell in cells:
+            v[cell] = verdict.rstrip("_")   # open_ -> open, ambiguous_ -> ambiguous
+    return v
+
+
+def test_covered_centroid_moves_spawn_to_open_cell():
+    """The red-first case: a report marking the geometry-centroid cells COVERED must relocate every
+    spawn onto cells the report classifies OPEN (never covered)."""
+    cols, rows = 16, 12
+    geom = choose_spawns(cols, rows, blocked=set(), door_cells=[])   # geometry-only placement
+    covered = {tuple(c) for c in geom["party"] + geom["npcs"]}       # exactly what sits on the centroid
+    open_region = {(2, 2), (2, 3), (3, 2), (3, 3), (4, 2)}           # the only OPEN floor in this plate
+    verdicts = _all_verdicts(cols, rows, open_=open_region)
+    for cell in covered:                                            # ensure the old anchor reads covered
+        verdicts[cell] = "covered"
+    sp = choose_spawns(cols, rows, blocked=set(), door_cells=[], cell_verdicts=verdicts)
+    placed = [tuple(c) for c in sp["party"] + sp["npcs"]]
+    assert placed, "coherence-aware placement produced no spawn"
+    for cell in placed:
+        assert cell not in covered, f"spawn {cell} stayed on a covered centroid cell"
+        assert verdicts.get(cell) == "open", f"spawn {cell} is not on an OPEN cell ({verdicts.get(cell)})"
+
+
+def test_absent_report_is_byte_identical():
+    """No report present ⇒ additive no-op: cell_verdicts=None reproduces the geometry-only spawn exactly."""
+    for room, geofile, doors in ROOMS:
+        geo = json.loads((GEO / geofile).read_text())
+        blocked = _blocked(geo, doors)
+        base = choose_spawns(geo["cols"], geo["rows"], blocked, doors)
+        same = choose_spawns(geo["cols"], geo["rows"], blocked, doors, cell_verdicts=None)
+        assert base == same, f"{room}: cell_verdicts=None changed the spawn"
+
+
+def test_no_open_cells_warns_and_falls_back(capsys):
+    """Every candidate covered (a fully mis-locked plate) ⇒ a LOUD warning + a geometry fallback, never
+    a crash or an empty spawn."""
+    cols, rows = 9, 9
+    verdicts = _all_verdicts(cols, rows, default="covered")          # nothing open, nothing ambiguous
+    sp = choose_spawns(cols, rows, blocked=set(), door_cells=[(0, 4)], cell_verdicts=verdicts)
+    assert sp["party"], "fallback must still place a party rather than crash/return empty"
+    assert sp == choose_spawns(cols, rows, blocked=set(), door_cells=[(0, 4)]), \
+        "the all-covered fallback must equal the geometry-only placement"
+    assert "WARNING" in capsys.readouterr().err.upper(), "an all-covered fallback must warn loudly"
+
+
+def test_ambiguous_only_fallback_prefers_ambiguous_over_covered(capsys):
+    """No OPEN cell but some ambiguous ⇒ warn and place on ambiguous cells, NEVER on covered ones."""
+    cols, rows = 9, 9
+    ambiguous = {(3, 3), (4, 4), (5, 5)}
+    verdicts = _all_verdicts(cols, rows, default="covered", ambiguous_=ambiguous)
+    sp = choose_spawns(cols, rows, blocked=set(), door_cells=[(0, 4)], cell_verdicts=verdicts)
+    placed = [tuple(c) for c in sp["party"] + sp["npcs"]]
+    assert placed and all(c in ambiguous for c in placed), f"spawn not confined to ambiguous cells: {placed}"
+    assert "WARNING" in capsys.readouterr().err.upper()
+
+
+def test_load_cell_verdicts_reads_a_real_report():
+    """load_cell_verdicts parses a shipped coherence report into tuple-keyed verdicts; a missing report
+    (or None dir) returns None so the seed path stays geometry-only."""
+    reports = REPO / "qa" / "evidence" / "paint-coherence"
+    crypt = load_cell_verdicts(reports, "crypt")
+    assert crypt is not None and crypt.get((7, 7)) == "covered", "crypt (7,7) should read as covered"
+    assert load_cell_verdicts(reports, "no_such_room") is None, "missing report ⇒ None"
+    assert load_cell_verdicts(None, "crypt") is None, "no dir ⇒ None"


### PR DESCRIPTION
## qa: coherence-aware spawn placement (#1647 wave 1)

Demo-critical-path fix for the VQA-adjudicated spawn violations: seeded party/npc spawns land on cells that are **grid-open but visually COVERED** by a tall prop's painted silhouette (the crypt sarcophagus, the shop counter, the tavern counter). `choose_spawns` now consults the room's `paint_coherence` report and restricts candidates to cells classified **OPEN**.

Stacked on **#1648** (base `user-truth-coherence`), which ships `qa/paint_coherence.py` + the per-room `qa/evidence/paint-coherence/*_coherence_report.json` this fix reads.

### What changed
- `qa/seed_gfx_town.py`: `load_cell_verdicts()` (reads `<room>_coherence_report.json` → `{(c,r): verdict}`) + `_prefer_open()`; `choose_spawns` gains an **additive** `cell_verdicts` arg; `build_grid_from_geometry` gains `coherence_reports_dir`. Open-floor-centroid + door-clear ranking is unchanged — it now ranks **among the OPEN cells**.
- `qa/seed_adventure_demo.py`, `qa/seed_gfx_registered_world.py`: pass `DEFAULT_COHERENCE_DIR`.
- `qa/test_seed_spawns.py`: +5 red-first tests.

**Fallback discipline:** no OPEN candidate ⇒ ambiguous (never covered) + loud `stderr` warning; all-covered ⇒ bare geometry floor + louder warning (degrade, never crash). **No report present ⇒ behaviour byte-identical (additive).**

### BEFORE → AFTER (verdict key: o=open, c=covered, a=ambiguous)

| room | BEFORE party | BEFORE npc | before | AFTER party | AFTER npc | after |
|------|------|------|------|------|------|------|
| **crypt** | [(7,7),(8,7)] | [(6,7)] | `c,c,a` | [(5,6),(5,5)] | [(4,5)] | `o,o,o` |
| **tavern** | [(6,5),(6,6)] | [(7,5)] | `c,o,c` | [(6,6),(5,7)] | [(4,7)] | `o,o,o` |
| **shop** | [(6,4),(5,4)] | [(7,4)] | `c,c,c` | [(4,4),(4,3)] | [(3,4)] | `o,o,o` |
| **tavern_snug** | [(5,4),(6,4)] | [(6,5)] | `c,o,o` | [(5,3),(6,3)] | [(6,4)] | `o,o,o` |
| **throne_hall** | [(7,6),(8,6)] | [(7,5)] | `c,c,a` | [(8,7),(8,8)] | [(9,8)] | `o,o,o` |

Every AFTER spawn is fully OPEN. Verified against the live seeded campaigns: both `seed_adventure_demo` and `seed_gfx_registered_world` seed green (static gate) and bake exactly these AFTER cells; `camp_clearing` (no report) keeps its geometry placement (additive proof).

`camp_clearing_v2`: geometry lives on branch `camp-regen` and has no coherence report on this branch — skipped (awkward cross-branch; no report to consult).

### Arrivals: engine-side, out of scope
Door-**arrival** cells are **pure engine reciprocals** — `servers/engine/server.py::_seed_stage_cells_on_arrival` computes the landing cell at `cross_door` time (nearest reachable free cell to the reciprocal door). The seeds place **no** arrival override, so the arrival-covered violations (e.g. crypt door [15,5]) need an **engine-side** fix and are deliberately **not** hacked here.

### Tests
`qa/test_seed_spawns.py`: **11 passed** (6 existing + 5 new). `qa/test_paint_coherence.py`: **17 passed** (importer of `choose_spawns`, unaffected).

Red-first: the 5 new tests reference `cell_verdicts` / `load_cell_verdicts`, which do not exist pre-change (TypeError/ImportError on old code).

### Open risk
The `paint_coherence` **gate** reproduces spawns via `derive_room` → `choose_spawns` **without** verdicts, so re-running the gate still reports the OLD covered spawns (false RED) until its `derive_room` also passes the reports dir (or reports are regenerated post-seed). That is a #1648-side / wave-2 change, left untouched here to avoid a cross-PR edit to the instrument file.
