### PR TITLE
roadmap follow-up: G1 /app-status contract + stale NOW lines (post-#1650 codex round)

### DIFF
--- a/docs/roadmap/NOW.md
+++ b/docs/roadmap/NOW.md
@@ -29,9 +29,8 @@ _Last updated: 2026-07-21 (UTC) — Jul-16 generator chain merged; Task #76 in f
   known-hole SLA + rebuild-not-patch) in §9.2. The A-series evals below are its instruments.
 - **A-SERIES SHIPPED (2026-07-22):** the Adventure Loop — PRODUCT-ROADMAP §4d. Both eval
   modalities live (#1637/#1638 merged); first weakest-link verdicts: #1645 (combat lifecycle),
-  #1639 (cast presence), #1647 (user-truth gates epic).
-  A0 lanes (get_quests RPC + seed_adventure_demo fixture) dispatched; A-T and A-G build in
-  PARALLEL after A0; the adventure eval's weakest-link verdict routes every subsequent sprint.
+  #1639 (cast presence), #1647 (user-truth gates epic). The weakest-link verdict routes every
+  subsequent sprint (first verdict: behavioral → #1645).
 
 ## Live lanes
 

--- a/docs/roadmap/PRODUCT-ROADMAP.md
+++ b/docs/roadmap/PRODUCT-ROADMAP.md
@@ -420,7 +420,7 @@ quest_completed — with ZERO user-truth defects. Demo completion proves the sys
 
 **Proven by four gates (checkable, never narrative):**
 - G1 — the certification gates that EXIST run green against the INSTALLED build, verified by
-  build identity: the app self-reports its build stamp (/debug), and the gate evidence records the
+  build identity: the app self-reports its build stamp via the /app-status contract (WorldOS-GUI-RUNBOOK §app-status; viewer/server.py), and the gate evidence records the
   SAME stamp — a mismatch is a G1 FAIL (the certified-build ≠ installed-build class, #1651).
   Today that means walk_static (CI) + the paint-coherence gate + the A-T/A-G evals run against the
   installed pair; G1 UPGRADES to the full `player_cert` suite when §9.2 lands (a proof clause may


### PR DESCRIPTION
Two codex catches that posted after #1650's auto-merge fired: (1) G1's build-identity wording named /debug but the implemented app/build status contract is /app-status (WorldOS-GUI-RUNBOOK §app-status, viewer/server.py) — G1 now cites the real contract; (2) the SHIPPED A-series NOW entry still carried stale 'A0 dispatched, build after' bootstrap instructions — purged.