### PR TITLE
client: silhouette occluder-scoping fix (#1677), foe tint/footing polish (#1665), monster bind guard (#1666) + cert counter-assert

### DIFF
--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -83,6 +83,15 @@ public class CombatSurfaceClient : MonoBehaviour
     static readonly Color WarmAmb = new Color(0.55f, 0.35f, 0.18f);   // CohesionProbe _warmAmb (lit-ground warm band)
     const float WARM_AMBIENT_FLOOR = 0.35f;                           // CohesionProbe WARM_AMBIENT_FLOOR
 
+    // #1665 FOE-TINT POLISH: the runtime monster albedo warmth must NOT reuse WarmAmb/WARM_AMBIENT_FLOOR.
+    // WarmAmb (0.55,0.35,0.18) is a DARK, RED-DOMINANT grounding-blob color; Lerp(albedo, WarmAmb, 0.35) on
+    // a full-body albedo washed the goblins + boss to saturated BLOOD-RED (owner eyeball, throne_g4 /
+    // shot_sil_behind). A full-body tint wants a LIGHT, warm-NEUTRAL target (r≈g, only slightly > b — a
+    // hearth-lit skin warmth, not a red overlay) applied at a much lower weight so the foe reads integrated
+    // with the brazier-lit plate the way the party actors do, not stained red.
+    static readonly Color MonsterWarmTint = new Color(1.0f, 0.88f, 0.72f);   // light warm-neutral (candle/hearth)
+    const float MONSTER_WARM_FLOOR = 0.12f;                                  // subtle: a nudge, not an overlay
+
     // #1441 W5d player interactivity: grounded reposition + engine-confirmed glide + walk clips + click
     // pre-validation. GlideSpeed tunes the cell->cell walk tween; the maps below track per-actor state.
     [Header("Glide (#1441 W5d)")]
@@ -310,6 +319,16 @@ public class CombatSurfaceClient : MonoBehaviour
     const string TemplateCharFbx = "Assets/chars_v2/patron_commoner/rigged.fbx";
     const string TemplateCharAlbedo = "Assets/chars_v2/patron_commoner/albedo.jpg";
     const string TemplateCharAnim = "Assets/chars_v2/patron_commoner/anim_idle.fbx";
+    // #1666 MONSTER path: the character guard is scoped OUT of monsters (they legitimately vary in size),
+    // so a degenerate MONSTER bind (the g4 crypt goblin that rendered as a ~0.2m foe-red hand fragment over
+    // the west stairs) was uncovered. Guard monsters too, with a LOWER floor — even a small goblin's bind
+    // figure clears ~0.3m, while a hand/glove/prop fragment sits well under it. Rebind to the SAME generic
+    // goblin monster the rest of the foe cast resolve to (ResolveAsset's monster default), so a fragment
+    // never renders as a floating hand instead of a foe.
+    const float MinMonsterBindHeight = 0.3f;
+    const string TemplateMonsterFbx = "Assets/chars_v2/goblin/goblin.fbx";
+    const string TemplateMonsterAlbedo = "Assets/chars_v2/goblin/albedo.png";
+    const string TemplateMonsterAnim = "";
 
     // W6.1 (#1460) RUNTIME OCCLUDER PROXIES: the runtime twin of the paint_combat_v1.cs:487-533 editor
     // bake. The engine ships `occluders` ({cells:[[c,r]...], band:"low"|"mid"|"tall"}) on /combat-surface
@@ -1606,7 +1625,7 @@ public class CombatSurfaceClient : MonoBehaviour
         // a fragment UP to human height and mask the defect). On a degenerate bind, rebind to the template
         // humanoid so the party can never be invisible-but-for-a-hand, and log loudly (token+name+model+height)
         // so the box session can repair the registry/asset that resolved a character to a fragment.
-        float bindH = kind == "character" ? PrefabBindHeight(prefab) : 0f;
+        float bindH = PrefabBindHeight(prefab);   // #1666: pure read (sharedMesh.bounds); cheap for both kinds
         if (kind == "character" && bindH < MinBindHeight && fbx != TemplateCharFbx)
         {
             Debug.LogWarning("[CSC] #1666 degenerate character bind for token " + id + " name='" + tokName
@@ -1616,6 +1635,16 @@ public class CombatSurfaceClient : MonoBehaviour
             aref = new[] { fbx, alb, TemplateCharAnim };
             prefab = LoadAsset<GameObject>(fbx);
             if (prefab == null) { Debug.LogWarning("[CSC] #1666 template model MISSING " + fbx + " for token " + id + " (bundle stale?)"); return null; }
+        }
+        else if (kind == "monster" && bindH < MinMonsterBindHeight && fbx != TemplateMonsterFbx)
+        {
+            Debug.LogWarning("[CSC] #1666 degenerate monster bind for token " + id + " name='" + tokName
+                + "' model=" + fbx + " bindH=" + bindH.ToString("F2") + "m < " + MinMonsterBindHeight
+                + "m -> monster template fallback " + TemplateMonsterFbx);
+            fbx = TemplateMonsterFbx; alb = TemplateMonsterAlbedo;
+            aref = new[] { fbx, alb, TemplateMonsterAnim };
+            prefab = LoadAsset<GameObject>(fbx);
+            if (prefab == null) { Debug.LogWarning("[CSC] #1666 monster template model MISSING " + fbx + " for token " + id + " (bundle stale?)"); return null; }
         }
 
         // #idle-fix: register the model + moveset fbx BEFORE the idle pose so the idle resolver (FindOwnClip)
@@ -1694,10 +1723,11 @@ public class CombatSurfaceClient : MonoBehaviour
                 var mm = new Material(Shader.Find("Standard")); mm.mainTexture = al; mm.SetFloat("_Glossiness", 0.2f); mm.SetFloat("_Metallic", 0f);
                 // #1665: warm a runtime MONSTER toward the room's lit-ground ambient so a spawned foe reads
                 // integrated with the brazier-lit plate instead of pale/flat. The baked path bakes this warmth
-                // into the PainterlyActor _AmbientColor (#1524); here a conservative warm multiply on the
-                // Standard albedo tint, reusing the SAME WarmAmb/WARM_AMBIENT_FLOOR floor the grounding decals
-                // already use. Foe-scoped: party actors are intentionally untouched (not in the #1665 report).
-                if (foe) mm.color = Color.Lerp(mm.color, WarmAmb, WARM_AMBIENT_FLOOR);
+                // into the PainterlyActor _AmbientColor (#1524); here a subtle warm nudge on the Standard albedo
+                // tint toward a LIGHT warm-neutral (MonsterWarmTint) at a low weight (MONSTER_WARM_FLOOR) — the
+                // g4 polish fix: the prior Lerp toward the dark red-dominant WarmAmb @0.35 stained goblins +
+                // boss blood-red. Foe-scoped: party actors are intentionally untouched (not in the #1665 report).
+                if (foe) mm.color = Color.Lerp(mm.color, MonsterWarmTint, MONSTER_WARM_FLOOR);
                 foreach (var r in rends) r.sharedMaterial = mm;
             }
         }
