### PR TITLE
engine+qa: combat lifecycle closure (#1645, §9.1 item 1)

### DIFF
--- a/qa/run_adventure.sh
+++ b/qa/run_adventure.sh
@@ -273,9 +273,22 @@ that opens onto a throne hall where the Goblin Boss waits. The quest \"$QUEST_TI
 objectives — Speak with Keeper Maera, Clear the crypt of goblins, Slay the goblin boss, Return to
 Maera for the reward. As the party achieves each, call complete_objective so the engine records it
 (the last one auto-resolves the quest and hands over the reward via complete_quest). Run real combat
-in the crypt and the throne hall (start_combat / attack / end_combat). Keep the arc MOVING toward the
-crypt and the boss; the player is here to finish this job, not to linger. The player is the seeded PC
-already in the party — do NOT seat a new character."
+in the crypt and the throne hall THROUGH THE ENGINE, and CLOSE it — an unclosed fight is this arc's
+#1 failure mode: it eats the whole beat budget and flips the behavioral gate RED before the boss is
+ever reached. COMBAT-CLOSURE DISCIPLINE, non-negotiable and enforced by the QA gate:
+  (1) DRIVE EVERY ATTACK THROUGH THE ACTION ECONOMY, not prose — start_combat on the foe ids, then
+      each round resolve the strikes with attack() (or cast_spell / use_action) and advance with
+      next_turn. Narrating 'you cut the goblin down' with no attack() call leaves action_used=False
+      and 0 attacks (an action_economy WARN): the blow never landed in engine state.
+  (2) THE BEAT THE LAST HOSTILE DROPS, CALL end_combat(resolution='...'). The engine surfaces a LOUD
+      pending_resolution nudge in the combat state the moment no living hostile remains — obey it.
+      end_combat auto-awards the defeated foes' XP in xp mode (so a clean fight needs no separate
+      award_xp); a fight left active is a combat_ended + xp_awarded WARN and its XP never lands.
+  (3) ADVANCE THE CLOCK after significant beats — a resolved fight, a cleared room, reaching the
+      throne hall — via advance_time / long_rest / travel_to(advance_time=True). An arc where the
+      clock never moves is a dm_advanced_time WARN.
+Keep the arc MOVING toward the crypt and the boss; the player is here to finish this job, not to
+linger. The player is the seeded PC already in the party — do NOT seat a new character."
 PLAYER_BRIEF="$(cat "$PLAYER_PROMPT_FILE")"
 
 COMBINED="$T/$RUN.jsonl"; [ "$RESUME_MODE" = "1" ] || : > "$COMBINED"

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -1538,6 +1538,32 @@ class Combat(_StrictModel):
     # mirrors last_move_path's shape so the walkability gate can path-audit rest walks the same way
     # it audits combat moves. Presentation/QA only; empty == no rest walk yet (old snapshots round-trip).
     last_walk_path: list[list[int]] = Field(default_factory=list)
