### PR TITLE
engine+qa: coherence-aware arrival hints + live-save migration (#1647 wave-2)

### DIFF
--- a/qa/migrate_arrival_hints.py
+++ b/qa/migrate_arrival_hints.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Live-save migration: bake coherence-aware ARRIVAL HINTS into an EXISTING campaign (#1647 wave-2).
+
+The owner-facing win: their live campaign must NOT be wiped or reseeded to get the "Aldric on the
+tavern bar" fix. This script loads a live campaign through the SAME engine store the seeds use, and
+ADDITIVELY writes ``scene_grid.arrival_hints`` into every location that has a paint-coherence report
+(the walkslice rooms: crypt / tavern / shop / tavern_snug / throne_hall). It ALSO relocates any party
+token currently standing on a coherence-``covered`` cell to the nearest visually-OPEN cell — so the
+"standing on the bar" state ends the moment the migration runs, not just on the next door crossing.
+
+SOLE-WRITER discipline (load-bearing): the engine is the only writer of ``snapshot.json``. Run this
+with the owner engine STOPPED. It uses the exact same store API the reseed scripts use
+(``server.load_campaign`` -> mutate -> ``server.save_campaign``, atomic temp-file + os.replace under
+the campaign lock), so there is never a second concurrent writer. It is ADDITIVE: it only ADDS hint
+keys the seed would have baked and only MOVES a token off a covered cell — it never drops or rewrites
+any other field, and a location with no coherence report is left byte-identical.
+
+Usage:
+  python3 qa/migrate_arrival_hints.py <state_dir> <campaign_id> [--dry-run] [--coherence-dir DIR]
+
+  --dry-run        compute + print what WOULD change; write NOTHING (no save).
+  --coherence-dir  override the coherence-report directory (default: qa/evidence/paint-coherence).
+
+Prints a per-location summary (hint counts + any relocations). The orchestrator runs the real
+invocation against the owner's state — this script never targets it by default.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _room_candidates(loc, scene_grid) -> list[str]:
+    """Ordered room-name candidates to look a coherence report up by. The seed pipeline names a
+    location by its room (crypt/tavern/...), so the location id is the primary key; the scene_id
+    tail (``<cid>:<town>_<room>`` or ``<cid>:<room>``) is the fallback."""
+    out: list[str] = []
+    lid = getattr(loc, "id", None)
+    if isinstance(lid, str) and lid:
+        out.append(lid)
+    sgl = getattr(scene_grid, "location_id", None)
+    if isinstance(sgl, str) and sgl and sgl not in out:
+        out.append(sgl)
+    sid = getattr(scene_grid, "scene_id", None)
+    if isinstance(sid, str) and ":" in sid:
+        tail = sid.split(":", 1)[1]
+        for cand in (tail, tail.split("_", 1)[-1]):
+            if cand and cand not in out:
+                out.append(cand)
+    return out
+
+
+def _report_room(coherence_dir: str, loc, scene_grid) -> str | None:
+    """The first candidate room name that HAS a ``<room>_coherence_report.json`` here, else None."""
+    for room in _room_candidates(loc, scene_grid):
+        if (Path(coherence_dir) / f"{room}_coherence_report.json").is_file():
+            return room
+    return None
+
+
+def _nearest_open(cell, cols: int, rows: int, blocked: set, verdicts: dict):
+    """The nearest visually-OPEN, non-blocked cell to ``cell`` (Chebyshev, stable (r, c) tiebreak),
+    or None when the room has no open floor left. ``blocked`` includes wall/prop terrain AND the cells
+    already claimed by other party members so two relocated tokens never stack."""
+    opens = [
+        (c, r)
+        for r in range(rows) for c in range(cols)
+        if verdicts.get((c, r)) == "open" and (c, r) not in blocked
+    ]
+    if not opens:
+        return None
+    cx, cy = int(cell[0]), int(cell[1])
+    return min(opens, key=lambda p: (max(abs(p[0] - cx), abs(p[1] - cy)), p[1], p[0]))
+
+
+def migrate(state_dir: str, campaign_id: str, coherence_dir: str, dry_run: bool) -> dict:
+    """Load the campaign, bake arrival hints + relocate covered party tokens, save (unless dry-run).
+    Returns a summary dict (also printed). Pure w.r.t. any location without a coherence report."""
+    os.environ["WORLDOS_STATE_DIR"] = state_dir
+    sys.path.insert(0, HERE)
+    sys.path.insert(0, os.path.join(HERE, "..", "servers", "engine"))
+    import server  # noqa: PLC0415
+    import scene_grid as scene_grid_mod  # noqa: PLC0415
+    from seed_gfx_town import compute_arrival_hints, load_cell_verdicts  # noqa: PLC0415
+
+    c = server.load_campaign(campaign_id)
+    if c is None:
+        raise SystemExit(f"no campaign with id {campaign_id!r} under {state_dir!r}")
+
+    party_ids = set(getattr(c, "party", []) or [])
+    current_loc = getattr(c, "current_location_id", None)
+    summary: dict = {"campaign_id": campaign_id, "state_dir": state_dir, "dry_run": dry_run,
+                     "locations": [], "total_hint_doors": 0, "total_relocations": 0}
+
+    def _at(ch, loc_id: str) -> bool:
+        """A character is IN ``loc_id`` if its ``location_id`` says so, OR (mirroring how the engine
+        co-locates the party) it carries no explicit location and this is the campaign's current
+        location — so a freshly-seated PC standing on the current room is still relocated."""
+        lid = getattr(ch, "location_id", None)
+        return lid == loc_id or (lid is None and loc_id == current_loc)
+
+    for lid, loc in c.locations.items():
+        grid = getattr(loc, "scene_grid", None)
+        if grid is None:
+            continue
+        room = _report_room(coherence_dir, loc, grid)
+        if room is None:
+            continue
+        verdicts = load_cell_verdicts(coherence_dir, room)
+        if not verdicts:
+            continue
+        cols = int(grid.grid.cols)
+        rows = int(grid.grid.rows)
+        if cols <= 0 or rows <= 0:
+            continue
+        door_cells = [tuple(d) for d in (getattr(grid, "door_cells", None) or [])]
+        blocked = {tuple(x) for x in scene_grid_mod.impassable_cells(grid, cols, rows)}
+
+        # (1) arrival hints — ADDITIVE merge (never clobber a door key already present).
+        computed = compute_arrival_hints(door_cells, blocked, cols, rows, verdicts)
+        existing = dict(getattr(grid, "arrival_hints", None) or {})
+        added = {k: v for k, v in computed.items() if k not in existing}
+        merged = {**existing, **added}
+
+        # (2) relocate party tokens off coherence-COVERED cells. Occupancy = every member's cell in
+        # this room; move a covered mover to the nearest open cell not already claimed.
+        occupied: set = set()
+        for ch in c.characters.values():
+            if _at(ch, loc.id) and getattr(ch, "stage_cell", None) is not None:
+                occupied.add((int(ch.stage_cell[0]), int(ch.stage_cell[1])))
+        relocations: list[dict] = []
+        for cid, ch in c.characters.items():
+            travels = cid in party_ids or getattr(ch, "kind", "") in ("player", "companion")
+            if not travels or not _at(ch, loc.id):
+                continue
+            sc = getattr(ch, "stage_cell", None)
+            if sc is None:
+                continue
+            here = (int(sc[0]), int(sc[1]))
+            if verdicts.get(here) != "covered":
+                continue
+            avoid = blocked | (occupied - {here})
+            dest = _nearest_open(here, cols, rows, avoid, verdicts)
+            if dest is None or dest == here:
+                continue
+            relocations.append({"character": cid, "from": list(here), "to": list(dest)})
+            occupied.discard(here)
+            occupied.add(dest)
+            if not dry_run:
+                ch.stage_cell = dest
+
+        if not dry_run and added:
+            grid.arrival_hints = merged
+
+        summary["locations"].append({
+            "location_id": lid, "room": room,
+            "doors_with_hints": len(merged), "doors_added": len(added),
+            "hint_counts": {k: len(v) for k, v in sorted(merged.items())},
+            "relocations": relocations,
+        })
+        summary["total_hint_doors"] += len(added)
+        summary["total_relocations"] += len(relocations)
+
+    if not dry_run:
+        server.save_campaign(c)
+
+    return summary
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Bake coherence-aware arrival hints into a live campaign.")
+    ap.add_argument("state_dir")
+    ap.add_argument("campaign_id")
+    ap.add_argument("--dry-run", action="store_true", help="compute + print; write nothing")
+    ap.add_argument("--coherence-dir", default=os.path.join(HERE, "evidence", "paint-coherence"))
+    args = ap.parse_args()
+
+    summary = migrate(args.state_dir, args.campaign_id, args.coherence_dir, args.dry_run)
+
+    mode = "DRY-RUN (no save)" if args.dry_run else "WROTE snapshot"
+    print(f"[migrate_arrival_hints] {mode}: campaign={summary['campaign_id']} "
+          f"state_dir={summary['state_dir']}")
+    if not summary["locations"]:
+        print("  no coherence-covered locations found — nothing to migrate (byte-identical).")
+    for loc in summary["locations"]:
+        print(f"  {loc['location_id']} (report={loc['room']}): "
+              f"{loc['doors_added']} door(s) newly hinted, {loc['doors_with_hints']} total; "
+              f"hint_counts={loc['hint_counts']}")
+        for rel in loc["relocations"]:
+            print(f"    relocate {rel['character']}: {rel['from']} (covered) -> {rel['to']} (open)")
+    print(f"  TOTAL: {summary['total_hint_doors']} door(s) hinted, "
+          f"{summary['total_relocations']} token(s) relocated across "
+          f"{len(summary['locations'])} location(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/qa/seed_gfx_town.py
+++ b/qa/seed_gfx_town.py
@@ -122,6 +122,39 @@ def choose_spawns(cols: int, rows: int, blocked: set, door_cells: list,
     return {"party": chosen[:n_party], "npcs": chosen[n_party:n_party + n_npc]}
 
 
+def compute_arrival_hints(door_cells: list, blocked: set, cols: int, rows: int,
+                          cell_verdicts: dict | None, max_per_door: int = 6) -> dict:
+    """Coherence-aware ARRIVAL HINTS (#1647 wave-2) baked into world data: for EACH door, an ordered
+    list of the visually-OPEN cells nearest that door — the cells a cross_door arrival should PREFER
+    so the party never lands on a grid-open cell the player SEES as under painted furniture (the
+    "Aldric on the tavern bar" bug). Keyed by the door cell string ``f"{c},{r}"`` (the same key
+    ``_seed_stage_cells_on_arrival`` looks the arrival door up by); value = list of ``[c, r]`` cells,
+    nearest-the-door first (Chebyshev, stable (r, c) tiebreak).
+
+    DOOR-RING-SAFE: a hint is never a door cell itself (arriving ON a threshold) and never a `blocked`
+    wall/prop cell — the engine additionally re-checks reachability + freeness at arrival time, so a
+    hint is only ever a PREFERENCE, never a forced placement. Requires a coherence report: with
+    ``cell_verdicts is None`` (no report for this room) it returns ``{}`` — the grid then behaves
+    BYTE-IDENTICALLY to the pre-#1647 world (the SceneGrid serializer omits an empty ``arrival_hints``).
+    Deterministic + pure, so it is unit-testable."""
+    if not cell_verdicts:
+        return {}
+    door_set = {tuple(d) for d in door_cells}
+    open_cells = [
+        (c, r)
+        for r in range(rows) for c in range(cols)
+        if cell_verdicts.get((c, r)) == "open" and (c, r) not in blocked and (c, r) not in door_set
+    ]
+    hints: dict = {}
+    for d in door_cells:
+        dc, dr = int(d[0]), int(d[1])
+        ranked = sorted(open_cells, key=lambda p: (max(abs(p[0] - dc), abs(p[1] - dr)), p[1], p[0]))
+        picked = ranked[:max_per_door]  # tuples — the same Cell convention door_cells/spawns use
+        if picked:
+            hints[f"{dc},{dr}"] = picked
+    return hints
+
+
 def build_grid_from_geometry(geo: dict, location_id: str, town_id: str, room: str,
                              door_pairs: list, coherence_reports_dir=None) -> "SceneGrid":
     """SceneGrid from a generate_town room geometry: perimeter/prop cells impassable, door cells
@@ -166,8 +199,10 @@ def build_grid_from_geometry(geo: dict, location_id: str, town_id: str, room: st
                                mood="lantern-lit stone district"),
     )
     grid.door_cells = door_cells
-    grid.spawns = choose_spawns(cols, rows, blocked, door_cells,
-                                cell_verdicts=load_cell_verdicts(coherence_reports_dir, room))
+    verdicts = load_cell_verdicts(coherence_reports_dir, room)
+    grid.spawns = choose_spawns(cols, rows, blocked, door_cells, cell_verdicts=verdicts)
+    # #1647 wave-2: bake coherence-aware arrival hints (no-op → {} without a report; omitted on dump).
+    grid.arrival_hints = compute_arrival_hints(door_cells, blocked, cols, rows, verdicts)
     grid.art.layout_hash = _layout_hash(grid)
     return grid
 

--- a/qa/test_arrival_hints_seed.py
+++ b/qa/test_arrival_hints_seed.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Unit proof for compute_arrival_hints — the seed-side of coherence-aware arrival hints (#1647 wave-2).
+
+For each door, the hint list is the visually-OPEN cells (per the paint-coherence verdicts) NEAREST the
+door, ordered by Chebyshev distance, door-ring-safe (never a door cell) and never a blocked wall/prop.
+No coherence report ⇒ ``{}`` (byte-identical to the pre-#1647 world). Pure + deterministic.
+
+Run: python3 -m pytest qa/test_arrival_hints_seed.py -q -p no:xdist
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from seed_gfx_town import compute_arrival_hints, load_cell_verdicts  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+COHERENCE = REPO / "qa" / "evidence" / "paint-coherence"
+
+
+def test_none_verdicts_yields_no_hints():
+    """No coherence report (cell_verdicts=None) ⇒ {} ⇒ additive/byte-identical."""
+    assert compute_arrival_hints([(5, 0)], set(), 10, 10, None) == {}
+    assert compute_arrival_hints([(5, 0)], set(), 10, 10, {}) == {}
+
+
+def test_hints_are_open_cells_nearest_the_door():
+    """A door at (5,0): the hint list is OPEN cells ordered nearest-first, and (5,5) [covered] is
+    excluded even though it is grid-open."""
+    verdicts = {(5, 1): "open", (4, 1): "open", (5, 5): "covered", (2, 8): "open"}
+    hints = compute_arrival_hints([(5, 0)], blocked=set(), cols=10, rows=10,
+                                  cell_verdicts=verdicts, max_per_door=6)
+    cells = hints["5,0"]
+    assert (5, 5) not in cells                      # covered — never hinted
+    assert cells[0] in ((5, 1), (4, 1))             # nearest the door first (Chebyshev 1)
+    assert cells[-1] == (2, 8)                       # the far open cell ranks last
+    assert set(cells) == {(5, 1), (4, 1), (2, 8)}
+
+
+def test_door_and_blocked_cells_are_never_hinted():
+    """Door-ring-safe: a door cell itself and any blocked wall/prop cell are excluded from hints even
+    when the verdict map calls them open."""
+    verdicts = {(5, 0): "open", (3, 3): "open", (6, 6): "open"}
+    hints = compute_arrival_hints([(5, 0)], blocked={(3, 3)}, cols=10, rows=10,
+                                  cell_verdicts=verdicts)
+    cells = hints["5,0"]
+    assert (5, 0) not in cells      # the door cell (arriving on the threshold)
+    assert (3, 3) not in cells      # a blocked wall/prop cell
+    assert cells == [(6, 6)]
+
+
+def test_per_door_keys_and_cap():
+    """Each door gets its own key; `max_per_door` caps the list length."""
+    verdicts = {(c, r): "open" for r in range(1, 9) for c in range(1, 9)}
+    hints = compute_arrival_hints([(0, 0), (9, 9)], blocked=set(), cols=10, rows=10,
+                                  cell_verdicts=verdicts, max_per_door=3)
+    assert set(hints) == {"0,0", "9,9"}
+    assert len(hints["0,0"]) == 3
+    # nearest the (0,0) door first
+    assert hints["0,0"][0] == (1, 1)
+    assert hints["9,9"][0] == (8, 8)
+
+
+def test_real_tavern_report_produces_hints():
+    """End-to-end against the checked-in tavern coherence report: the tavern's authored door yields a
+    non-empty hint list of cells the report classifies OPEN."""
+    verdicts = load_cell_verdicts(str(COHERENCE), "tavern")
+    assert verdicts, "tavern coherence report should load"
+    # tavern authored door (per qa test fixtures) — use whatever open cells exist near a plausible door.
+    door = (7, 0)
+    hints = compute_arrival_hints([door], blocked=set(), cols=14, rows=10, cell_verdicts=verdicts)
+    cells = hints.get("7,0", [])
+    assert cells, "expected open hint cells near the tavern door"
+    for cell in cells:
+        assert verdicts.get(cell) == "open"

--- a/qa/test_migrate_arrival_hints.py
+++ b/qa/test_migrate_arrival_hints.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Live-save migration proof for migrate_arrival_hints.py (#1647 wave-2).
+
+On a SYNTHETIC save (never the owner's real state): a location whose room has a paint-coherence report
+gets ``scene_grid.arrival_hints`` baked in ADDITIVELY, and a party token standing on a coherence-COVERED
+cell is relocated to the nearest visually-OPEN cell — so the "Aldric standing ON the tavern bar" state
+ends the instant the migration runs. Also proves --dry-run writes nothing.
+
+Run: python3 -m pytest qa/test_migrate_arrival_hints.py -q -p no:xdist
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+QA = Path(__file__).resolve().parent
+ENGINE = QA.parent / "servers" / "engine"
+for p in (str(QA), str(ENGINE)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+COHERENCE = QA / "evidence" / "paint-coherence"
+COVERED_CELL = (7, 1)   # verdict 'covered' in the checked-in tavern_coherence_report.json
+COLS, ROWS = 14, 10
+DOOR = (0, 5)
+
+
+def _seed_synthetic(state_dir: str) -> tuple[str, str, str]:
+    """A one-room 'tavern' campaign with a hint-less scene_grid and a PC parked on a COVERED cell."""
+    os.environ["WORLDOS_STATE_DIR"] = state_dir
+    import server  # noqa: PLC0415
+    from scene_grid import SceneGrid, SceneGridSpec, SceneCellDefault  # noqa: PLC0415
+
+    cid = server.create_campaign("migrate-test")["id"]
+    tavern = server.add_location(campaign_id=cid, name="Tavern", location_id="tavern",
+                                 make_current=True)["id"]
+    c = server._require(cid)
+    c.locations[tavern].scene_grid = SceneGrid(
+        scene_id=f"{cid}:tavern", location_id="tavern", kind="town_room", biome="tavern",
+        grid=SceneGridSpec(cols=COLS, rows=ROWS, cell_size_ft=5, projection="dimetric-2to1"),
+        cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
+        cells=[], props=[], door_cells=[DOOR],
+    )
+    server.save_campaign(c)
+    hero = server.create_character(cid, "Aldric", kind="player", max_hp=30, add_to_party=True,
+                                   location_id=tavern)["id"]
+    c = server._require(cid)
+    c.characters[hero].stage_cell = COVERED_CELL   # standing ON the bar
+    server.save_campaign(c)
+    return cid, tavern, hero
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    import server  # noqa: PLC0415
+    from migrate_arrival_hints import migrate  # noqa: PLC0415
+    from seed_gfx_town import load_cell_verdicts  # noqa: PLC0415
+
+    cid, tavern, hero = _seed_synthetic(str(tmp_path))
+    summary = migrate(str(tmp_path), cid, str(COHERENCE), dry_run=True)
+
+    assert summary["total_hint_doors"] >= 1
+    assert summary["total_relocations"] == 1   # computed, but NOT persisted
+
+    reloaded = server.load_campaign(cid)
+    grid = reloaded.locations[tavern].scene_grid
+    assert not (getattr(grid, "arrival_hints", None) or {})     # nothing written
+    assert tuple(reloaded.characters[hero].stage_cell) == COVERED_CELL  # token unmoved
+
+
+def test_migration_bakes_hints_and_relocates_off_covered(tmp_path):
+    import server  # noqa: PLC0415
+    from migrate_arrival_hints import migrate  # noqa: PLC0415
+    from seed_gfx_town import load_cell_verdicts  # noqa: PLC0415
+
+    cid, tavern, hero = _seed_synthetic(str(tmp_path))
+    verdicts = load_cell_verdicts(str(COHERENCE), "tavern")
+    assert verdicts.get(COVERED_CELL) == "covered"
+
+    summary = migrate(str(tmp_path), cid, str(COHERENCE), dry_run=False)
+
+    # (1) arrival hints baked additively for the door.
+    reloaded = server.load_campaign(cid)
+    grid = reloaded.locations[tavern].scene_grid
+    hints = getattr(grid, "arrival_hints", None) or {}
+    assert f"{DOOR[0]},{DOOR[1]}" in hints
+    assert hints[f"{DOOR[0]},{DOOR[1]}"], "door should have at least one open hint cell"
+    for cell in hints[f"{DOOR[0]},{DOOR[1]}"]:
+        assert verdicts.get(tuple(cell)) == "open"
+
+    # (2) the PC was relocated OFF the covered cell to an OPEN cell.
+    new_cell = tuple(reloaded.characters[hero].stage_cell)
+    assert new_cell != COVERED_CELL
+    assert verdicts.get(new_cell) == "open"
+    assert summary["total_relocations"] == 1
+
+
+def test_second_run_is_idempotent_additive(tmp_path):
+    """Re-running the migration adds no new door keys (already present) and relocates nothing (the PC
+    is already on an open cell) — additive + safe to re-run."""
+    import server  # noqa: PLC0415
+    from migrate_arrival_hints import migrate  # noqa: PLC0415
+
+    cid, tavern, hero = _seed_synthetic(str(tmp_path))
+    migrate(str(tmp_path), cid, str(COHERENCE), dry_run=False)
+    summary2 = migrate(str(tmp_path), cid, str(COHERENCE), dry_run=False)
+
+    assert summary2["total_hint_doors"] == 0     # no NEW door keys added
+    assert summary2["total_relocations"] == 0    # already on open floor

--- a/servers/engine/scene_grid.py
+++ b/servers/engine/scene_grid.py
@@ -32,7 +32,7 @@ import json
 import random
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, model_serializer
 
 from models import _StrictModel
 
@@ -131,8 +131,35 @@ class SceneGrid(_StrictModel):
     # docs/roadmap/ROOM-OCCLUSION-PATHING-SPRINTS.md.
     door_cells: list[Cell] = Field(default_factory=list)
     protected_lane_cells: list[Cell] = Field(default_factory=list)
+    # ARRIVAL HINTS (#1647 wave-2; additive, empty == today): world-data-baked, coherence-aware
+    # preferred arrival cells so a cross_door arrival never lands the party on a grid-open cell that
+    # the player SEES as under painted furniture (the "Aldric on the tavern bar" bug). Keyed by the
+    # ARRIVAL-DOOR cell string ``f"{c},{r}"`` (the same door cell ``_seed_stage_cells_on_arrival``
+    # resolves); the value is an ORDERED list of ``[c, r]`` preferred cells (visually-OPEN, nearest
+    # the door first). The engine stays PAINT-BLIND — it merely PREFERS the first hinted cell that is
+    # reachable + free, then falls back to today's nearest-free logic. The seed side
+    # (qa/seed_gfx_town.build_grid_from_geometry) computes these from the paint-coherence reports;
+    # a room with no report gets ``{}`` and behaves BYTE-IDENTICALLY to the pre-#1647 world (the wrap
+    # serializer below OMITS the key when empty, so a hint-less grid dumps exactly as before).
+    arrival_hints: dict[str, list[Cell]] = Field(default_factory=dict)
     lighting: SceneLighting = Field(default_factory=SceneLighting)
     art: SceneArt = Field(default_factory=SceneArt)
+
+    @model_serializer(mode="wrap")
+    def _ser_omit_empty_arrival_hints(self, handler):
+        """OMIT ``arrival_hints`` from the dump when empty so a grid the seed never computed hints
+        for serializes BYTE-IDENTICALLY to a pre-#1647-wave-2 snapshot (which never carried the key).
+        Narrowly scoped to ONE key (NOT a blanket ``exclude_defaults``) for the SAME reason
+        Location._ser_omit_none_scene_grid / Character._ser_omit_none_stage_cell are: the store's
+        dirty-skip byte-compares the candidate dump to disk, so emitting ``"arrival_hints": {}`` for
+        every hint-less grid (a key old snapshots lack) would defeat the no-op-save guard and silently
+        rewrite files on a pure load->save. A grid WITH hints serializes them normally; all other
+        keys/order are preserved exactly. Respects any ``include``/``exclude`` the caller passed (e.g.
+        ``_layout_hash``'s ``include=`` set, which never lists ``arrival_hints``)."""
+        data = handler(self)
+        if not self.arrival_hints:
+            data.pop("arrival_hints", None)
+        return data
 
 
 # ── Deterministic seed derivation ───────────────────────────────────────────────────

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4886,9 +4886,33 @@ def _seed_stage_cells_on_arrival(
     # Candidate rest cells: every FREE cell reachable from the door (routes around walls/props so
     # nobody lands in a walled-off pocket), ranked nearest-first with a stable (y, x) tiebreak.
     reach = combat_grid.reachable(door, width + height, set(), width, height, impassable=blocked)
-    candidates = iter(
-        sorted(reach, key=lambda cell: (combat_grid.chebyshev_cells(cell, door), cell[1], cell[0]))
-    )
+    nearest = sorted(reach, key=lambda cell: (combat_grid.chebyshev_cells(cell, door), cell[1], cell[0]))
+    # ARRIVAL HINTS (#1647 wave-2): world-data-baked preferred arrival cells for THIS arrival door.
+    # The engine stays PAINT-BLIND — it merely PREFERS a hinted cell that is reachable + free (in
+    # `reach`; `reach` already excludes the door/start cell and every `blocked` occupancy/terrain
+    # cell), in the authored order, then falls back to the nearest-free ranking below. Keyed by the
+    # resolved arrival-door cell string. ADDITIVE: no `arrival_hints` (or none for this door) ⇒
+    # `hinted` is empty ⇒ the candidate order is BYTE-IDENTICALLY today's nearest-free `sorted(reach)`.
+    hints_map = getattr(grid, "arrival_hints", None) or {}
+    hinted: list[tuple[int, int]] = []
+    if hints_map:
+        seen_h: set[tuple[int, int]] = set()
+        for entry in hints_map.get(f"{door[0]},{door[1]}") or []:
+            if not (isinstance(entry, (list, tuple)) and len(entry) == 2):
+                print(f"[arrival_hints] {dest.id}: malformed hint {entry!r} for door {door} — ignored",
+                      file=sys.stderr)
+                continue
+            try:
+                cell = (int(entry[0]), int(entry[1]))
+            except (TypeError, ValueError):
+                print(f"[arrival_hints] {dest.id}: non-int hint {entry!r} for door {door} — ignored",
+                      file=sys.stderr)
+                continue
+            if cell in reach and cell not in seen_h:  # reachable + free; dedupe repeats
+                hinted.append(cell)
+                seen_h.add(cell)
+    hinted_set = set(hinted)
+    candidates = iter(hinted + [cell for cell in nearest if cell not in hinted_set])
     # Traveling party = the members _move_party_to just co-located here (PC(s) + companions), in
     # c.characters insertion order for a deterministic seat assignment. Cells are unique + consumed
     # sequentially, so each member lands on a distinct cell (no stacking).

--- a/servers/engine/tests/test_arrival_hints.py
+++ b/servers/engine/tests/test_arrival_hints.py
@@ -1,0 +1,163 @@
+"""Coherence-aware ARRIVAL HINTS (#1647 wave-2): a cross_door arrival must PREFER a world-data-baked
+hinted cell (a visually-OPEN cell the seed computed from the paint-coherence report) over the naive
+nearest-free cell, so the party never lands on a grid-open cell the player SEES as under painted
+furniture (owner's "Aldric standing ON the tavern bar" bug).
+
+The engine stays PAINT-BLIND — ``_seed_stage_cells_on_arrival`` reads ``scene_grid.arrival_hints`` and
+prefers the first hint that is reachable + free, then falls back to today's nearest-free logic. These
+tests drive the seed function directly (as test_arrival_reciprocal_door.py does) and assert:
+  * a hint is honored (member lands on the hinted cell, not the nearest-free cell);
+  * an occupied/blocked hint SKIPS to the next hint;
+  * ABSENT hints are byte-identical to today (placement AND serialization);
+  * malformed hints are logged (loud) and ignored — never a crash.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import combat_grid  # noqa: E402  (conftest puts servers/engine on the path)
+import server  # noqa: E402
+from scene_grid import SceneGrid, SceneGridSpec, SceneCellDefault  # noqa: E402
+
+COLS, ROWS = 10, 10
+DOOR = (5, 0)               # door_cells[0]; with source_id=None the arrival anchors here
+NEAREST_FREE = (4, 0)       # sorted(reach, key=(chebyshev, r, c))[0] for an all-floor room
+
+
+def _mk_campaign(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("arrival-hints")["id"]
+    dest = server.add_location(campaign_id=cid, name="Dest", make_current=True)["id"]
+    return cid, dest
+
+
+def _author_grid(cid, loc_id, *, arrival_hints=None):
+    """An all-floor 10x10 room with a single door at (5,0). ``arrival_hints`` (if given) uses tuple
+    cells — the same Cell convention door_cells/spawns use — so it round-trips through the store."""
+    c = server._require(cid)
+    grid = SceneGrid(
+        scene_id=f"{cid}:{loc_id}", location_id=loc_id, kind="dungeon", biome="test",
+        grid=SceneGridSpec(cols=COLS, rows=ROWS, cell_size_ft=5, projection="dimetric-2to1"),
+        cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
+        cells=[], props=[], door_cells=[DOOR],
+    )
+    if arrival_hints is not None:
+        grid.arrival_hints = arrival_hints
+    c.locations[loc_id].scene_grid = grid
+    server.save_campaign(c)
+
+
+def _seat(cid, dest, name="Hero", kind="player", cell=None):
+    hid = server.create_character(cid, name, kind=kind, max_hp=20)["id"]
+    c = server._require(cid)
+    c.characters[hid].location_id = dest
+    if cell is not None:
+        c.characters[hid].stage_cell = cell
+    server.save_campaign(c)
+    return hid
+
+
+def _run_seed(cid, dest, source_id=None):
+    c = server._require(cid)
+    placed = server._seed_stage_cells_on_arrival(c, c.locations[dest], source_id=source_id)
+    return placed, c
+
+
+def test_hint_is_honored_over_nearest_free(tmp_path, monkeypatch):
+    """A single traveling member lands on the FIRST hinted cell (5,5) — far from the door — instead
+    of the nearest-free cell (4,0) the pre-#1647 logic would pick."""
+    cid, dest = _mk_campaign(tmp_path, monkeypatch)
+    _author_grid(cid, dest, arrival_hints={f"{DOOR[0]},{DOOR[1]}": [(5, 5), (6, 6)]})
+    hero = _seat(cid, dest)
+
+    placed, c = _run_seed(cid, dest)
+
+    assert placed == [hero]
+    assert tuple(c.characters[hero].stage_cell) == (5, 5)
+    assert tuple(c.characters[hero].stage_cell) != NEAREST_FREE
+
+
+def test_occupied_hint_skips_to_next(tmp_path, monkeypatch):
+    """When the first hint is occupied (a stationary NPC stands on it ⇒ it is `blocked` ⇒ not in
+    `reach`), the arriving member skips to the NEXT hint (6,6), not back to the nearest-free cell."""
+    cid, dest = _mk_campaign(tmp_path, monkeypatch)
+    _author_grid(cid, dest, arrival_hints={f"{DOOR[0]},{DOOR[1]}": [(5, 5), (6, 6)]})
+    # A stationary NPC (kind that does NOT travel) sits on the first hint -> occupied/blocked there.
+    _seat(cid, dest, name="Barkeep", kind="npc", cell=(5, 5))
+    hero = _seat(cid, dest)
+
+    placed, c = _run_seed(cid, dest)
+
+    assert placed == [hero]
+    assert tuple(c.characters[hero].stage_cell) == (6, 6)
+
+
+def test_two_members_consume_hints_in_order(tmp_path, monkeypatch):
+    """Two traveling members claim distinct hinted cells in order (hint[0] then hint[1]) — a sequential
+    consume, never a stack, mirroring the nearest-free contention discipline."""
+    cid, dest = _mk_campaign(tmp_path, monkeypatch)
+    _author_grid(cid, dest, arrival_hints={f"{DOOR[0]},{DOOR[1]}": [(5, 5), (6, 6)]})
+    a = _seat(cid, dest, name="Aldric", kind="player")
+    b = _seat(cid, dest, name="Shadowheart", kind="companion")
+
+    placed, c = _run_seed(cid, dest)
+
+    assert set(placed) == {a, b}
+    cells = {tuple(c.characters[a].stage_cell), tuple(c.characters[b].stage_cell)}
+    assert cells == {(5, 5), (6, 6)}
+
+
+def test_absent_hints_is_byte_identical_placement(tmp_path, monkeypatch):
+    """No arrival_hints ⇒ the arriving member lands on the nearest-free cell (4,0) — byte-identical to
+    the pre-#1647 nearest-free logic. Proven against BOTH an empty-dict grid and a never-set grid."""
+    cid, dest = _mk_campaign(tmp_path, monkeypatch)
+    _author_grid(cid, dest, arrival_hints={})   # explicit empty
+    hero = _seat(cid, dest)
+    placed, c = _run_seed(cid, dest)
+    assert placed == [hero]
+    assert tuple(c.characters[hero].stage_cell) == NEAREST_FREE
+
+    # A grid constructed WITHOUT ever setting arrival_hints places identically.
+    cid2, dest2 = _mk_campaign(tmp_path, monkeypatch)
+    _author_grid(cid2, dest2, arrival_hints=None)
+    hero2 = _seat(cid2, dest2)
+    _, c2 = _run_seed(cid2, dest2)
+    assert tuple(c2.characters[hero2].stage_cell) == NEAREST_FREE
+
+
+def test_empty_arrival_hints_omitted_from_dump_present_when_set():
+    """Serializer byte-identity: an empty ``arrival_hints`` is OMITTED from the dump (so a hint-less
+    grid serializes exactly as a pre-#1647-wave-2 snapshot and the store's no-op-save guard holds);
+    a populated one serializes normally."""
+    grid = SceneGrid(
+        scene_id="c:loc", location_id="loc",
+        grid=SceneGridSpec(cols=COLS, rows=ROWS), cell_default=SceneCellDefault(),
+        door_cells=[DOOR],
+    )
+    dump_empty = grid.model_dump(mode="json")
+    assert "arrival_hints" not in dump_empty
+    assert "arrival_hints" not in json.dumps(dump_empty)
+
+    grid.arrival_hints = {f"{DOOR[0]},{DOOR[1]}": [(5, 5)]}
+    dump_set = grid.model_dump(mode="json")
+    assert dump_set["arrival_hints"] == {"5,0": [[5, 5]]}
+
+
+def test_malformed_hints_are_logged_and_ignored_not_crash(tmp_path, monkeypatch, capsys):
+    """Malformed hint entries (wrong arity, non-int) are logged LOUDLY to stderr and skipped; the one
+    well-formed hint (6,6) is still honored — never a crash."""
+    cid, dest = _mk_campaign(tmp_path, monkeypatch)
+    _author_grid(cid, dest)          # a valid, hint-less grid persists (round-trips cleanly)
+    hero = _seat(cid, dest)
+    # Inject malformed hints on the IN-MEMORY grid only (bypasses pydantic) to mimic a corrupted /
+    # hand-built grid, then seed WITHOUT a save/reload — the store would reject the invalid shape.
+    c = server._require(cid)
+    c.locations[dest].scene_grid.arrival_hints = {f"{DOOR[0]},{DOOR[1]}": [[1], "bad", [5, 5, 5], [6, 6]]}
+    placed = server._seed_stage_cells_on_arrival(c, c.locations[dest], source_id=None)
+
+    assert placed == [hero]
+    assert tuple(c.characters[hero].stage_cell) == (6, 6)  # only the well-formed hint survived
+    err = capsys.readouterr().err
+    assert "malformed hint" in err or "non-int hint" in err


### PR DESCRIPTION
## The owner-felt bug
Crossing a door places the party on a grid-open cell **under painted furniture** (Aldric standing ON the tavern bar; third owner report today). Root cause: door arrivals are picked engine-side at `cross_door` time by `_seed_stage_cells_on_arrival` (nearest reachable-free cell to the reciprocal door) with **zero paint knowledge**; the merged coherence instrument (`qa/paint_coherence.py`) knows exactly which cells are visually open.

Settled design (#1647 wave-2, on the issue): **ARRIVAL HINTS baked into WORLD DATA** — the engine stays paint-blind; it just *prefers* hinted cells.

## What changed
- **`servers/engine/scene_grid.py`** — new additive `SceneGrid.arrival_hints: dict[str, list[Cell]]` (keyed by arrival-door cell `"c,r"` → ordered preferred cells) + a `@model_serializer(mode="wrap")` that **OMITS the key when empty**, so a hint-less grid serializes **byte-identically** to a pre-wave-2 snapshot (the store's no-op-save guard holds). Mirrors the `stage_cell` / `scene_grid` omit-none discipline.
- **`servers/engine/server.py`** — `_seed_stage_cells_on_arrival` consults `arrival_hints` for the resolved arrival door FIRST (first hint that is **reachable + free** wins, in authored order), then falls back to today's nearest-free ranking. Malformed hint entries are logged loudly to stderr and skipped (never crash). **Absent/empty hints ⇒ candidate order is byte-identically today's `sorted(reach)`.**
- **`qa/seed_gfx_town.py`** — new pure `compute_arrival_hints(...)` (visually-OPEN cells nearest each door, door-ring-safe: never a door cell, never a blocked wall/prop). `build_grid_from_geometry` bakes hints from the coherence report; `seed_adventure_demo` + `seed_gfx_registered_world` inherit it via the shared path automatically. No report ⇒ `{}` ⇒ byte-identical.
- **`qa/migrate_arrival_hints.py`** (new) — live-save migration: loads a campaign via the same store API the seeds use (sole-writer: run with the engine STOPPED), bakes `arrival_hints` **additively** into every location with a coherence report (crypt/tavern/shop/tavern_snug/throne_hall), and **relocates any party token standing on a coherence-`covered` cell to the nearest open cell** — ends "standing on the bar" immediately. `--dry-run` computes + prints, writes nothing.

## Hint schema
`SceneGrid.arrival_hints`: `{ "<doorCol>,<doorRow>": [[c, r], ...] }` — key is the arrival-door cell (same cell `_seed_stage_cells_on_arrival` resolves); value is an ordered list of preferred `[c, r]` cells, visually-OPEN and nearest-the-door first. Empty ⇒ omitted on dump.

## Per-room hint counts (seed_adventure_demo, real coherence reports)
| room | doors | doors hinted | hint cells/door |
|---|---|---|---|
| camp_clearing (no report) | 2 | 0 | — (byte-identical) |
| tavern_snug | 2 | 2 | 6, 6 |
| shop | 1 | 1 | 6 |
| crypt | 2 | 2 | 6, 6 |
| throne_hall | 1 | 1 | 6 |

## Migration dry-run (on a COPY of a synthetic save)
```
[migrate_arrival_hints] DRY-RUN (no save): campaign=camp_5a37dd2e8864 state_dir=/tmp/synth_copy
  tavern (report=tavern): 1 door(s) newly hinted, 1 total; hint_counts={'0,5': 6}
    relocate char_752c72ee0e8c: [7, 1] (covered) -> [7, 0] (open)
  TOTAL: 1 door(s) hinted, 1 token(s) relocated across 1 location(s).
```
`diff -rq` src vs copy after the dry-run: **IDENTICAL** (wrote nothing).

## ⚠ Migration NOT run against the owner's real state (owner-surface discipline)
The orchestrator runs it, engine STOPPED. Exact invocation:
```
# 1) inspect first
python3 qa/migrate_arrival_hints.py <OWNER_STATE_DIR> <OWNER_CAMPAIGN_ID> --dry-run
# 2) apply (engine STOPPED; additive, sole-writer via the store's atomic save)
python3 qa/migrate_arrival_hints.py <OWNER_STATE_DIR> <OWNER_CAMPAIGN_ID>
```

## Tests (red-first) — all green
- `servers/engine/tests/test_arrival_hints.py` (6): hint honored; occupied hint skips to next; two-member ordered consume; **absent hints byte-identical (placement + dump-omits-key)**; malformed hints logged-not-crash.
- `qa/test_arrival_hints_seed.py` (5): open-cells-nearest-door; None⇒{}; door/blocked never hinted; per-door keys + cap; real tavern report.
- `qa/test_migrate_arrival_hints.py` (3): bakes + relocates off covered; --dry-run writes nothing; idempotent re-run.
- Regression: full engine suite **3551 passed**; scene_grid/arrival/cross_door/seed suites green; `license check passed`.

Do NOT merge yet — orchestrator review + adversarial-invariant-verify.