### PR TITLE
client: G4 punch batch — actor mesh-binding fix (#1666), runtime monster grounding/scale/tint (#1665), silhouette shader always-included + pre-flight guard (#1674)

### DIFF
--- a/docs/ROOM-PIPELINE-RUNBOOK.md
+++ b/docs/ROOM-PIPELINE-RUNBOOK.md
@@ -472,6 +472,23 @@ still land or the next build regresses.
 Tools/WorldOS/Build/macOS Player (Universal)   # Unity Editor menu item, on the box
 ```
 
+**★ ALWAYS-INCLUDED SHADERS pre-flight (#1674 — walk-behind silhouette shipped disabled, 2026-07-22):**
+`WorldOS/ActorSilhouette` (walk-behind mask) and `WorldOS/OccluderDepth` (occluder proxies) are resolved
+at runtime via `Shader.Find` and referenced by NO asset, so a player build strips them unless they are in
+Graphics → Always-Included Shaders. `BuildMacOSPlayer.Build()` now bakes both in itself (via
+`EnsureAlwaysIncludedShaders()`, no longer only the manual `Tools/WorldOS/W5b`), and records the resolved
+list on the report's `alwaysIncludedShaders=` line. Run the repo pre-flight BEFORE the box rebuild — it
+FAILS if the build source stops guaranteeing a required shader:
+
+```
+python3 qa/check_always_included_shaders.py                                   # source guarantee (pre-build)
+python3 qa/check_always_included_shaders.py --build-report BuildOutput/build-report.txt   # post-build confirm
+```
+
+Sync the shader files (`extensions/renderers/unity/shaders/ActorSilhouette.shader`,
+`OccluderDepth.shader`) to the box project's `Assets/Shaders/` before the rebuild; then `player_cert`'s
+silhouette assert flips GREEN and `WORLDOS_SILHOUETTE=0` reproduces the RED as the deliberate-regression proof.
+
 ### 10b. The sandbox hot-load GATE LOOP (the proven per-room iteration cycle, 2026-07-16)
 
 ```

--- a/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
+++ b/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
@@ -4,6 +4,7 @@ using System.IO;
 using UnityEditor;
 using UnityEditor.Build.Reporting;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 /// <summary>
 /// W5a (#1322) — macOS standalone PLAYER build, batch-mode-free (the box forbids `-batchmode`,
@@ -219,6 +220,14 @@ public static class BuildMacOSPlayer
         var scenes = new[] { new EditorBuildSettingsScene(SceneToBuild, true) };
         EditorBuildSettings.scenes = scenes;
 
+        // #1674: GUARANTEE the runtime-resolved shaders (Shader.Find, referenced by no asset) survive
+        // player-build variant stripping. Previously ONLY the manual Tools/WorldOS/W5b menu item added these
+        // to Always-Included; a box rebuild that skipped W5b shipped WITHOUT WorldOS/ActorSilhouette, so
+        // CombatSurfaceClient.EnsureSilhouetteMaterial warned once and the walk-behind mask silently no-op'd
+        // (#1674 / #1651 player_cert). Baking the registration into the build itself means the class can never
+        // ship silently again; qa/check_always_included_shaders.py is the pre-flight hard gate on the source.
+        string[] includedShaders = EnsureAlwaysIncludedShaders();
+
         string projectRoot = Directory.GetParent(Application.dataPath).FullName;
         string outDir = Path.Combine(projectRoot, OutputDir);
         Directory.CreateDirectory(outDir);
@@ -249,10 +258,46 @@ public static class BuildMacOSPlayer
             "buildEndedAt=" + s.buildEndedAt + "\n" +
             "platform=" + s.platform + "\n" +
             "architecture=" + archResult + "\n" +
+            "alwaysIncludedShaders=" + string.Join(",", includedShaders) + "\n" +
             "scenesBuilt=" + string.Join(",", options.scenes) + "\n");
 
         Debug.Log("[BuildMacOSPlayer] DONE result=" + s.result + " errors=" + s.totalErrors
             + " warnings=" + s.totalWarnings + " size=" + s.totalSize + " time=" + s.totalTime
             + " report=" + reportPath);