+    # #1645: consecutive next_turn advances observed with NO living hostile left in the order —
+    # the inverse of end_combat's live-hostile guard. Drives the DM-visible `pending_resolution`
+    # nudge in _combat_view (surfaced immediately once no hostile is up; escalated to URGENT once
+    # this streak crosses _COMBAT_RESOLUTION_NUDGE_TURNS). The engine NEVER auto-ends combat
+    # (questgen.py:7 invariant — the DM owns the end_combat predicate); this only makes an
+    # un-closed fight progressively LOUDER. ADDITIVE: default 0 == today; reset to 0 the moment a
+    # living hostile is seen, cleared wholesale when end_combat replaces c.combat with a fresh
+    # Combat(). Omitted from the dump when 0 (the serializer below) so a pre-#1645 snapshot
+    # round-trips BYTE-IDENTICALLY and the store's dirty-skip never bumps updated_at on a pure
+    # load->save.
+    no_hostile_turns: int = 0
+
+    @model_serializer(mode="wrap")
+    def _ser_omit_default_no_hostile_turns(self, handler):
+        """OMIT ``no_hostile_turns`` from the dump when it is 0 so a combat carrying no pending-
+        resolution streak (the overwhelming majority — every out-of-combat campaign holds a fresh
+        Combat()) serializes BYTE-IDENTICALLY to a pre-#1645 snapshot that never carried the key.
+        Without this the store's F08-2 dirty-skip (store.py:145 byte-compares the dump to disk)
+        would see a new key on EVERY load->save and bump updated_at / steal the #640 live pointer
+        — the same narrowly-scoped guard as Consequence._ser_omit_empty_quest_id, for the same
+        reason. A fight actively carrying the streak (>0) is mid-mutation anyway, so emitting the
+        key then is free; all other keys/order are unchanged."""
+        data = handler(self)
+        if not self.no_hostile_turns:
+            data.pop("no_hostile_turns", None)
+        return data
 
     @property
     def current_combatant_id(self) -> Optional[str]:

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -481,6 +481,26 @@ def _backlog_dict(item: BacklogItem) -> dict:
     }
 
 
+# #1645: consecutive next_turn advances with NO living hostile left before the combat-closure
+# nudge escalates from advisory to URGENT in the DM-visible combat surface. The DM stays the SOLE
+# resolver — the engine NEVER auto-ends combat (questgen.py:7 invariant); this only makes an
+# un-closed fight progressively louder in the state the DM reads.
+_COMBAT_RESOLUTION_NUDGE_TURNS = 2
+
+
+def _living_hostiles(c: Campaign) -> list[Character]:
+    """The monsters still IN the combat order at >0 HP and not dead — the engine's canonical
+    'is the fight still on' set, matching end_combat's live_hostiles guard (~server.py:7490)
+    and the combat_left_hanging cue (~server.py:14174). A fled monster was removed from the
+    order; a killed one is dead. Pure read (no mutation)."""
+    out: list[Character] = []
+    for cb in c.combat.order:
+        ch = c.characters.get(cb.character_id)
+        if ch is not None and ch.kind == "monster" and ch.current_hp > 0 and not ch.dead:
+            out.append(ch)
+    return out
+
+
 def _combat_view(c: Campaign) -> dict:
     order = []
     for cb in c.combat.order:
@@ -519,6 +539,29 @@ def _combat_view(c: Campaign) -> dict:
             "cell_size": c.combat.grid_cell_size,
             "diagonal_mode": c.combat.diagonal_mode,
         }
+    # #1645 COMBAT-CLOSURE NUDGE (advisory ONLY; the engine NEVER auto-ends — the DM owns the
+    # end_combat predicate, questgen.py:7). When the fight is active but NO living hostile remains
+    # in the order, the encounter is over in FACT yet the engine still reads active — surface a
+    # LOUD, DM-visible pending_resolution flag telling the DM to close it (end_combat resets
+    # initiative/HP and, in xp mode, auto-awards the defeated foes' XP). Escalates to URGENT once
+    # the no-hostile state has persisted across _COMBAT_RESOLUTION_NUDGE_TURNS consecutive
+    # next_turn advances (combat.no_hostile_turns). ADDITIVE: every key here is ABSENT while a
+    # hostile still lives (or combat is inactive), so an ongoing fight's view is byte-for-byte
+    # unchanged; the nudge clears wholesale when end_combat replaces c.combat with a fresh Combat().
+    if c.combat.active and not _living_hostiles(c):
+        streak = c.combat.no_hostile_turns
+        view["pending_resolution"] = True
+        view["living_hostiles"] = 0
+        if streak:
+            view["pending_resolution_turns"] = streak
+        view["resolution_nudge"] = (
+            ("URGENT: " if streak >= _COMBAT_RESOLUTION_NUDGE_TURNS else "")
+            + "no living hostile remains — the fight is over in fact but combat still reads "
+            "active. Call end_combat(resolution='...') to close it: it resets initiative/HP and, "
+            "in xp mode, auto-awards the defeated foes' XP. The engine will NOT end the fight for "
+            "you (you are the sole resolver) — a fight left active leaks into the next beat as a "
+            "phantom encounter."
+        )
     return view
 
 