@@ -1724,7 +1754,28 @@ public class CombatSurfaceClient : MonoBehaviour
         _topOf[id] = height + 1.4f;
         _cellOf[id] = new[] { cx, cy };
         Debug.Log("[CSC] spawned " + nm + " model=" + fbx + " x" + sc.ToString("F2") + " @cell(" + cx + "," + cy + ") rends=" + rends.Length);
+        // #1665 residual-float re-snap: the ctrl-driven humanoid idle graph (and the avatar retarget) resolves
+        // its STEADY pose over the first few frames after spawn, so the frame-0 grounding above (measured right
+        // after animC.Update(0f)) can land on a transient pose whose bounds.min.y sits below the settled feet —
+        // leaving the throne boss hovering ~1/3 cell above its ring (#1665 residual). Re-ground once the idle
+        // graph is running steadily (a bounds-min re-snap), unless a move/down has since taken over. Cells carry
+        // no elevation (CellToWorld is flat FloorY), so this is a footing re-measure, not a dais-height lookup.
+        StartCoroutine(ResnapGroundedCo(id, cx, cy));
         return go.transform;
+    }
+
+    // #1665: re-ground an actor a few frames after spawn, once its idle graph has advanced past the bind/first
+    // frame the initial grounding measured. Presentation-only; skips a downed or already-gliding actor (whose
+    // own arrival re-grounds) and grounds to the actor's CURRENT engine cell if the poll moved it meanwhile.
+    IEnumerator ResnapGroundedCo(string id, int cx, int cy)
+    {
+        for (int i = 0; i < 4; i++) yield return null;   // let the idle graph settle its steady pose
+        var a = FindActor(id); if (a == null) yield break;
+        if (_downed.Contains(id)) yield break;
+        if (_glide.TryGetValue(id, out var g) && g != null) yield break;   // a move started; its arrival re-grounds
+        int gx = cx, gy = cy;
+        if (_cellOf.TryGetValue(id, out var cc) && cc != null && cc.Length == 2) { gx = cc[0]; gy = cc[1]; }
+        GroundSnap(a, gx, gy);
     }
 
     void MakeGroundQuad(string name, Vector3 p, float yOff, float scale, Texture2D tex, Color col, int queue)