+    }
+
+    // #1674: shaders CombatSurfaceClient resolves at runtime via Shader.Find and that NO asset references, so
+    // the player build strips them unless they are listed in Graphics -> Always-Included Shaders. The player
+    // build MUST carry both or the runtime feature (occluder proxies / walk-behind silhouette) silently no-ops
+    // in the shipped .app. Keep this list in sync with qa/check_always_included_shaders.py (the pre-flight gate).
+    static readonly string[] RequiredAlwaysIncluded = { "WorldOS/OccluderDepth", "WorldOS/ActorSilhouette" };
+
+    // Ensure every RequiredAlwaysIncluded shader is registered in Graphics -> Always-Included Shaders
+    // (idempotent — mirrors W5bWireScene.EnsureAlwaysIncluded). Returns the resolved list for the build-report
+    // evidence. A shader missing from the project (not yet imported) is logged but does NOT abort the build;
+    // qa/check_always_included_shaders.py is the hard gate that fails the box build pre-flight in that case.
+    static string[] EnsureAlwaysIncludedShaders()
+    {
+        var so = new SerializedObject(GraphicsSettings.GetGraphicsSettings());
+        var arr = so.FindProperty("m_AlwaysIncludedShaders");
+        var present = new List<string>();
+        foreach (var name in RequiredAlwaysIncluded)
+        {
+            var sh = Shader.Find(name);
+            if (sh == null) { Debug.LogWarning("[BuildMacOSPlayer] #1674 required shader NOT FOUND (import it before ship): " + name); continue; }
+            bool already = false;
+            for (int i = 0; i < arr.arraySize; i++)
+                if (arr.GetArrayElementAtIndex(i).objectReferenceValue == sh) { already = true; break; }
+            if (!already)
+            {
+                arr.InsertArrayElementAtIndex(arr.arraySize);
+                arr.GetArrayElementAtIndex(arr.arraySize - 1).objectReferenceValue = sh;
+                Debug.Log("[BuildMacOSPlayer] #1674 +Always-Included " + name);
+            }
+            present.Add(name);
+        }
+        so.ApplyModifiedProperties();
+        AssetDatabase.SaveAssets();
+        return present.ToArray();
     }
 }

--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -296,6 +296,21 @@ public class CombatSurfaceClient : MonoBehaviour
     const float ActorHeightFoe = 4.2f;
     const float ActorHeightChar = 3.2f;
 
+    // #1665: cap a runtime-spawned MONSTER's height to the room's cell scale (<=2 cells) so an imposing
+    // foe (the throne_hall Goblin Boss, #1662) stays grounded-and-readable rather than looming ~2x the
+    // room props. Expressed in cells * CellSize so it tracks any room's cell scale (not a bare unit).
+    const float MonsterMaxCells = 2f;
+    // #1666: a resolved CHARACTER whose bind-pose figure is shorter than this (metres, model units) is a
+    // degenerate fragment (a disembodied hand/glove/prop mesh), not a humanoid — rebind to the template so
+    // the party can never render as a floating hand. A humanoid FBX imports at ~1.4-2.2m; a hand fragment
+    // <~0.4m. Character-scoped (monsters legitimately vary in size), matching the #1666 report (party PC).
+    const float MinBindHeight = 0.6f;
+    // #1666 template-humanoid fallback targets — mirror ResolveAsset's character defaults (fbxDef/albDef/
+    // animDef) so the guard rebinds to the SAME generic rigged humanoid the rest of the cast spawn correctly.
+    const string TemplateCharFbx = "Assets/chars_v2/patron_commoner/rigged.fbx";
+    const string TemplateCharAlbedo = "Assets/chars_v2/patron_commoner/albedo.jpg";
+    const string TemplateCharAnim = "Assets/chars_v2/patron_commoner/anim_idle.fbx";
+
     // W6.1 (#1460) RUNTIME OCCLUDER PROXIES: the runtime twin of the paint_combat_v1.cs:487-533 editor
     // bake. The engine ships `occluders` ({cells:[[c,r]...], band:"low"|"mid"|"tall"}) on /combat-surface
     // (viewer/server.py _combat_occluders) — the OCCLUDER props (columns/statues) with footprint cells +