@@ -5691,6 +5734,14 @@ def next_turn(campaign_id: str) -> dict:
                 },
                 speaker=cur.name,
             )
+        # #1645: track how many consecutive turn-advances have passed with NO living hostile left,
+        # so _combat_view's pending_resolution nudge escalates to URGENT on a fight the DM keeps
+        # cycling turns in without closing. Reset the moment a hostile is still up. This NEVER ends
+        # combat — the DM owns the end_combat predicate (questgen.py:7 invariant).
+        if _living_hostiles(c):
+            c.combat.no_hostile_turns = 0
+        else:
+            c.combat.no_hostile_turns += 1
         view = _combat_view(c)
         view["current_name"] = cur.name if cur else None
         view["death_save_due"] = bool(cur and cur.current_hp == 0 and not cur.dead and not cur.stable)

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -501,6 +501,33 @@ def _living_hostiles(c: Campaign) -> list[Character]:
     return out
 
 
+def _apply_resolution_nudge(c: Campaign, out: dict) -> None:
+    """ADDITIVE pending-resolution advisory (#1645): attached by _combat_view AND by the killing
+    tools' own returns (attack), so the DM sees the nudge at the exact moment the last hostile
+    drops — not only on the next view read. Every key is ABSENT while a hostile lives."""
+    # LOUD, DM-visible pending_resolution flag telling the DM to close it (end_combat resets
+    # initiative/HP and, in xp mode, auto-awards the defeated foes' XP). Escalates to URGENT once
+    # the no-hostile state has persisted across _COMBAT_RESOLUTION_NUDGE_TURNS consecutive
+    # next_turn advances (combat.no_hostile_turns). ADDITIVE: every key here is ABSENT while a
+    # hostile still lives (or combat is inactive), so an ongoing fight's view is byte-for-byte
+    # unchanged; the nudge clears wholesale when end_combat replaces c.combat with a fresh Combat().
+    if c.combat.active and not _living_hostiles(c):
+        streak = c.combat.no_hostile_turns
+        out["pending_resolution"] = True
+        out["living_hostiles"] = 0
+        if streak:
+            out["pending_resolution_turns"] = streak
+        out["resolution_nudge"] = (
+            ("URGENT: " if streak >= _COMBAT_RESOLUTION_NUDGE_TURNS else "")
+            + "no living hostile remains — the fight is over in fact but combat still reads "
+            "active. Call end_combat(resolution='...') to close it: it resets initiative/HP and, "
+            "in xp mode, auto-awards the defeated foes' XP. The engine will NOT end the fight for "
+            "you (you are the sole resolver) — a fight left active leaks into the next beat as a "
+            "phantom encounter."
+        )
+
+
+
 def _combat_view(c: Campaign) -> dict:
     order = []
     for cb in c.combat.order:
@@ -542,26 +569,7 @@ def _combat_view(c: Campaign) -> dict:
     # #1645 COMBAT-CLOSURE NUDGE (advisory ONLY; the engine NEVER auto-ends — the DM owns the
     # end_combat predicate, questgen.py:7). When the fight is active but NO living hostile remains
     # in the order, the encounter is over in FACT yet the engine still reads active — surface a