--- a/extensions/renderers/unity/shaders/ActorSilhouette.shader
+++ b/extensions/renderers/unity/shaders/ActorSilhouette.shader
@@ -10,10 +10,26 @@
 // BG2/PoE convention (character behind a wall/prop stays a readable silhouette instead of vanishing) and
 // covers the owner's "character disappears near doors" report. Must be in Always-Included Shaders so
 // Shader.Find resolves it in the standalone player build (mirrors WorldOS/OccluderDepth, #1433).
+//
+// #1677 OCCLUDER-SCOPING (the g4 ghost-in-the-open fix): ZTest Greater ALONE is not sufficient to scope
+// the tint to "behind an occluder." #1545 was a SECOND MATERIAL on the same renderer, so in the open the
+// silhouette's front faces sat at EXACTLY the actor's own opaque depth (same draw, same MVP) and Greater
+// reliably FAILED. #1572 re-hosted the pass as a SEPARATE clone SkinnedMeshRenderer; two independent
+// skinning dispatches of the same rig do not produce bit-identical depth, so in the open the clone's
+// fragments read as marginally FARTHER than the actor's own body -> Greater fires -> the whole figure
+// tints ghost-cyan (#1677, install-blocking). The robust realization of the #1545 intent ("silhouette
+// only behind OCCLUDER depth") is a STENCIL gate: WorldOS/OccluderDepth stamps stencil bit 1 wherever an
+// occluder proxy renders, and this pass draws ONLY where that bit is set (Comp Equal, Ref 1). In the open
+// no proxy covers the actor -> stencil 0 -> the pass is culled regardless of the fragile equal-depth test.
+// Behind a proxy, stencil==1 AND ZTest Greater (actor farther than the proxy's nearer depth) -> the tint
+// draws. WORLDOS_SILHOUETTE kill-switch is unchanged (C#-side: no clone spawned when disabled).
 Shader "WorldOS/ActorSilhouette" {
   Properties { _Color ("Tint", Color) = (1,1,1,0.45) }
   SubShader {
     Tags { "RenderType"="Transparent" "Queue"="Transparent" }
+    // #1677: draw ONLY where an OccluderDepth proxy stamped stencil bit 1 (i.e. behind an occluder),
+    // so an unoccluded actor never tints itself against its own (clone-skinned, non-bit-identical) depth.
+    Stencil { Ref 1 Comp Equal }
     Pass {
       ZTest Greater
       ZWrite Off

--- a/extensions/renderers/unity/shaders/OccluderDepth.shader
+++ b/extensions/renderers/unity/shaders/OccluderDepth.shader
@@ -7,9 +7,18 @@
 // referencing it from the scene's occluder materials + Always-Included Shaders) gets its variant
 // compiled into the build. Source is byte-for-byte the same as the old runtime string (ColorMask 0,
 // ZWrite On, Queue Geometry-1), so editor renders stay identical — depth-only, writes no color.
+//
+// #1677: the proxy also STAMPS stencil bit 1 wherever it renders, so WorldOS/ActorSilhouette can scope
+// its walk-behind tint to "behind an occluder proxy" (Stencil Comp Equal Ref 1) instead of relying on a
+// fragile equal-depth test against the actor's OWN clone-skinned body — the g4 ghost-in-the-open defect.
+// The proxy still renders FIRST (Queue Geometry-1, on a cleared depth+stencil buffer), so it always
+// passes depth and Replace writes 1 across its footprint; regular geometry never touches stencil, so the
+// mark survives to the Transparent-queue silhouette pass. Depth output is byte-identical to before.
 Shader "WorldOS/OccluderDepth" {
   SubShader {
     Tags { "RenderType"="Opaque" "Queue"="Geometry-1" }
+    // #1677: mark stencil bit 1 across the proxy footprint (the silhouette pass reads it, Comp Equal).
+    Stencil { Ref 1 Comp Always Pass Replace }
     Pass {
       ColorMask 0
       ZWrite On

--- a/qa/player_cert.py
+++ b/qa/player_cert.py
@@ -71,6 +71,22 @@ VERIFIED_OCCLUDER_CELLS = {
     "crypt": [(13, 3), (13, 2), (14, 2), (14, 1)],   # NE corner, behind pillar_ne + the east wall
 }
 
+# ── #1677 counter-assert calibration: the party walk-behind silhouette is party-CYAN (the shader tint
+# Color(0.4,0.95,1.0) @ ~0.45 alpha). Composited over the actor it reads with G and B clearly ABOVE R.
+# The g4 ghost-in-the-open defect (the ZTest-Greater clone tinting the actor against its OWN body depth)
+# paints that cyan over the WHOLE unoccluded figure; a correctly occluder-SCOPED build (the #1677 stencil
+# fix) shows a normal actor there (skin/armor/hair — no cyan dominance). The FOE tint is red (r-dominant)
+# and is deliberately NOT matched — this counter-assert targets the party ghost-cyan of #1677.
+# Thresholds calibrated 2026-07-22 against the g4 frames (LEXAR session-notes 2026-07-22/g4-build): the
+# ghost frames (snug_g4b, throne_g4) peak at densest-window ghost-cyan shares of 0.092 / 0.066; the
+# pre-#1676 cert_green baseline (a normal actor) and a non-ghost capture read <= 0.011 — 0.03 separates.
+CYAN_DR = 20                   # g must exceed r by this (cyan/greenish, not warm)
+CYAN_DB = 30                   # b must exceed r by this (bluish)
+CYAN_FLOOR = 70                # (g+b)/2 must clear this (a real lit tint, not near-black noise)
+GHOST_WINDOW = 80              # px side of the densest-window ghost-cyan scan
+GHOST_STEP = 40                # px stride of the scan
+MAX_GHOST_TINT_SHARE = 0.03    # <= this densest-window ghost-cyan share == no overlay in the open (GREEN)
+
 
 # ── cell<->world geometry (the build_room_unified contract, mirror walk_test._visual_registration) ──
 def cell_to_world(cell: tuple, cols: int, rows: int) -> tuple:
@@ -237,6 +253,74 @@ def silhouette_verdict(rec: dict) -> str:
     if rec.get("frames_identical"):
         return "ERROR"      # two identical frames — no evidence about the silhouette
     return "GREEN" if density >= min_density else "RED"
+
+
+# ── #1677 counter-assert cores: the ghost-cyan tint must be ABSENT on an UNOCCLUDED actor (PURE) ─────
+def ghost_cyan_mask(img):
+    """Boolean HxW mask of pixels that read as the party ghost-cyan silhouette tint (G,B >> R, lit).
+    Pure (array/Image in, mask out). The party silhouette is cyan; the FOE tint is red (r-dominant) and
+    is deliberately NOT matched — this targets the #1677 party ghost-in-the-open."""
+    import numpy as np  # noqa: PLC0415
+    a = np.asarray(img, dtype=int)
+    r, g, b = a[..., 0], a[..., 1], a[..., 2]
+    return (g > r + CYAN_DR) & (b > r + CYAN_DB) & (((g + b) // 2) > CYAN_FLOOR)
+
+
+def ghost_tint_share(img, center_px: tuple, radius: int) -> float:
+    """Fraction of pixels in a square window around `center_px` that read as the ghost-cyan tint — the
+    single-frame analogue of head_window_diff_density (the LIVE probe reads it at the unoccluded actor's
+    head projection). Pure (array in, float out)."""
+    m = ghost_cyan_mask(img)
+    h, w = m.shape[0], m.shape[1]
+    x, y = int(center_px[0]), int(center_px[1])
+    ya, yb = max(0, y - radius), min(h, y + radius)
+    xa, xb = max(0, x - radius), min(w, x + radius)
+    if ya >= yb or xa >= xb:
+        return 0.0
+    return float(m[ya:yb, xa:xb].mean())
+
+
+def peak_ghost_tint_share(img, *, window: int = GHOST_WINDOW, step: int = GHOST_STEP,
+                          region: Optional[tuple] = None) -> float:
+    """The MAX ghost-cyan share over any window-sized box — position-agnostic (no actor projection
+    needed). `region` = (x0,y0,x1,y1) restricts the scan (the live probe bounds it to the figure so an
+    unrelated cyan prop/UI elsewhere cannot trip it); None scans the whole frame (the whole-PNG unit
+    tests). Pure (array in, float out)."""
+    m = ghost_cyan_mask(img)
+    h, w = m.shape[0], m.shape[1]
+    x0, y0, x1, y1 = (0, 0, w, h) if region is None else region
+    x0, y0 = max(0, int(x0)), max(0, int(y0))
+    x1, y1 = min(w, int(x1)), min(h, int(y1))
+    best = 0.0
+    yy = y0
+    while yy < y1 - 1:
+        xx = x0
+        while xx < x1 - 1:
+            ye, xe = min(yy + window, h), min(xx + window, w)
+            if ye > yy and xe > xx:
+                d = float(m[yy:ye, xx:xe].mean())
+                if d > best:
+                    best = d
+            xx += step
+        yy += step
+    return best
+
+
+def silhouette_absent_verdict(rec: dict) -> str:
+    """PURE tri-state for the #1677 counter-assert (silhouette_absent_when_visible). ERROR (harness —
+    never a certification verdict) when the open-cell frame could not be captured or measured. Otherwise
+    GREEN when the UNOCCLUDED actor shows NO ghost-cyan overlay (peak ghost-cyan share <= threshold), RED
+    when the ghost overlay IS present in the open (share above threshold — the g4 install-blocker the
+    occluder-scoping stencil fix removes). The complement of silhouette_verdict: that one demands the tint
+    WHERE occluded, this one forbids it WHERE VISIBLE."""
+    if rec.get("harness_errors"):
+        return "ERROR"
+    if not rec.get("captured"):
+        return "ERROR"
+    share, thresh = rec.get("tint_share"), rec.get("max_tint_share")
+    if share is None or thresh is None:
+        return "ERROR"
+    return "GREEN" if share <= thresh else "RED"
 
 
 # ── Primitive B helpers: spawn/arrival cells reachable, prop-clear, coherence-open (PURE) ───────────
@@ -469,6 +553,79 @@ def _silhouette_row(ctx: dict) -> dict:
             "harness_errors": rec.get("harness_errors", [])}
 
 
+def probe_silhouette_absent(ctx: dict) -> dict:
+    """PRIMITIVE A COUNTER-ASSERT (#1677) — capture the party actor on its UNOCCLUDED start cell and
+    prove it does NOT wear the walk-behind silhouette tint in the open. Captures ONE /shot (no move),
+    measures the PEAK ghost-cyan share in a window bounded to the actor's projected figure (so an
+    unrelated cyan prop/UI elsewhere on the plate can't trip it), and reads the verdict: a ghost overlay
+    (share above threshold) is RED (the g4 ghost-in-the-open install-blocker), a normal actor is GREEN.
+    Deterministic, no LLM / no image model — the complement of probe_silhouette."""
+    engine, qa, out = ctx["engine"], ctx["qa"], ctx["out"]
+    rec = {"harness_errors": [], "captured": False, "max_tint_share": MAX_GHOST_TINT_SHARE}
+    try:
+        surf = W._get(f"{engine}/combat-surface")
+    except Exception as e:  # noqa: BLE001
+        rec["harness_errors"].append(f"surface: {e}")
+        return rec
+    room = _room_of(surf) or ctx.get("room") or ""
+    rec["room"] = room
+    mask = W.walkmask_from_surface(surf)
+    cols, rows = mask["cols"], mask["rows"]
+    start = W._token_cell(surf)
+    if not start:
+        rec["harness_errors"].append("no party token cell on the surface")
+        return rec
+    rec["start_cell"] = list(start)
+    try:
+        health = W._get(f"{qa}/health")
+        w, h = int(health["screenW"]), int(health["screenH"])
+    except Exception as e:  # noqa: BLE001
+        rec["harness_errors"].append(f"health: {e}")
+        return rec
+    try:
+        boxes = _boxes_for_room(room)
+        ortho = float((boxes or {}).get("ortho") or W._room_ortho(room))
+    except Exception:  # noqa: BLE001
+        ortho = 11.0
+    rec["window"] = [w, h]
+
+    # bound the ghost scan to the actor's projected figure (head..feet at the unoccluded start cell).
+    wx, wz = cell_to_world(start, cols, rows)
+    head_px = W.world_to_window_px(wx, 2.4, wz, ortho, w, h)
+    torso_px = W.world_to_window_px(wx, 1.2, wz, ortho, w, h)
+    rec["head_px"] = [round(v) for v in head_px]
+    cpx = W.cell_px(ortho, h)
+    half = max(GHOST_WINDOW, int(round(1.2 * cpx)))
+    cx_px = (head_px[0] + torso_px[0]) / 2.0
+    region = (cx_px - half, head_px[1] - 0.4 * cpx, cx_px + half, torso_px[1] + 1.4 * cpx)
+    rec["region"] = [round(v) for v in region]
+
+    shot = W._capture_shot(qa, out, "sil_open")
+    rec["frames"] = {"open": shot}
+    if not shot:
+        rec["harness_errors"].append("shot capture failed (open frame missing)")
+        return rec
+    from PIL import Image  # noqa: PLC0415
+    im = Image.open(shot).convert("RGB")
+    rec["tint_share"] = round(peak_ghost_tint_share(im, region=region), 4)
+    rec["head_tint_share"] = round(
+        ghost_tint_share(im, head_px, max(GHOST_WINDOW // 2, int(round(0.55 * cpx)))), 4)
+    rec["captured"] = True
+    return rec
+
+
+def _silhouette_absent_row(ctx: dict) -> dict:
+    rec = probe_silhouette_absent(ctx)
+    verdict = silhouette_absent_verdict(rec)
+    detail = rec.get("detail")
+    if verdict in ("GREEN", "RED"):
+        detail = (f"open_cell={rec.get('start_cell')} tint_share={rec.get('tint_share')} "
+                  f"head_tint_share={rec.get('head_tint_share')} max={rec.get('max_tint_share')} "
+                  f"head_px={rec.get('head_px')}")
+    return {"verdict": verdict, "detail": detail, "record": rec,
+            "harness_errors": rec.get("harness_errors", [])}
+
+
 def _spawn_row(ctx: dict) -> dict:
     engine = ctx["engine"]
     try:
@@ -511,6 +668,13 @@ REGISTRY: list = [
         probe=_silhouette_row,
         doc="Primitive A — the party actor placed BEHIND a tall occluder still renders its walk-behind "
             "silhouette (#1572 per-submesh clone; WORLDOS_SILHOUETTE=0 turns this RED)."),
+    Assertion(
+        id="silhouette_absent_when_visible", scope="live_party", needs=("engine", "player"),
+        probe=_silhouette_absent_row,
+        doc="Primitive A COUNTER-assert — the party actor on its UNOCCLUDED cell shows NO walk-behind "
+            "silhouette tint (#1677 ghost-in-the-open: the ZTest-Greater clone tinting the actor against "
+            "its OWN body depth). A ghost-cyan overlay in the open turns this RED — the occluder-scoping "
+            "stencil fix keeps it GREEN."),
 ]
 
 

--- a/qa/test_player_cert.py
+++ b/qa/test_player_cert.py
@@ -275,3 +275,87 @@ def test_run_cert_live_silhouette_red_makes_suite_red(monkeypatch, tmp_path):
     ids = {a["id"]: a["verdict"] for a in rep["assertions"]}
     assert ids["silhouette_behind_occluder"] == "RED"
     assert rep["verdict"] == "RED"
+
+
+# ── #1677 counter-assert: the ghost-cyan tint must be ABSENT on an UNOCCLUDED actor ─────────────────
+def _cyan_block(bg=60, block=110, side=240, box=160):
+    """A `side`x`side` grey frame with a centered `box`x`box` party-ghost-cyan patch (G,B >> R) — the
+    #1677 ghost-in-the-open shape. RGB ~ (block, block+65, block+65) matches the measured g4 ghost mean."""
+    import numpy as np
+    from PIL import Image
+    a = np.full((side, side, 3), bg, dtype=np.uint8)
+    lo = (side - box) // 2
+    a[lo:lo + box, lo:lo + box] = (block, block + 65, block + 65)
+    return Image.fromarray(a)
+
+
+def _normal_block(side=200, box=90):
+    """A `side`x`side` frame with a centered r-dominant skin/armor patch (no cyan dominance) — a normal
+    unoccluded actor. Must read as ZERO ghost-cyan share (GREEN)."""
+    import numpy as np
+    from PIL import Image
+    a = np.full((side, side, 3), 40, dtype=np.uint8)
+    lo = (side - box) // 2
+    a[lo:lo + box, lo:lo + box] = (150, 120, 100)   # warm skin/armor, r >= g >= b
+    return Image.fromarray(a)
+
+
+def test_peak_ghost_tint_share_high_on_cyan_block():
+    """A solid cyan patch fills a scan window -> peak share ~1.0, well above MAX_GHOST_TINT_SHARE."""
+    share = PC.peak_ghost_tint_share(_cyan_block())
+    assert share > PC.MAX_GHOST_TINT_SHARE
+    assert share > 0.9
+
+
+def test_peak_ghost_tint_share_zero_on_normal_actor():
+    """A warm r-dominant actor patch has no cyan -> peak share 0.0, below threshold."""
+    assert PC.peak_ghost_tint_share(_normal_block()) == 0.0
+
+
+def test_ghost_tint_share_window_reads_cyan_center():
+    """ghost_tint_share is high in a window over the cyan patch, zero over the grey corner."""
+    img = _cyan_block()
+    assert PC.ghost_tint_share(img, (100, 100), 40) > 0.9   # centered on the patch
+    assert PC.ghost_tint_share(img, (10, 10), 8) == 0.0     # grey corner
+
+
+def test_silhouette_absent_verdict_green_when_no_tint():
+    """No ghost overlay in the open (share <= threshold) -> GREEN (the occluder-scoped build)."""
+    rec = {"captured": True, "tint_share": 0.004, "max_tint_share": PC.MAX_GHOST_TINT_SHARE}
+    assert PC.silhouette_absent_verdict(rec) == "GREEN"
+
+
+def test_silhouette_absent_verdict_red_when_ghost_overlay():
+    """A ghost-cyan overlay on the unoccluded actor (share above threshold) -> RED — the #1677 defect."""
+    rec = {"captured": True, "tint_share": 0.09, "max_tint_share": PC.MAX_GHOST_TINT_SHARE}
+    assert PC.silhouette_absent_verdict(rec) == "RED"
+
+
+def test_silhouette_absent_verdict_error_paths():
+    assert PC.silhouette_absent_verdict({"harness_errors": ["surface: boom"]}) == "ERROR"
+    assert PC.silhouette_absent_verdict({"captured": False}) == "ERROR"
+    assert PC.silhouette_absent_verdict({"captured": True, "max_tint_share": 0.03}) == "ERROR"  # no share
+
+
+# Real g4 frame calibration (skips when the LEXAR evidence isn't mounted — CI has no LEXAR). The very
+# frames the owner eyeballed: the ghost frames must go RED and the normal baseline GREEN, proving the
+# counter-assert is red-first against the actual ghost-in-the-open pixels (#1677), not just synthetics.
+def _lexar(*parts):
+    from pathlib import Path
+    p = Path("/Volumes/LEXAR/Codex/session-notes/2026-07-22").joinpath(*parts)
+    return p if p.is_file() else None
+
+
+def test_ghost_frames_calibration_real_pngs():
+    import pytest
+    from PIL import Image
+    ghost_a = _lexar("g4-build", "artifacts", "snug_g4b.png")
+    ghost_b = _lexar("g4-build", "artifacts", "throne_g4.png")
+    normal = _lexar("player-cert-live", "artifacts", "cert_green", "shot_sil_baseline.png")
+    if not (ghost_a and ghost_b and normal):
+        pytest.skip("LEXAR g4 calibration frames not mounted")
+    for g in (ghost_a, ghost_b):
+        share = PC.peak_ghost_tint_share(Image.open(g).convert("RGB"))
+        assert share > PC.MAX_GHOST_TINT_SHARE, f"{g.name} ghost share {share} should exceed threshold (RED)"
+    nshare = PC.peak_ghost_tint_share(Image.open(normal).convert("RGB"))
+    assert nshare <= PC.MAX_GHOST_TINT_SHARE, f"normal actor share {nshare} should be below threshold (GREEN)"


### PR DESCRIPTION
Client Polish Round 2 — the fixes that unblock the owner install of the g4 demo build. Repo-side only (extensions/renderers/unity + qa). C#/shader cannot compile locally; the Python cert addition has real red-first unit tests.

## #1677 — silhouette tints the actor ghost-cyan IN THE OPEN (P1, install-blocking)
**Root cause.** `#1545` shipped the walk-behind silhouette as a SECOND MATERIAL on the actor's own renderer, so in the open the silhouette's front faces sat at EXACTLY the actor's own opaque depth (same draw, same MVP) and `ZTest Greater` reliably FAILED — no tint. `#1572` re-hosted the pass as a SEPARATE clone `SkinnedMeshRenderer` (to cover multi-submesh rigs). Two independent skinning dispatches of the same rig do NOT produce bit-identical depth, so in the open the clone's fragments read as marginally FARTHER than the actor's own body → `Greater` fires → the whole figure tints ghost-cyan (measured: `snug_g4b.png`, `throne_g4.png`).

**Mechanism chosen — stencil occluder-scoping (candidate a).** The robust realization of the `#1545` design intent ("silhouette only behind OCCLUDER depth"): `WorldOS/OccluderDepth` now stamps stencil bit 1 across its footprint (`Stencil { Ref 1 Comp Always Pass Replace }`); `WorldOS/ActorSilhouette` draws ONLY where that bit is set (`Stencil { Ref 1 Comp Equal }`) AND is behind the proxy depth (`ZTest Greater`, unchanged). In the open no proxy covers the actor → stencil 0 → the pass is culled regardless of the fragile equal-depth test. Behind a proxy → stencil 1 AND actor farther than the proxy's nearer depth → the tint draws (walk-behind preserved). The proxy renders first (Queue Geometry-1, cleared depth+stencil) so `Replace` always writes; regular geometry never touches stencil, so the mark survives to the Transparent-queue silhouette pass. Depth output byte-identical. `WORLDOS_SILHOUETTE` kill-switch untouched (C#-side; no clone spawned when off).

## #1665 — foe warm tint reads blood-red
**Root cause.** The runtime monster albedo warmth reused `WarmAmb` (0.55,0.35,0.18 — a DARK, red-dominant grounding-blob color) via `Lerp(albedo, WarmAmb, 0.35)`, staining goblins + boss saturated red.
**Fix.** Dedicated subtle constants: `MonsterWarmTint` (1.0,0.88,0.72 — a light warm-NEUTRAL, r≈g, only slightly > b) at `MONSTER_WARM_FLOOR` 0.12 — a hearth-lit nudge, not a red overlay.

## #1665 — residual boss float (~1/3 cell above the ring on the dais)
**Root cause.** The ctrl-driven humanoid idle graph (and avatar retarget) resolves its STEADY pose over the first few frames; the frame-0 grounding (`animC.Update(0f)` then `Measure`) can land on a transient pose whose `bounds.min.y` sits below the settled feet. Cells carry no elevation (`CellToWorld` is flat `FloorY`), so this is a footing re-measure, not a dais-height lookup.
**Fix.** `ResnapGroundedCo` — a bounds-min re-snap 4 frames after spawn once the idle graph is steady; skips a downed/gliding actor and re-grounds to the actor's current engine cell.

## #1666 — degenerate MONSTER bind (floating hand/blob)
**Root cause.** The `#1676` degenerate-bind guard is character-scoped ("monsters legitimately vary in size"), so a fragment-bound goblin (renders as a ~0.2m hand over the west stairs) was uncovered.
**Fix.** Extend the guard to monsters with a lower floor `MinMonsterBindHeight` 0.3m (even a small goblin clears it) → rebind to the goblin monster template + log `[CSC] #1666 degenerate monster bind`.

## player_cert — the #1677 cert gap
New `silhouette_absent_when_visible` counter-assert (the complement of `silhouette_behind_occluder`): on the party's UNOCCLUDED cell, assert the actor shows NO ghost-cyan tint. Pure cores (`ghost_cyan_mask` / `ghost_tint_share` / `peak_ghost_tint_share` / `silhouette_absent_verdict`) + a live probe. Red-first, calibrated against the actual g4 frames:

```
peak_ghost_tint_share vs MAX=0.030
  GHOST snug_g4b   share=0.0922 -> RED
  GHOST throne_g4  share=0.0661 -> RED
  NORMAL baseline  share=0.0030 -> GREEN
```

## Files
- `extensions/renderers/unity/shaders/ActorSilhouette.shader` — stencil Comp Equal gate.
- `extensions/renderers/unity/shaders/OccluderDepth.shader` — stencil Replace stamp.
- `extensions/renderers/unity/scripts/CombatSurfaceClient.cs` — foe tint constants; monster bind guard; `ResnapGroundedCo`.
- `qa/player_cert.py` — counter-assert cores + live probe + registry entry.
- `qa/test_player_cert.py` — red-first units (synthetic + real g4 PNGs when LEXAR mounted).

## Tests
`uv run --directory servers/engine python -m pytest qa/test_player_cert.py -q -p no:xdist` → **32 passed** (incl. the real-g4-frame calibration). `qa/test_check_always_included_shaders.py` still green. ruff clean.

## Box re-verify recipe
1. Build the player on GEX44 (Always-Included already covers both shaders, `#1674`).
2. Eyeball an OPEN party actor in `tavern_snug` / `throne_hall` — no ghost-cyan overlay.
3. Walk the party behind a tall occluder — the walk-behind silhouette still renders (regression guard).
4. `qa/player_cert.py --live --run certlane` — both `silhouette_behind_occluder` (GREEN) and `silhouette_absent_when_visible` (GREEN).
5. Spawn goblins + Goblin Boss — subtle warm (not red), boss feet on the ring, no floating-hand fragment.