### PR TITLE
qa: fix bash-5.3 unbound-variable crash in the DM transient-retry path

### DIFF
--- a/qa/run_adventure.sh
+++ b/qa/run_adventure.sh
@@ -379,7 +379,7 @@ turn_retry() {  # transient-aware empty-output retry (mirrors run_duo)
     last_rc="$(cat "$STATE_DIR/.dm_last_rc" 2>/dev/null | tail -n1)"; last_rc="${last_rc:-0}"
     transient=0; worldos_dm_failure_is_transient "$last_out" "$last_rc" && transient=1
     if [ "$transient" != "1" ] && [ "$attempt" -ge 2 ]; then echo "[adventure] empty ($1) — REAL failure; stop retry." >&2; break; fi
-    if [ "$transient" = "1" ]; then echo "[adventure] empty ($1) — transient; retry $((attempt+1))/$max…" >&2; worldos_dm_retry_backoff "$attempt"; else echo "[adventure] empty ($1) — retry once…" >&2; fi
+    if [ "$transient" = "1" ]; then echo "[adventure] empty ($1) — transient; retry $((attempt+1))/${max}…" >&2; worldos_dm_retry_backoff "$attempt"; else echo "[adventure] empty ($1) — retry once…" >&2; fi
     if [ "${3:-}" = "1" ]; then
       worldos_dm_remint_session_on_retry --session-id "$2"; local _fresh="$2"
       [ "${#WORLDOS_DM_RETRY_SESSION[@]}" -ge 2 ] && _fresh="${WORLDOS_DM_RETRY_SESSION[1]}"


### PR DESCRIPTION
adv_live3's beat-2 DM timeout (rc=124) was correctly classified TRANSIENT, but the retry-announce echo — `retry $((attempt+1))/$max…` — crashed with `max�: unbound variable` before the retry ran, turning a recoverable timeout into a fatal beat and ending the run.

Root cause: homebrew **bash 5.3.15** under `set -u` gloms the first byte of the U+2026 ellipsis into the variable-name scan when it directly abuts `$max` (`/bin/bash` 3.2 parses it fine). Red-first repro in the commit message. Fix: brace the expansion (`${max}…`). Repo-wide sweep for `$var` abutting a multibyte char found exactly this one instance.

This unblocks the #1656/#1657/#1659 acceptance rerun (adv_live4).