-    # LOUD, DM-visible pending_resolution flag telling the DM to close it (end_combat resets
-    # initiative/HP and, in xp mode, auto-awards the defeated foes' XP). Escalates to URGENT once
-    # the no-hostile state has persisted across _COMBAT_RESOLUTION_NUDGE_TURNS consecutive
-    # next_turn advances (combat.no_hostile_turns). ADDITIVE: every key here is ABSENT while a
-    # hostile still lives (or combat is inactive), so an ongoing fight's view is byte-for-byte
-    # unchanged; the nudge clears wholesale when end_combat replaces c.combat with a fresh Combat().
-    if c.combat.active and not _living_hostiles(c):
-        streak = c.combat.no_hostile_turns
-        view["pending_resolution"] = True
-        view["living_hostiles"] = 0
-        if streak:
-            view["pending_resolution_turns"] = streak
-        view["resolution_nudge"] = (
-            ("URGENT: " if streak >= _COMBAT_RESOLUTION_NUDGE_TURNS else "")
-            + "no living hostile remains — the fight is over in fact but combat still reads "
-            "active. Call end_combat(resolution='...') to close it: it resets initiative/HP and, "
-            "in xp mode, auto-awards the defeated foes' XP. The engine will NOT end the fight for "
-            "you (you are the sole resolver) — a fight left active leaks into the next beat as a "
-            "phantom encounter."
-        )
+    _apply_resolution_nudge(c, view)
     return view
 
 