@@ -1553,6 +1568,23 @@ public class CombatSurfaceClient : MonoBehaviour
         return b;
     }
 
+    // #1666: the tallest local BIND-pose extent across a prefab's mesh renderers, in the prefab's own units
+    // — read from sharedMesh.bounds (no Instantiate / BakeMesh, so it is a pure, edit-mode-testable measure).
+    // A humanoid FBX reports ~1.4-2.2m here; a disembodied hand/glove/prop fragment <~0.4m. SpawnActor uses
+    // this to reject a degenerate CHARACTER bind and fall back to the template humanoid (the floating-hand fix).
+    static float PrefabBindHeight(GameObject prefab)
+    {
+        if (prefab == null) return 0f;
+        float h = 0f;
+        foreach (var smr in prefab.GetComponentsInChildren<SkinnedMeshRenderer>(true))
+            if (smr != null && smr.sharedMesh != null)
+                h = Mathf.Max(h, smr.sharedMesh.bounds.size.y * Mathf.Abs(smr.transform.lossyScale.y));
+        foreach (var mf in prefab.GetComponentsInChildren<MeshFilter>(true))
+            if (mf != null && mf.sharedMesh != null)
+                h = Mathf.Max(h, mf.sharedMesh.bounds.size.y * Mathf.Abs(mf.transform.lossyScale.y));
+        return h;
+    }
+
     // Spawn one actor for a token that has no baked/prior GameObject. Mirrors paint_combat_v1.cs's
     // spawn() lambda: registry-resolve -> load prefab from the bundle -> pitch guard -> BIND-POSE scale
     // lock -> idle pose (embedded clip, else humanoid donor retarget) -> ground+center on the cell ->
@@ -1566,6 +1598,25 @@ public class CombatSurfaceClient : MonoBehaviour
         string fbx = aref[0], alb = aref[1];
         var prefab = LoadAsset<GameObject>(fbx);
         if (prefab == null) { Debug.LogWarning("[CSC] spawn MISSING model " + fbx + " for token " + id + " (bundle stale?)"); return null; }
+
+        // #1666 MESH-BINDING GUARD: reject a degenerate CHARACTER bind. The party PC rendered as a tiny
+        // disembodied hand floating over its marker ring in BOTH tavern_snug (rest) and crypt (combat) while
+        // the body meshes never appeared — a resolved model that is a hand/glove/prop fragment, not a figure.
+        // Measured on the RAW prefab bind (BEFORE the height normalization below, which would otherwise scale
+        // a fragment UP to human height and mask the defect). On a degenerate bind, rebind to the template
+        // humanoid so the party can never be invisible-but-for-a-hand, and log loudly (token+name+model+height)
+        // so the box session can repair the registry/asset that resolved a character to a fragment.
+        float bindH = kind == "character" ? PrefabBindHeight(prefab) : 0f;
+        if (kind == "character" && bindH < MinBindHeight && fbx != TemplateCharFbx)
+        {
+            Debug.LogWarning("[CSC] #1666 degenerate character bind for token " + id + " name='" + tokName
+                + "' model=" + fbx + " bindH=" + bindH.ToString("F2") + "m < " + MinBindHeight
+                + "m -> template humanoid fallback " + TemplateCharFbx);
+            fbx = TemplateCharFbx; alb = TemplateCharAlbedo;
+            aref = new[] { fbx, alb, TemplateCharAnim };
+            prefab = LoadAsset<GameObject>(fbx);
+            if (prefab == null) { Debug.LogWarning("[CSC] #1666 template model MISSING " + fbx + " for token " + id + " (bundle stale?)"); return null; }
+        }
 
         // #idle-fix: register the model + moveset fbx BEFORE the idle pose so the idle resolver (FindOwnClip)
         // can search this actor's OWN clips in EITHER source — a rigged char whose idle lives in a separate