@@ -7051,7 +7059,11 @@ def attack(
         # Persist regardless of hit/miss: a miss still consumed the action/reaction
         # economy above, and that bookkeeping must survive (sole-writer discipline).
         save_campaign(c)
-        return result
+        # #1645 codex round: the KILLING BLOW itself must surface the closure nudge — attack() returns
+    # its own result dict (no _combat_view), so without this the DM only saw the nudge on the NEXT
+    # combat-tool read.
+    _apply_resolution_nudge(c, result)
+    return result
 
 
 @mcp.tool()

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -7540,9 +7540,7 @@ def end_combat(campaign_id: str, resolution: str = "") -> dict:
         # extra_attack_reminder advisory pattern. Computed from the order BEFORE the reset.
         live_hostiles = [
             {"id": ch.id, "name": ch.name, "hp": f"{ch.current_hp}/{ch.max_hp}"}
-            for cb in c.combat.order
-            if (ch := c.characters.get(cb.character_id)) is not None
-            and ch.kind == "monster" and ch.current_hp > 0 and not ch.dead
+            for ch in _living_hostiles(c)  # the ONE canonical predicate (#1654 review dedup)
         ]
         res = (resolution or "").strip()
         if res:

--- a/servers/engine/tests/test_combat_lifecycle_nudge.py
+++ b/servers/engine/tests/test_combat_lifecycle_nudge.py
@@ -182,3 +182,19 @@ def test_next_turn_streak_ticks_through_the_pc_skip_path(_state):
     assert view["pending_resolution"] is True
     reloaded = store.load_campaign(c.id)
     assert reloaded.combat.no_hostile_turns == 1
+
+
+def test_killing_blow_return_carries_the_nudge(_state):
+    # codex #1654 round: attack() returns its own dict (no combat view) — the closure advisory
+    # must ride the killing blow's OWN return, not just the next view read.
+    living = _monster(name="Last Goblin", dead=False)
+    c = _campaign_in_combat(living, _pc(), no_hostile_turns=0, turn_index=1)
+    living_id = c.combat.order[0].character_id
+    ch = c.characters[living_id]
+    ch.current_hp = 1
+    pc_id = c.combat.order[1].character_id
+    store.save_campaign(c)
+    result = server.attack(c.id, attacker_id=pc_id, target_id=living_id,
+                           attack_bonus=100, damage_dice="1d1+100", damage_type="slashing")
+    assert result.get("pending_resolution") is True
+    assert result.get("living_hostiles") == 0

--- a/servers/engine/tests/test_combat_lifecycle_nudge.py
+++ b/servers/engine/tests/test_combat_lifecycle_nudge.py
@@ -7,7 +7,7 @@ left OPEN, so no XP landed and the arc's beat budget was eaten before the boss w
 The engine assist (secondary lever): when a fight is ACTIVE but NO living hostile remains, the
 DM-visible combat surface (`_combat_view`, returned by every combat tool) surfaces a LOUD
 `pending_resolution` nudge suggesting `end_combat` — and ESCALATES to URGENT once the no-hostile
-state has persisted across `_COMBAT_RESOLUTION_NUDGE_TURNS` consecutive `next_turn` advances.
+state has persisted across `server._COMBAT_RESOLUTION_NUDGE_TURNS` consecutive `next_turn` advances.
 The engine NEVER auto-ends combat (questgen.py:7 invariant — the DM owns the end_combat
 predicate); this only makes an un-closed fight progressively louder.
 
@@ -22,7 +22,6 @@ import pytest
 import server
 import store
 from models import Campaign, Character, Combat, Combatant
-from server import _COMBAT_RESOLUTION_NUDGE_TURNS
 
 
 # --- helpers ----------------------------------------------------------------
@@ -92,21 +91,21 @@ def test_flag_absent_when_combat_inactive():
 
 
 def test_nudge_escalates_to_urgent_at_the_streak_threshold():
-    """Once the no-hostile state persists across _COMBAT_RESOLUTION_NUDGE_TURNS advances,
+    """Once the no-hostile state persists across server._COMBAT_RESOLUTION_NUDGE_TURNS advances,
     the nudge escalates to URGENT and reports the streak."""
     c = _campaign_in_combat(_pc(), _monster(dead=True),
-                            no_hostile_turns=_COMBAT_RESOLUTION_NUDGE_TURNS)
+                            no_hostile_turns=server._COMBAT_RESOLUTION_NUDGE_TURNS)
     view = server._combat_view(c)
     assert view["pending_resolution"] is True
-    assert view["pending_resolution_turns"] == _COMBAT_RESOLUTION_NUDGE_TURNS
+    assert view["pending_resolution_turns"] == server._COMBAT_RESOLUTION_NUDGE_TURNS
     assert view["resolution_nudge"].startswith("URGENT")
 
 
 def test_nudge_is_advisory_one_below_the_threshold():
     c = _campaign_in_combat(_pc(), _monster(dead=True),
-                            no_hostile_turns=_COMBAT_RESOLUTION_NUDGE_TURNS - 1)
+                            no_hostile_turns=server._COMBAT_RESOLUTION_NUDGE_TURNS - 1)
     view = server._combat_view(c)
-    assert view["pending_resolution_turns"] == _COMBAT_RESOLUTION_NUDGE_TURNS - 1
+    assert view["pending_resolution_turns"] == server._COMBAT_RESOLUTION_NUDGE_TURNS - 1
     assert not view["resolution_nudge"].startswith("URGENT")
 
 
@@ -168,3 +167,18 @@ def test_no_hostile_turns_emitted_when_nonzero_and_round_trips():
     assert dumped["no_hostile_turns"] == 4
     restored = Combat.model_validate(dumped)
     assert restored.no_hostile_turns == 4
+
+
+def test_next_turn_streak_ticks_through_the_pc_skip_path(_state):
+    # evaOS #1654 round: the prior streak tests put the MONSTER at turn_index=0, bypassing
+    # next_turn's PC-skip guard (server.py ~5476). Here the PC is the OUTGOING combatant —
+    # the guard path runs — and the no-hostile streak must still tick and surface the nudge.
+    c = _campaign_in_combat(_monster(dead=True), _pc(), no_hostile_turns=0, turn_index=1)
+    store.save_campaign(c)
+    # The guard requires the outgoing PC to have acted — declare a pass, then advance.
+    pc_id = c.combat.order[1].character_id
+    server.use_action(c.id, pc_id, kind="skip")
+    view = server.next_turn(c.id)
+    assert view["pending_resolution"] is True
+    reloaded = store.load_campaign(c.id)
+    assert reloaded.combat.no_hostile_turns == 1

--- a/servers/engine/tests/test_combat_lifecycle_nudge.py
+++ b/servers/engine/tests/test_combat_lifecycle_nudge.py
@@ -1,0 +1,170 @@
+"""#1645 — the COMBAT-CLOSURE nudge (the inverse of end_combat's live-hostile guard).
+
+The proven failure (the FIRST live arc-duo adventure eval, adv_live1): the DM narrated a
+crypt goblin fight, `start_combat` fired, but `end_combat` was never called — the fight was
+left OPEN, so no XP landed and the arc's beat budget was eaten before the boss was reached.
+
+The engine assist (secondary lever): when a fight is ACTIVE but NO living hostile remains, the
+DM-visible combat surface (`_combat_view`, returned by every combat tool) surfaces a LOUD
+`pending_resolution` nudge suggesting `end_combat` — and ESCALATES to URGENT once the no-hostile
+state has persisted across `_COMBAT_RESOLUTION_NUDGE_TURNS` consecutive `next_turn` advances.
+The engine NEVER auto-ends combat (questgen.py:7 invariant — the DM owns the end_combat
+predicate); this only makes an un-closed fight progressively louder.
+
+These guard: the flag APPEARS when hostiles are dead, is ABSENT while any hostile lives (or
+combat is inactive), escalates on a persisting streak, CLEARS on end_combat, and — the additive
+contract — a combat with no streak (no_hostile_turns == 0) serializes BYTE-IDENTICALLY to a
+pre-#1645 snapshot (no new key), so the store's dirty-skip never bumps updated_at.
+"""
+
+import pytest
+
+import server
+import store
+from models import Campaign, Character, Combat, Combatant
+from server import _COMBAT_RESOLUTION_NUDGE_TURNS
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _monster(name: str = "Goblin", hp: int = 7, dead: bool = False, xp_value: int = 50) -> Character:
+    return Character(
+        name=name,
+        kind="monster",
+        current_hp=0 if dead else hp,
+        max_hp=hp,
+        dead=dead,
+        xp_value=xp_value,
+    )
+
+
+def _pc(name: str = "Hero", hp: int = 12) -> Character:
+    return Character(name=name, kind="player", current_hp=hp, max_hp=hp)
+
+
+def _campaign_in_combat(*combatants: Character, active: bool = True,
+                        no_hostile_turns: int = 0, turn_index: int = 0) -> Campaign:
+    """Register a campaign whose combat order is exactly `combatants`, in initiative
+    order. PCs/companions are added to the party."""
+    c = Campaign(title="The Crypt Below")
+    order = []
+    for i, ch in enumerate(combatants):
+        c.characters[ch.id] = ch
+        if ch.kind in ("player", "companion"):
+            c.party.append(ch.id)
+        order.append(Combatant(character_id=ch.id, initiative=20 - i))
+    c.combat = Combat(active=active, order=order, no_hostile_turns=no_hostile_turns,
+                      turn_index=turn_index, round=1)
+    return c
+
+
+# --- the pure _combat_view surface ------------------------------------------
+
+
+def test_pending_resolution_flag_appears_when_all_hostiles_dead():
+    """Hostiles-dead + combat active -> the LOUD advisory flag + nudge text appear."""
+    c = _campaign_in_combat(_pc(), _monster(dead=True))
+    view = server._combat_view(c)
+    assert view["pending_resolution"] is True
+    assert view["living_hostiles"] == 0
+    assert "end_combat" in view["resolution_nudge"]
+    # Below the escalation threshold (streak 0): advisory, NOT urgent, no streak key.
+    assert not view["resolution_nudge"].startswith("URGENT")
+    assert "pending_resolution_turns" not in view
+
+
+def test_flag_absent_while_a_hostile_still_lives():
+    """A single living hostile in the order suppresses the whole nudge — the fight is on."""
+    c = _campaign_in_combat(_pc(), _monster(dead=True), _monster(name="Goblin Boss", dead=False))
+    view = server._combat_view(c)
+    assert "pending_resolution" not in view
+    assert "resolution_nudge" not in view
+    assert "living_hostiles" not in view
+
+
+def test_flag_absent_when_combat_inactive():
+    """No active fight -> no nudge, even if a dead monster lingers in a stale order."""
+    c = _campaign_in_combat(_pc(), _monster(dead=True), active=False)
+    view = server._combat_view(c)
+    assert "pending_resolution" not in view
+    assert "resolution_nudge" not in view
+
+
+def test_nudge_escalates_to_urgent_at_the_streak_threshold():
+    """Once the no-hostile state persists across _COMBAT_RESOLUTION_NUDGE_TURNS advances,
+    the nudge escalates to URGENT and reports the streak."""
+    c = _campaign_in_combat(_pc(), _monster(dead=True),
+                            no_hostile_turns=_COMBAT_RESOLUTION_NUDGE_TURNS)
+    view = server._combat_view(c)
+    assert view["pending_resolution"] is True
+    assert view["pending_resolution_turns"] == _COMBAT_RESOLUTION_NUDGE_TURNS
+    assert view["resolution_nudge"].startswith("URGENT")
+
+
+def test_nudge_is_advisory_one_below_the_threshold():
+    c = _campaign_in_combat(_pc(), _monster(dead=True),
+                            no_hostile_turns=_COMBAT_RESOLUTION_NUDGE_TURNS - 1)
+    view = server._combat_view(c)
+    assert view["pending_resolution_turns"] == _COMBAT_RESOLUTION_NUDGE_TURNS - 1
+    assert not view["resolution_nudge"].startswith("URGENT")
+
+
+# --- the next_turn streak tick (the "N consecutive advances") ---------------
+
+
+@pytest.fixture
+def _state(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+
+
+def test_next_turn_increments_streak_when_no_hostile_remains(_state):
+    # Current combatant is the dead monster (kind==monster => next_turn's PC-skip guard is
+    # not engaged), so the advance is legal with no PC action taken.
+    c = _campaign_in_combat(_monster(dead=True), _pc(), no_hostile_turns=0, turn_index=0)
+    store.save_campaign(c)
+    view = server.next_turn(c.id)
+    assert view["pending_resolution"] is True
+    reloaded = store.load_campaign(c.id)
+    assert reloaded.combat.no_hostile_turns == 1
+
+
+def test_next_turn_resets_streak_when_a_hostile_is_still_up(_state):
+    # A living hostile is in the order and a stale streak is carried -> the advance clears it.
+    living = _monster(name="Goblin Boss", dead=False)
+    c = _campaign_in_combat(living, _pc(), no_hostile_turns=5, turn_index=0)
+    store.save_campaign(c)
+    view = server.next_turn(c.id)
+    assert "pending_resolution" not in view
+    reloaded = store.load_campaign(c.id)
+    assert reloaded.combat.no_hostile_turns == 0
+
+
+def test_end_combat_clears_the_nudge(_state):
+    c = _campaign_in_combat(_pc(), _monster(dead=True), no_hostile_turns=3)
+    store.save_campaign(c)
+    server.end_combat(c.id, resolution="the last goblin falls")
+    reloaded = store.load_campaign(c.id)
+    assert reloaded.combat.active is False
+    assert reloaded.combat.no_hostile_turns == 0
+    # And the surface is quiet: a fresh Combat() carries no pending_resolution.
+    assert "pending_resolution" not in server._combat_view(reloaded)
+
+
+# --- the additive serialization contract (byte-identical round-trip) --------
+
+
+def test_no_hostile_turns_omitted_from_dump_when_zero():
+    """A combat with no streak dumps WITHOUT the key -> a pre-#1645 snapshot round-trips
+    byte-identically and the store's dirty-skip stays a no-op on a pure load->save."""
+    assert "no_hostile_turns" not in Combat().model_dump()
+    assert "no_hostile_turns" not in Combat().model_dump_json()
+    # A campaign with a default (out-of-combat) Combat carries no new key at all.
+    assert "no_hostile_turns" not in Campaign(title="x").model_dump_json()
+
+
+def test_no_hostile_turns_emitted_when_nonzero_and_round_trips():
+    dumped = Combat(no_hostile_turns=4).model_dump()
+    assert dumped["no_hostile_turns"] == 4
+    restored = Combat.model_validate(dumped)
+    assert restored.no_hostile_turns == 4


### PR DESCRIPTION
Closes the A2 flywheel's first weakest-link verdict (#1645): the first live arc-duo (adv_live1) stalled in the crypt — `start_combat` fired but `action_used=False`, `end_combat` was never called, no XP landed, and the boss was never reached (behavioral RED). Both levers from the issue, in preference order.

## Lever 1 — PROMPT (primary), arc-runner-scoped
`qa/run_adventure.sh` — the DM brief is `cat qa/play_dm_duo.txt` (the SHARED duo brief) + an inline **ARC ADDENDUM**. Only the addendum is touched; **`play_dm_duo.txt` is unchanged**, so the `sc_`/`lc_` engine-duo rulers do not shift. The existing single-sentence "Run real combat…" is expanded into a **COMBAT-CLOSURE DISCIPLINE** block, phrased like the base brief's gate-adjacent guidance ("enforced by the QA gate", "flips the gate RED") and mapped onto the exact behavioral checks that WARNed:
1. **Drive every attack through the action economy** (not prose) — `start_combat` → `attack()`/`cast_spell`/`use_action` → `next_turn`. Maps to `action_economy_engaged`.
2. **Call `end_combat(resolution=…)` the beat the last hostile drops** — obey the engine's `pending_resolution` nudge; `end_combat` auto-awards XP in xp mode. Maps to `combat_ended` + `xp_awarded`.
3. **Advance the clock after significant beats** via `advance_time`/`long_rest`/`travel_to(advance_time=True)`. Maps to `dm_advanced_time`.

## Lever 2 — ENGINE nudge (secondary, additive)
`servers/engine/server.py` `_combat_view` (the DM-visible combat surface every combat tool returns): when a fight is **active but zero living hostiles remain** (`_living_hostiles`, matching `end_combat`'s live-hostile guard), it surfaces a LOUD `pending_resolution: True` + `resolution_nudge` telling the DM to call `end_combat`. It **escalates to URGENT** once the state persists across `_COMBAT_RESOLUTION_NUDGE_TURNS` (=2) consecutive `next_turn` advances, tracked by the new additive `Combat.no_hostile_turns` (incremented/reset in `next_turn`). The engine **NEVER auto-ends combat** — the DM stays the sole resolver (questgen.py:7 invariant). Additive contract: `no_hostile_turns` is omitted from the dump when 0 (a `@model_serializer`, mirroring `Consequence._ser_omit_empty_quest_id`), so a pre-#1645 snapshot round-trips **byte-identically** and the store's F08-2 dirty-skip never bumps `updated_at`. The nudge clears wholesale when `end_combat` resets `c.combat`.

## Tests
`servers/engine/tests/test_combat_lifecycle_nudge.py` — **10 tests, red-first** (`pending_resolution` / `no_hostile_turns` / `_COMBAT_RESOLUTION_NUDGE_TURNS` / `_living_hostiles` are all absent on origin/main): flag appears when hostiles dead; absent when a hostile lives or combat inactive; escalates to URGENT at the streak threshold; `next_turn` increments/resets the streak; `end_combat` clears it; byte-identical serialization when the streak is 0.

## Validation
Offline only (per instructions — no live `claude -p`): `bash -n qa/run_adventure.sh` OK; `uv run pytest` — new file 10/10, plus combat/obligations/grid/zones (397) and store/persistence (3543) suites green. **Acceptance:** the orchestrator runs the arc-duo re-eval — target is `adv_live2` **completes the arc, or at least reaches boss_dead with behavioral non-RED on the combat checks** (`action_economy_engaged`, `combat_ended`, `xp_awarded`, `dm_advanced_time`).

Do NOT merge — awaiting orchestrator arc-duo re-eval.