@@ -1602,6 +1653,7 @@ public class CombatSurfaceClient : MonoBehaviour
         // idle first frame can't inflate curH and over-scale the actor.
         Bounds bb = Measure(go, rends); float curH = bb.size.y > 0.001f ? bb.size.y : 1f;
         float height = foe ? ActorHeightFoe : ActorHeightChar;   // #1441: named, single-source heights
+        if (foe) height = Mathf.Min(height, MonsterMaxCells * CellSize);   // #1665: cap a monster to <=2 cells (room-scaled, not looming ~2x the props)
         float sc = height / curH; go.transform.localScale = go.transform.localScale * sc;
 
         // #anim-pack: a VALID humanoid avatar retargets the shared RPG-pack controller (idle/walk/run +
@@ -1640,6 +1692,12 @@ public class CombatSurfaceClient : MonoBehaviour
             if (al != null)
             {
                 var mm = new Material(Shader.Find("Standard")); mm.mainTexture = al; mm.SetFloat("_Glossiness", 0.2f); mm.SetFloat("_Metallic", 0f);
+                // #1665: warm a runtime MONSTER toward the room's lit-ground ambient so a spawned foe reads
+                // integrated with the brazier-lit plate instead of pale/flat. The baked path bakes this warmth
+                // into the PainterlyActor _AmbientColor (#1524); here a conservative warm multiply on the
+                // Standard albedo tint, reusing the SAME WarmAmb/WARM_AMBIENT_FLOOR floor the grounding decals
+                // already use. Foe-scoped: party actors are intentionally untouched (not in the #1665 report).
+                if (foe) mm.color = Color.Lerp(mm.color, WarmAmb, WARM_AMBIENT_FLOOR);
                 foreach (var r in rends) r.sharedMaterial = mm;
             }
         }
@@ -2038,7 +2096,12 @@ public class CombatSurfaceClient : MonoBehaviour
         var anim = go.GetComponentInChildren<Animator>();
         if (anim == null || anim.avatar == null) { SampleClipRuntime(go, clip, 0f); return; }   // legacy rig
         KillIdleGraph(id);
-        anim.enabled = true; anim.Rebind();   // clear stale binding so the fresh graph output applies
+        // #1665 FLOAT FIX: the idle graph is re-evaluated every frame with Time.deltaTime (Update loop). If the
+        // idle clip carries ROOT MOTION and the Animator applies it, that per-frame root delta accumulates and
+        // drifts the actor UP off its grounded feet — the runtime monster "floating ~half a cell above the ring."
+        // Disable root motion so the idle breathes IN PLACE (mirrors the ctrlDriven path's applyRootMotion=false
+        // and the baked one-shot Evaluate, which never accumulates). Keeps feet planted at the grounded FloorY.
+        anim.enabled = true; anim.applyRootMotion = false; anim.Rebind();   // clear stale binding so the fresh graph output applies
         var g = UnityEngine.Playables.PlayableGraph.Create("Idle_" + go.name);
         var cp = UnityEngine.Animations.AnimationClipPlayable.Create(g, clip);
         var op = UnityEngine.Animations.AnimationPlayableOutput.Create(g, "Out", anim);

--- a/qa/check_always_included_shaders.py
+++ b/qa/check_always_included_shaders.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""check_always_included_shaders.py — box-build PRE-FLIGHT gate for #1674.
+
+Ground truth checked before writing this (2026-07-22): the Unity project's ProjectSettings/
+GraphicsSettings.asset is NOT carried in this repo (the box project holds it), so a Python gate cannot
+inspect the Always-Included Shaders list of a not-yet-built .app directly. What the repo DOES own is the
+shipping build source — extensions/renderers/unity/scripts/BuildMacOSPlayer.cs — which (as of #1674) bakes
+the required Shader.Find-resolved shaders into Always-Included at build time via EnsureAlwaysIncludedShaders().
+
+The regression #1674 caught: WorldOS/ActorSilhouette (the #1545/#1651 walk-behind silhouette) was resolved
+at runtime via Shader.Find and referenced by no asset, so the player build stripped it; the shipped .app
+logged "WorldOS/ActorSilhouette not found (add to Always-Included Shaders); walk-behind mask disabled" and
+the feature silently no-op'd. Only the manual Tools/WorldOS/W5b menu item added it — a step a box rebuild
+could (and did) skip. This gate makes that class un-shippable by FAILING the pre-flight whenever the build
+SOURCE stops guaranteeing a required shader is in Always-Included (someone deletes the registration, drops a
+shader from the list, or the shader file goes missing).
+
+What it verifies (all machine-checkable against repo files):
+  1. Each required shader FILE exists under extensions/renderers/unity/shaders/.
+  2. BuildMacOSPlayer.cs calls EnsureAlwaysIncludedShaders() from its player Build() path.
+  3. BuildMacOSPlayer.cs's RequiredAlwaysIncluded list names every required shader.
+
+Optionally (when --build-report PATH is given, i.e. post-build on the box) it also asserts the produced
+build-report.txt's `alwaysIncludedShaders=` line lists every required shader — the belt-and-braces
+post-build confirmation the runbook's packaged-check step runs against the installed app's report.
+
+Exit codes (tri-state, matching the sibling qa gates): 0 clean, 1 findings, 2 harness error.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Keep this list in sync with BuildMacOSPlayer.RequiredAlwaysIncluded (the C# source of truth).
+REQUIRED_SHADERS = ["WorldOS/OccluderDepth", "WorldOS/ActorSilhouette"]
+
+BUILD_SCRIPT_REL = "extensions/renderers/unity/scripts/BuildMacOSPlayer.cs"
+SHADER_DIR_REL = "extensions/renderers/unity/shaders"
+# shader-name -> its .shader filename (the file whose first line declares `Shader "<name>"`).
+SHADER_FILES = {
+    "WorldOS/OccluderDepth": "OccluderDepth.shader",
+    "WorldOS/ActorSilhouette": "ActorSilhouette.shader",
+}
+
+
+def evaluate_build_source(build_script_text: str, required=REQUIRED_SHADERS) -> list[str]:
+    """Pure check of the build-source guarantee. Returns a list of problem strings ([] == clean).
+
+    Testable with no filesystem: pass the BuildMacOSPlayer.cs text and the required shader names.
+    """
+    problems: list[str] = []
+    # Require the INVOCATION (`...();`), not merely the method definition (`...() {`) — otherwise deleting
+    # the call while leaving the helper defined would slip past the gate.
+    if "EnsureAlwaysIncludedShaders();" not in build_script_text:
+        problems.append(
+            "BuildMacOSPlayer.cs no longer calls EnsureAlwaysIncludedShaders() — the player build "
+            "does not guarantee runtime shaders survive variant stripping (#1674 regression class)."
+        )
+    for name in required:
+        if name not in build_script_text:
+            problems.append(
+                f"required Always-Included shader not registered in the build source: {name} "
+                "(add it to BuildMacOSPlayer.RequiredAlwaysIncluded)."
+            )
+    return problems
+
+
+def evaluate_build_report(report_text: str, required=REQUIRED_SHADERS) -> list[str]:
+    """Post-build confirmation: the report's `alwaysIncludedShaders=` line lists every required shader."""
+    problems: list[str] = []
+    line = None
+    for ln in report_text.splitlines():
+        if ln.startswith("alwaysIncludedShaders="):
+            line = ln[len("alwaysIncludedShaders="):]
+            break
+    if line is None:
+        problems.append("build-report.txt has no alwaysIncludedShaders= line (stale/pre-#1674 build).")
+        return problems
+    listed = {s.strip() for s in line.split(",") if s.strip()}
+    for name in required:
+        if name not in listed:
+            problems.append(f"build-report alwaysIncludedShaders is missing: {name} (shader stripped from the built .app).")
+    return problems
+
+
+def run(root: Path = ROOT, build_report: Path | None = None) -> tuple[int, list[str]]:
+    """Filesystem wrapper. Returns (exit_code, messages)."""
+    problems: list[str] = []
+
+    # 1) shader files present
+    shader_dir = root / SHADER_DIR_REL
+    for name in REQUIRED_SHADERS:
+        fname = SHADER_FILES.get(name)
+        if not fname:
+            problems.append(f"no known .shader filename mapped for required shader {name} (update SHADER_FILES).")
+            continue
+        if not (shader_dir / fname).is_file():
+            problems.append(f"required shader file missing: {SHADER_DIR_REL}/{fname} (for {name}).")
+
+    # 2 + 3) build-source guarantee
+    build_script = root / BUILD_SCRIPT_REL
+    try:
+        text = build_script.read_text(encoding="utf-8")
+    except OSError as exc:
+        return 2, [f"harness error: cannot read {BUILD_SCRIPT_REL}: {exc}"]
+    problems.extend(evaluate_build_source(text))
+
+    # optional post-build confirmation
+    if build_report is not None:
+        try:
+            rtext = Path(build_report).read_text(encoding="utf-8")
+        except OSError as exc:
+            return 2, [f"harness error: cannot read build report {build_report}: {exc}"]
+        problems.extend(evaluate_build_report(rtext))
+
+    return (1 if problems else 0), problems
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Pre-flight gate: required shaders are baked into Always-Included (#1674).")
+    ap.add_argument("--root", type=Path, default=ROOT, help="repo root (default: inferred from this file).")
+    ap.add_argument("--build-report", type=Path, default=None,
+                    help="optional BuildOutput/build-report.txt to also confirm post-build (box packaged-check).")
+    args = ap.parse_args(argv)
+
+    code, messages = run(args.root, args.build_report)
+    if code == 0:
+        print("[check_always_included_shaders] OK — build guarantees " + ", ".join(REQUIRED_SHADERS) + " in Always-Included.")
+    else:
+        tag = "HARNESS ERROR" if code == 2 else "FAIL"
+        print(f"[check_always_included_shaders] {tag} (#1674):")
+        for m in messages:
+            print("  - " + m)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/test_check_always_included_shaders.py
+++ b/qa/test_check_always_included_shaders.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Tests for qa/check_always_included_shaders.py — the #1674 Always-Included-Shaders pre-flight gate."""
+import unittest
+from pathlib import Path
+
+from check_always_included_shaders import (
+    BUILD_SCRIPT_REL,
+    REQUIRED_SHADERS,
+    SHADER_DIR_REL,
+    SHADER_FILES,
+    evaluate_build_report,
+    evaluate_build_source,
+    run,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# A minimal build source that satisfies the gate: calls the ensure helper and names both shaders.
+GOOD_SOURCE = """
+        string[] includedShaders = EnsureAlwaysIncludedShaders();
+    static readonly string[] RequiredAlwaysIncluded = { "WorldOS/OccluderDepth", "WorldOS/ActorSilhouette" };
+    static string[] EnsureAlwaysIncludedShaders() { return RequiredAlwaysIncluded; }
+"""
+
+
+class EvaluateBuildSourceTests(unittest.TestCase):
+    def test_good_source_is_clean(self):
+        self.assertEqual(evaluate_build_source(GOOD_SOURCE), [])
+
+    def test_missing_ensure_call_fails(self):
+        src = GOOD_SOURCE.replace("EnsureAlwaysIncludedShaders();", "SomethingElse();")
+        problems = evaluate_build_source(src)
+        self.assertTrue(any("EnsureAlwaysIncludedShaders" in p for p in problems), problems)
+
+    def test_missing_silhouette_shader_fails(self):
+        # Drop ActorSilhouette entirely from the source -> the regression #1674 would recur.
+        src = GOOD_SOURCE.replace('"WorldOS/ActorSilhouette"', '"WorldOS/SomethingElse"')
+        problems = evaluate_build_source(src)
+        self.assertTrue(any("WorldOS/ActorSilhouette" in p for p in problems), problems)
+
+    def test_missing_occluder_shader_fails(self):
+        src = GOOD_SOURCE.replace('"WorldOS/OccluderDepth"', '"WorldOS/SomethingElse"')
+        problems = evaluate_build_source(src)
+        self.assertTrue(any("WorldOS/OccluderDepth" in p for p in problems), problems)
+
+
+class EvaluateBuildReportTests(unittest.TestCase):
+    def test_report_listing_both_is_clean(self):
+        report = "result=Succeeded\nalwaysIncludedShaders=WorldOS/OccluderDepth,WorldOS/ActorSilhouette\n"
+        self.assertEqual(evaluate_build_report(report), [])
+
+    def test_report_missing_silhouette_fails(self):
+        report = "result=Succeeded\nalwaysIncludedShaders=WorldOS/OccluderDepth\n"
+        problems = evaluate_build_report(report)
+        self.assertTrue(any("WorldOS/ActorSilhouette" in p for p in problems), problems)
+
+    def test_report_without_line_fails(self):
+        report = "result=Succeeded\narchitecture=x64ARM64\n"
+        problems = evaluate_build_report(report)
+        self.assertTrue(any("no alwaysIncludedShaders" in p for p in problems), problems)
+
+
+class RealRepoTests(unittest.TestCase):
+    """The actual repo state must PASS the gate (this batch wired the guarantee)."""
+
+    def test_required_shader_files_exist(self):
+        for name in REQUIRED_SHADERS:
+            fname = SHADER_FILES[name]
+            self.assertTrue((ROOT / SHADER_DIR_REL / fname).is_file(), f"missing {fname}")
+
+    def test_build_script_present(self):
+        self.assertTrue((ROOT / BUILD_SCRIPT_REL).is_file(), BUILD_SCRIPT_REL)
+
+    def test_repo_passes_gate(self):
+        code, messages = run(ROOT)
+        self.assertEqual(code, 0, f"gate should pass on this repo; problems: {messages}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Client-side fix batch for the demo G4 punch list — Unity C# + config in `extensions/renderers/unity/` and a Python pre-flight, repo-side ONLY. The box build that ships these is a separate later step (see box-build recipe below).

## #1666 — actor renders as a floating hand/glove (mesh-binding)
**Root cause (analysis, not fully box-confirmed):** In the repo registry BOTH `aidan` (PC) and `keeper-maera` (NPC) fall through to the same `template_human` → `patron_commoner` model, yet only the party PC mis-renders, and it reproduces in BOTH `tavern_snug` (rest) and `crypt` (combat). That rules out plain name→model resolution and a rest-only attachment path — it's the shared `SpawnActor` path, and the box registry most likely resolves the PC to a fragment asset (a hand/glove/prop mesh) the repo registry lacks. C# can't be compiled locally and the box registry/asset isn't visible from here, so the exact box asset is unconfirmed.

**Fix:** new static `PrefabBindHeight()` (reads `sharedMesh.bounds` — no Instantiate/BakeMesh, edit-mode-testable). In `SpawnActor`, a CHARACTER whose **raw** bind height < `MinBindHeight` (0.6m) rebinds to the template humanoid and logs loudly (`[CSC] #1666 degenerate character bind …`). Measured on the raw bind *before* the height-normalization (which would scale a fragment up to human height and mask the defect). Character-scoped — monsters legitimately vary in size. This is the packet's suggested guard ("assert bound mesh bounds exceed a minimum height") and makes an invisible-but-for-a-hand party un-shippable.

**Residual (honest):** if the box asset is a full-height rig whose *body submeshes fail to render* (full bounds, only a hand visible), the height guard passes; the complement is a render-coverage guard that needs on-box observation — out of safe-blind scope, flagged for a box session.

## #1665 — runtime monster tokens unintegrated (scale / float / tint)
- **(a) scale:** `if (foe) height = Mathf.Min(height, MonsterMaxCells * CellSize)` → ≤2 cells (4.2→4.0u at CellSize 2), tied to cell scale.
- **(b) float — real root cause found:** idle graphs are re-evaluated every frame with `Time.deltaTime` (Update loop), but `PlayIdleGraph` never set `applyRootMotion=false` (the ctrlDriven path does). A rooted idle clip accumulates root translation → drifts feet up = the reported "feet float ~half a cell above the ring." Fix sets `anim.applyRootMotion=false` in `PlayIdleGraph`. Runtime grounding already matches the baked #1284 footing rule (feet `min.y`→`FloorY`); the missing piece was root-motion, not the footing rule.
- **(c) tint:** foe-scoped warm multiply on the Standard albedo material (`Color.Lerp(mm.color, WarmAmb, WARM_AMBIENT_FLOOR)`) — reuses existing constants; the baked path bakes the same warmth into PainterlyActor `_AmbientColor` (#1524). Party actors intentionally untouched (not in the report; avoids an unverifiable party regression).

## #1674 — ActorSilhouette shader stripped from builds
No `ProjectSettings/GraphicsSettings.asset` in this repo (the box project owns it). Fix: `BuildMacOSPlayer.Build()` now calls `EnsureAlwaysIncludedShaders()` which bakes `WorldOS/OccluderDepth` + `WorldOS/ActorSilhouette` into Graphics → Always-Included at build time (previously only the manual `Tools/WorldOS/W5b` did — a box rebuild could skip it), and records them on the build-report's `alwaysIncludedShaders=` line. New pre-flight `qa/check_always_included_shaders.py` FAILS when the build source stops guaranteeing a required shader (deleted call, dropped shader, or missing `.shader` file) — so the class can never ship silently again. 10 pytest cases, all green.

## Verification
- **C#:** cannot be compiled locally (no Unity on this Mac) — diffs kept surgical, existing idioms mirrored (`EnsureAlwaysIncluded` mirrors `W5bWireScene`; `applyRootMotion=false` mirrors the ctrlDriven path). Reasoning + line-cites above.
- **Python:** `uv run pytest qa/test_check_always_included_shaders.py` → **10 passed**. `python3 qa/check_always_included_shaders.py` → OK on this repo.

## Box-build recipe (the box session runs this — separate step)
1. Sync changed files from this branch to the box Unity project (`/home/unity/worldos-unity/`):
   - `extensions/renderers/unity/scripts/CombatSurfaceClient.cs` → `Assets/.../CombatSurfaceClient.cs`
   - `extensions/renderers/unity/scripts/BuildMacOSPlayer.cs` → its Editor script location
   - `extensions/renderers/unity/shaders/ActorSilhouette.shader` + `OccluderDepth.shader` → `Assets/Shaders/`
2. Pre-flight (repo side, before rebuild): `python3 qa/check_always_included_shaders.py` (must exit 0).
3. Rebuild: `Tools/WorldOS/Build/macOS Player (Universal)` (headed editor, NOT `-batchmode`). It now auto-registers the shaders into Always-Included.
4. Packaged-check: `python3 qa/check_always_included_shaders.py --build-report BuildOutput/build-report.txt` (confirms `alwaysIncludedShaders=` lists ActorSilhouette), then `qa/player_smoke.sh`, then re-run `player_cert` — the silhouette assert flips GREEN and `WORLDOS_SILHOUETTE=0` reproduces the RED as the deliberate-regression proof.
5. Re-cert the #1666/#1665 walk in `tavern_snug` + `crypt` + `throne_hall` (party renders full figure; Goblin Boss grounded, ≤2 cells, warm-tinted). If #1666 persists on-box, grep `Player.log` for `[CSC] #1666 degenerate character bind` to see the mis-resolved model, then fix the box registry/asset.

Closes #1674. Advances #1666, #1665 (pending on-box cert).
