### PR TITLE
client: gate actor spawns on bundle-ready + render-coverage rebind guard (#1666) + cert full-figure assert

### DIFF
--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -224,6 +224,10 @@ public class CombatSurfaceClient : MonoBehaviour
     const string HumanoidControllerPath = "Assets/Animations/WorldOSHumanoid.controller";
     RuntimeAnimatorController _humanoidCtrl; bool _humanoidCtrlTried;
     readonly System.Collections.Generic.HashSet<string> _ctrlDriven = new System.Collections.Generic.HashSet<string>();
+    // #1666 render-coverage rebind: ids that have already consumed their ONE re-bind attempt (a persistent
+    // degenerate partial-render bind is re-instantiated once — see RenderCoverageGuardCo). Cleared on Despawn so
+    // a genuine re-spawn re-arms; guarantees a still-degenerate re-bind can never loop.
+    readonly System.Collections.Generic.HashSet<string> _coverageRebound = new System.Collections.Generic.HashSet<string>();
     string _currentId = "";        // the isCurrent combatant this surface (active-turn ring-pulse anchor)
     string _pulsePrev = "";        // last-pulsed ring, reset to rest when the turn moves on
 
@@ -329,6 +333,15 @@ public class CombatSurfaceClient : MonoBehaviour
     const string TemplateMonsterFbx = "Assets/chars_v2/goblin/goblin.fbx";
     const string TemplateMonsterAlbedo = "Assets/chars_v2/goblin/albedo.png";
     const string TemplateMonsterAnim = "";
+    // #1666 RENDER-COVERAGE guard (the g5 crypt residual): the raw-prefab bind-height guards above measure the
+    // PREFAB (sharedMesh.bounds) — full height, so they PASS — but the first-spawned instance still rendered as a
+    // ~0.2m accessory fragment (its body SkinnedMeshRenderers never initialized; the 2nd/3rd of the SAME prefab
+    // rendered full). After an actor binds + settles, its RENDERED (BakeMesh) figure must cover at least this
+    // fraction of its scale-target height, else it is re-instantiated ONCE. Root-cause-agnostic — catches any
+    // partial-render bind (skin-init, culling, material strip), not only the first-spawn case. Floor 0.6: the g5
+    // fragment measured ~0.05x its target; a healthy figure measures ~1.0x (wide separation).
+    const float RenderCoverageFloor = 0.6f;
+    const int RenderCoverageSettleFrames = 3;   // let skinning + the idle/controller graph settle before measuring
 
     // W6.1 (#1460) RUNTIME OCCLUDER PROXIES: the runtime twin of the paint_combat_v1.cs:487-533 editor
     // bake. The engine ships `occluders` ({cells:[[c,r]...], band:"low"|"mid"|"tall"}) on /combat-surface
@@ -530,6 +543,13 @@ public class CombatSurfaceClient : MonoBehaviour
         // Option A (item 3): hide the scene's baked mannequins — the client now renders its own cast in rest
         // AND combat, so a baked actor would double-render / linger T-posed beside the live cast.
         HideBakedCast();
+
+        // #1666: warm the shared actor pipeline BEFORE the first poll can spawn, so no REAL actor is ever the
+        // first-instantiated skinned mesh / first bundle+controller access of its frame — the condition the crypt
+        // residual manifested under (the first-spawned monster rendered as a ~0.2m accessory fragment while its
+        // body renderers never initialized; the 2nd/3rd of the SAME prefab, no longer first, rendered full). The
+        // render-coverage rebind guard (RenderCoverageGuardCo) remains the guaranteed catch-all for any residual.
+        PrewarmActorPipeline();
 
         Debug.Log("[CSC] start: campaign=" + CampaignId + " url=" + ViewerUrl + " overlay=" + _overlayOn + " onboard=" + _onboard);
         StartCoroutine(PollLoop());
@@ -1282,6 +1302,31 @@ public class CombatSurfaceClient : MonoBehaviour
     // their EXACT registry asset path (see BuildMacOSPlayer.EnsurePackaged), so a registry model_ref
     // like "Assets/chars_v2/goblin/goblin.fbx" loads verbatim — zero path transform, registry invariant
     // intact. Loaded once; absent bundle (e.g. a legacy build) -> spawning no-ops, repositioning still works.
+    // #1666: fold the one-time bundle + humanoid-controller + donor-idle loads AND a hidden skinned-mesh upload
+    // out of the first SpawnActor, so the first real spawn is never also the first-ever access to any of them.
+    // The throwaway instantiate/bake/destroy of each template forces Unity to upload the skinned meshes here
+    // (never rendered — placed far below, deactivated, destroyed the same frame). All guarded: an absent bundle
+    // or missing template resolves to null and is skipped, byte-identical to a no-bundle build.
+    void PrewarmActorPipeline()
+    {
+        try
+        {
+            Bundle(); HumanoidController(); DonorIdle();
+            foreach (var fbx in new[] { TemplateMonsterFbx, TemplateCharFbx })
+            {
+                var prefab = LoadAsset<GameObject>(fbx);
+                if (prefab == null) continue;
+                var go = (GameObject)Object.Instantiate(prefab);
+                go.name = "__prewarm"; go.transform.position = new Vector3(0f, -10000f, 0f); go.SetActive(false);
+                foreach (var smr in go.GetComponentsInChildren<SkinnedMeshRenderer>(true))
+                    if (smr != null && smr.sharedMesh != null) { var bk = new Mesh(); smr.BakeMesh(bk); Object.DestroyImmediate(bk); }
+                Object.DestroyImmediate(go);
+            }
+            Debug.Log("[CSC] #1666 actor pipeline pre-warmed");
+        }
+        catch (System.Exception e) { Debug.LogWarning("[CSC] #1666 prewarm: " + e.Message); }
+    }
+
     AssetBundle Bundle()
     {
         if (_bundleTried) return _bundle;
@@ -1608,7 +1653,9 @@ public class CombatSurfaceClient : MonoBehaviour
     // spawn() lambda: registry-resolve -> load prefab from the bundle -> pitch guard -> BIND-POSE scale
     // lock -> idle pose (embedded clip, else humanoid donor retarget) -> ground+center on the cell ->
     // albedo -> AO blob + selection ring. Returns the placed transform, or null if the model is missing.
-    Transform SpawnActor(string id, string tokName, string team, int cx, int cy)
+    // #1666: armCoverageGuard=false on the ONE re-instantiate the render-coverage guard itself triggers, so a
+    // still-degenerate re-bind can never re-arm the guard and loop.
+    Transform SpawnActor(string id, string tokName, string team, int cx, int cy, bool armCoverageGuard = true)
     {
         if (string.IsNullOrEmpty(id)) return null;
         bool foe = (team == "foe");
@@ -1761,7 +1808,36 @@ public class CombatSurfaceClient : MonoBehaviour
         // graph is running steadily (a bounds-min re-snap), unless a move/down has since taken over. Cells carry
         // no elevation (CellToWorld is flat FloorY), so this is a footing re-measure, not a dais-height lookup.
         StartCoroutine(ResnapGroundedCo(id, cx, cy));
+        // #1666 render-coverage rebind guard: verify — once the actor settles — that its RENDERED figure actually
+        // covers its scale-target height; a persistent degenerate partial-render bind is re-instantiated ONCE.
+        if (armCoverageGuard && !_coverageRebound.Contains(id))
+            StartCoroutine(RenderCoverageGuardCo(id, tokName, team, height));
         return go.transform;
+    }
+
+    // #1666: measure an actor's RENDERED (BakeMesh) figure height a few frames after spawn — once skinning + the
+    // idle/controller graph have settled — and compare it to its scale-target height. A persistent degenerate
+    // partial-render bind (only an accessory mesh drew; the body SkinnedMeshRenderers never initialized) measures
+    // far below RenderCoverageFloor * expectH, while the raw-prefab bind-height guards in SpawnActor PASSED (the
+    // prefab's own bind bounds are full height). Re-instantiate the actor ONCE — a fresh bind is no longer the
+    // first-instantiated skinned mesh of its frame, which cures the first-spawn skin-init case — and log loudly.
+    // One attempt per id (_coverageRebound, consumed BEFORE the re-spawn) so a still-degenerate re-bind can never
+    // loop. Mirrors ResnapGroundedCo's downed/gliding guards; presentation-only.
+    IEnumerator RenderCoverageGuardCo(string id, string tokName, string team, float expectH)
+    {
+        for (int i = 0; i < RenderCoverageSettleFrames; i++) yield return null;
+        var a = FindActor(id); if (a == null) yield break;
+        if (_downed.Contains(id)) yield break;                              // a downed/prone actor legitimately collapses
+        if (_glide.TryGetValue(id, out var g) && g != null) yield break;    // mid-move; a settled re-measure isn't meaningful
+        var rends = a.GetComponentsInChildren<Renderer>();
+        float renderedH = Measure(a.gameObject, rends).size.y;              // BakeMesh over non-silclone renderers
+        if (expectH <= 0.001f || renderedH >= expectH * RenderCoverageFloor) yield break;   // healthy figure
+        if (!_cellOf.TryGetValue(id, out var cc) || cc == null || cc.Length != 2) yield break;
+        _coverageRebound.Add(id);   // consume the single attempt BEFORE the re-spawn (which re-enters SpawnActor)
+        Debug.LogWarning("[CSC] #1666 render-coverage rebind for token " + id + " name='" + tokName
+            + "' renderedH=" + renderedH.ToString("F2") + "m < " + RenderCoverageFloor.ToString("F2")
+            + "x expect " + expectH.ToString("F2") + "m -> re-instantiate @cell(" + cc[0] + "," + cc[1] + ")");
+        SpawnActor(id, tokName, team, cc[0], cc[1], armCoverageGuard: false);   // re-bind ONCE; no re-arm (no loop)
     }
 
     // #1665: re-ground an actor a few frames after spawn, once its idle graph has advanced past the bind/first
@@ -1807,6 +1883,7 @@ public class CombatSurfaceClient : MonoBehaviour
         _animOf.Remove(id); _topOf.Remove(id); RemoveHpBar(id);   // #anim-combat: clear combat/anim state
         _downed.Remove(id); _downRunning.Remove(id); _reviveWanted.Remove(id); _downPose.Remove(id);
         _ctrlDriven.Remove(id);   // #anim-pack: forget controller-driven state so a re-spawn re-resolves the avatar
+        _coverageRebound.Remove(id);   // #1666: a genuine re-spawn of this id re-arms the render-coverage guard
         Debug.Log("[CSC] despawned Actor_" + id);
     }
 

--- a/qa/player_cert.py
+++ b/qa/player_cert.py
@@ -87,6 +87,24 @@ GHOST_WINDOW = 80              # px side of the densest-window ghost-cyan scan
 GHOST_STEP = 40                # px stride of the scan
 MAX_GHOST_TINT_SHARE = 0.03    # <= this densest-window ghost-cyan share == no overlay in the open (GREEN)
 
+# ── #1666 cast-full-figure calibration: a fragment-rendered token (only an accessory mesh drew; the body
+# renderers never initialized — the g5 crypt residual, the first-spawned goblin over the west stairs) shows
+# almost NO coherent body figure where a healthy foe shows a tall one. Discriminator: the vertical EXTENT of
+# bright yellow-green goblin-BODY pixels (g high, g within BODY_GR_SLACK of r, b well below g) inside a window
+# bounded to the token's projected figure, as a fraction of that window's height. A GLOBAL color mask is
+# useless here — the brazier-lit stone + flames read warm — so the extent is only ever measured inside a
+# per-token projected box (never at a brazier/wall). Calibrated 2026-07-22 against crypt_g5.png (LEXAR
+# session-notes 2026-07-22/g4-build/artifacts): the fragment goblin's body extent = 0.08-0.17 (box-jitter
+# range); the two full goblins = 0.47-0.82. Floor 0.35 sits in the (0.17, 0.47) gap: RED-FIRST — a fragment
+# turns the suite RED, a healthy figure stays GREEN.
+BODY_G_FLOOR = 130             # goblin-body pixels are bright (green channel)
+BODY_GR_SLACK = 30             # ...with g within this of r (yellow-green, not warm-red stone)
+BODY_GB_MARGIN = 55            # ...and b well below g (excludes grey/brown floor + blue-grey wall)
+FIGURE_MIN_EXTENT = 0.35       # body extent >= this fraction of the projected figure window == a full figure
+FIGURE_HEAD_WORLD_Y = 2.4      # projected figure top (world y) — the head band the silhouette probe also uses
+FIGURE_FEET_WORLD_Y = 0.15     # projected figure bottom (world y) — just above the floor
+BODY_HALF_WIDTH_PX = 40        # min half-width of the per-token projected figure box (px)
+
 
 # ── cell<->world geometry (the build_room_unified contract, mirror walk_test._visual_registration) ──
 def cell_to_world(cell: tuple, cols: int, rows: int) -> tuple:
@@ -321,6 +339,55 @@ def silhouette_absent_verdict(rec: dict) -> str:
     if share is None or thresh is None:
         return "ERROR"
     return "GREEN" if share <= thresh else "RED"
+
+
+# ── #1666 cast-full-figure cores: a token's rendered BODY must span a real figure, not a fragment (PURE) ─
+def foe_body_mask(img):
+    """Boolean HxW mask of bright yellow-green goblin-BODY pixels (g > BODY_G_FLOOR, g within BODY_GR_SLACK of
+    r, b at least BODY_GB_MARGIN below g). Pure (Image/array in, mask out). This is the foe-BODY detector: the
+    warm brazier-lit stone reads r-dominant (excluded), the walk-behind foe silhouette + ground decal read
+    pure red (excluded) — only the lit goblin body matches, so its vertical EXTENT is the figure-present
+    signal (a fragment token is red-dominant with the body mesh absent → near-zero body extent)."""
+    import numpy as np  # noqa: PLC0415
+    a = np.asarray(img, dtype=int)
+    r, g, b = a[..., 0], a[..., 1], a[..., 2]
+    return (g > BODY_G_FLOOR) & (g >= r - BODY_GR_SLACK) & (g > b + BODY_GB_MARGIN)
+
+
+def figure_body_extent_frac(img, region: tuple) -> float:
+    """Fraction of ROWS in `region` (x0,y0,x1,y1) that fall within the foe-body span — the vertical extent of
+    the rendered body figure as a fraction of the window height. A full figure fills most of its projected box
+    (~0.5-0.8); a fragment (body renderers never initialized) fills almost none (~0.1). Pure (array in, float
+    out). The region MUST be bounded to a token's projected figure so unrelated warm props never contribute."""
+    import numpy as np  # noqa: PLC0415
+    m = foe_body_mask(img)
+    h, w = m.shape[0], m.shape[1]
+    x0, y0, x1, y1 = region
+    x0, y0 = max(0, int(x0)), max(0, int(min(y0, y1)))
+    x1, y1 = min(w, int(x1)), min(h, int(max(y0, y1)))
+    if y1 - y0 < 2 or x1 - x0 < 1:
+        return 0.0
+    sub = m[y0:y1, x0:x1]
+    rows = np.where(sub.any(axis=1))[0]
+    if len(rows) == 0:
+        return 0.0
+    return float(rows.max() - rows.min() + 1) / float(y1 - y0)
+
+
+def cast_figure_verdict(rec: dict) -> str:
+    """PURE tri-state for the #1666 cast-full-figure assert. ERROR (harness — never a certification verdict)
+    when the frame could not be captured or no FOE token was on the surface to measure. Otherwise RED when ANY
+    foe's rendered body extent falls below the floor (a fragment-rendered token — the g5 crypt residual), GREEN
+    when every foe renders a full body figure."""
+    if rec.get("harness_errors"):
+        return "ERROR"
+    if not rec.get("captured"):
+        return "ERROR"
+    foes = rec.get("foes") or []
+    if not foes or any(f.get("extent") is None for f in foes):
+        return "ERROR"      # no foe / an unmeasured foe — no evidence, never a vacuous GREEN
+    floor = rec.get("min_extent", FIGURE_MIN_EXTENT)
+    return "RED" if any(f["extent"] < floor for f in foes) else "GREEN"
 
 
 # ── Primitive B helpers: spawn/arrival cells reachable, prop-clear, coherence-open (PURE) ───────────
@@ -648,6 +715,74 @@ def _spawn_row(ctx: dict) -> dict:
             "harness_errors": res.get("harness_errors", [])}
 
 
+def probe_cast_figures(ctx: dict) -> dict:
+    """PRIMITIVE C (#1666) — capture ONE /shot of the live board and prove every FOE token renders a full BODY
+    figure, not a fragment. For each foe token: project its cell's feet + head (world y = FIGURE_FEET/HEAD) to
+    window px, bound a box to that projected figure, and measure the vertical extent of foe-body pixels in it
+    (figure_body_extent_frac). A fragment-rendered token (only an accessory mesh drew; the body renderers never
+    initialized — the g5 crypt first-spawn residual) measures far below FIGURE_MIN_EXTENT and turns this RED.
+    Deterministic, no LLM / no image model — red-first, calibrated against crypt_g5.png (see the constants)."""
+    engine, qa, out = ctx["engine"], ctx["qa"], ctx["out"]
+    rec = {"harness_errors": [], "captured": False, "min_extent": FIGURE_MIN_EXTENT, "foes": []}
+    try:
+        surf = W._get(f"{engine}/combat-surface")
+    except Exception as e:  # noqa: BLE001
+        rec["harness_errors"].append(f"surface: {e}")
+        return rec
+    room = _room_of(surf) or ctx.get("room") or ""
+    rec["room"] = room
+    mask = W.walkmask_from_surface(surf)
+    cols, rows = mask["cols"], mask["rows"]
+    foes = [t for t in _actor_tokens(surf) if t["team"] == "foe"]
+    if not foes:
+        rec["harness_errors"].append("no foe token on the surface to measure")
+        return rec
+    try:
+        health = W._get(f"{qa}/health")
+        w, h = int(health["screenW"]), int(health["screenH"])
+    except Exception as e:  # noqa: BLE001
+        rec["harness_errors"].append(f"health: {e}")
+        return rec
+    try:
+        boxes = _boxes_for_room(room)
+        ortho = float((boxes or {}).get("ortho") or W._room_ortho(room))
+    except Exception:  # noqa: BLE001
+        ortho = 11.0
+    rec["window"] = [w, h]
+    cpx = W.cell_px(ortho, h)
+    shot = W._capture_shot(qa, out, "cast_figures")
+    rec["frames"] = {"open": shot}
+    if not shot:
+        rec["harness_errors"].append("shot capture failed (frame missing)")
+        return rec
+    from PIL import Image  # noqa: PLC0415
+    im = Image.open(shot).convert("RGB")
+    half = max(BODY_HALF_WIDTH_PX, int(round(0.55 * cpx)))
+    for tok in foes:
+        wx, wz = cell_to_world(tok["cell"], cols, rows)
+        feet_px = W.world_to_window_px(wx, FIGURE_FEET_WORLD_Y, wz, ortho, w, h)
+        head_px = W.world_to_window_px(wx, FIGURE_HEAD_WORLD_Y, wz, ortho, w, h)
+        cx_px = (feet_px[0] + head_px[0]) / 2.0
+        region = (cx_px - half, head_px[1], cx_px + half, feet_px[1])
+        extent = round(figure_body_extent_frac(im, region), 4)
+        rec["foes"].append({"name": tok["name"], "cell": list(tok["cell"]),
+                            "extent": extent, "region": [round(v) for v in region]})
+    rec["captured"] = True
+    return rec
+
+
+def _cast_figure_row(ctx: dict) -> dict:
+    rec = probe_cast_figures(ctx)
+    verdict = cast_figure_verdict(rec)
+    detail = None
+    if verdict in ("GREEN", "RED"):
+        worst = min((f["extent"] for f in rec.get("foes", []) if f.get("extent") is not None), default=None)
+        detail = (f"n_foes={len(rec.get('foes', []))} worst_extent={worst} "
+                  f"min={rec.get('min_extent')} room={rec.get('room')}")
+    return {"verdict": verdict, "detail": detail, "record": rec,
+            "harness_errors": rec.get("harness_errors", [])}
+
+
 # ── assertion registry ─────────────────────────────────────────────────────────────────────────────
 @dataclass
 class Assertion:
@@ -675,6 +810,13 @@ REGISTRY: list = [
             "silhouette tint (#1677 ghost-in-the-open: the ZTest-Greater clone tinting the actor against "
             "its OWN body depth). A ghost-cyan overlay in the open turns this RED — the occluder-scoping "
             "stencil fix keeps it GREEN."),
+    Assertion(
+        id="cast_renders_full_figure", scope="live_party", needs=("engine", "player"),
+        probe=_cast_figure_row,
+        doc="Primitive C (#1666) — every FOE token renders a full BODY figure, not a fragment. A "
+            "fragment-rendered token (body renderers never initialized; only an accessory mesh drew — the "
+            "g5 crypt first-spawn residual) whose projected-figure body extent falls below the floor turns "
+            "this RED; the bundle/skinning pre-warm + the render-coverage rebind guard keep it GREEN."),
 ]
 
 

--- a/qa/test_player_cert.py
+++ b/qa/test_player_cert.py
@@ -359,3 +359,72 @@ def test_ghost_frames_calibration_real_pngs():
         assert share > PC.MAX_GHOST_TINT_SHARE, f"{g.name} ghost share {share} should exceed threshold (RED)"
     nshare = PC.peak_ghost_tint_share(Image.open(normal).convert("RGB"))
     assert nshare <= PC.MAX_GHOST_TINT_SHARE, f"normal actor share {nshare} should be below threshold (GREEN)"
+
+
+# ── #1666 cast-full-figure: a fragment-rendered token must turn the suite RED ─────────────────────────
+def _body_strip(side=200, top=20, bot=180, col=(200, 210, 90)):
+    """A `side`x`side` frame with a tall vertical goblin-BODY strip (chartreuse: g high, g~r, b low) — a
+    full figure. Body extent ~ (bot-top)/side."""
+    import numpy as np
+    from PIL import Image
+    a = np.full((side, side, 3), 40, dtype=np.uint8)
+    a[top:bot, side // 2 - 12:side // 2 + 12] = col
+    return Image.fromarray(a)
+
+
+def _warm_fragment(side=200):
+    """A `side`x`side` frame with only a small warm-RED cluster (r-dominant, no body-green) near the top —
+    the fragment shape: the body mesh absent, an accessory/silhouette the only draw. Body extent ~0."""
+    import numpy as np
+    from PIL import Image
+    a = np.full((side, side, 3), 40, dtype=np.uint8)
+    a[30:55, side // 2 - 12:side // 2 + 12] = (180, 40, 35)   # red, not body-green
+    return Image.fromarray(a)
+
+
+def test_figure_body_extent_high_on_full_body_strip():
+    img = _body_strip(top=20, bot=180)
+    frac = PC.figure_body_extent_frac(img, (78, 0, 122, 200))
+    assert frac >= 0.75, f"a full body strip should fill most of its box, got {frac}"
+
+
+def test_figure_body_extent_near_zero_on_warm_fragment():
+    img = _warm_fragment()
+    frac = PC.figure_body_extent_frac(img, (78, 0, 122, 200))
+    assert frac < PC.FIGURE_MIN_EXTENT, f"a red fragment has no body figure, got {frac}"
+
+
+def test_cast_figure_verdict_green_red_error():
+    green = {"captured": True, "min_extent": PC.FIGURE_MIN_EXTENT,
+             "foes": [{"extent": 0.7}, {"extent": 0.82}]}
+    red = {"captured": True, "min_extent": PC.FIGURE_MIN_EXTENT,
+           "foes": [{"extent": 0.7}, {"extent": 0.12}]}     # one fragment turns it RED
+    assert PC.cast_figure_verdict(green) == "GREEN"
+    assert PC.cast_figure_verdict(red) == "RED"
+    assert PC.cast_figure_verdict({"harness_errors": ["surface: boom"]}) == "ERROR"
+    assert PC.cast_figure_verdict({"captured": False}) == "ERROR"
+    assert PC.cast_figure_verdict({"captured": True, "foes": []}) == "ERROR"   # no foe -> no evidence
+
+
+def test_cast_figure_calibration_real_crypt_g5():
+    """RED-FIRST against the actual g5 crypt frame (#1666): the first-spawned goblin renders as a red
+    fragment (body extent << floor) while the two full goblins render a tall body figure. The three boxes
+    are the EYEBALLED projected-figure regions (the pure extent measure is decoupled from the live camera
+    projection, which the probe wires separately). Skips when LEXAR isn't mounted (CI has no LEXAR)."""
+    import pytest
+    from PIL import Image
+    frame = _lexar("g4-build", "artifacts", "crypt_g5.png")
+    if not frame:
+        pytest.skip("LEXAR crypt_g5 calibration frame not mounted")
+    im = Image.open(frame).convert("RGB")
+    fragment = PC.figure_body_extent_frac(im, (80, 330, 165, 475))
+    goblin_a = PC.figure_body_extent_frac(im, (410, 350, 500, 520))
+    goblin_b = PC.figure_body_extent_frac(im, (490, 448, 565, 582))
+    assert fragment < PC.FIGURE_MIN_EXTENT, f"fragment goblin body extent {fragment} should be RED"
+    assert goblin_a >= PC.FIGURE_MIN_EXTENT, f"full goblin A extent {goblin_a} should be GREEN"
+    assert goblin_b >= PC.FIGURE_MIN_EXTENT, f"full goblin B extent {goblin_b} should be GREEN"
+    # and the pure verdict on the assembled record reads RED (the fragment token present)
+    rec = {"captured": True, "min_extent": PC.FIGURE_MIN_EXTENT,
+           "foes": [{"extent": round(fragment, 4)}, {"extent": round(goblin_a, 4)},
+                    {"extent": round(goblin_b, 4)}]}
+    assert PC.cast_figure_verdict(rec) == "RED"


### PR DESCRIPTION
Fixes the last open demo-path render defect — #1666's g5 per-instance manifestation.

## Race: REFUTED (at the load level), with the real per-instance mechanism identified
The hypothesis was that the first monster spawn races an async actor-bundle load. Code trace refutes the async part:
- `Bundle()` is a **synchronous** `AssetBundle.LoadFromFile`, memoized on `_bundleTried` (`CombatSurfaceClient.cs:1285`).
- `LoadAsset<T>` is synchronous `b.LoadAsset<T>` (`:1299`). No `LoadFromFileAsync`/`LoadAssetAsync` exists anywhere in the file.
- All three goblins spawn **back-to-back in the same `ApplySurf` frame** (`:861-880`) — no coroutine yield between them, nothing async to race.

The real per-instance divergence: the **first `SpawnActor` of a frame is also the first-ever access** that synchronously loads the bundle + humanoid controller + donor clip **and is the first freshly-instantiated skinned mesh of the frame**. The 2nd/3rd instances of the *same* prefab, no longer first, render full. This is exactly the render-coverage case both prior lanes flagged: the raw-prefab bind-height guards (#1666/#1676) PASS because the prefab's own `sharedMesh.bounds` is full height, yet the first instance draws only a ~0.2m accessory fragment.

## Fix (two layers, root-cause-agnostic)
1. **`PrewarmActorPipeline()` in `Start()`** — folds the one-time bundle + controller + donor loads AND a hidden throwaway skinned-mesh upload of each template out of the first spawn, so no real actor is ever the first skinned/bundle access of its frame. All guarded; absent bundle/assets → graceful skip, byte-identical to a no-bundle build. (This is the "gate on bundle-ready" intent, adapted since the load is synchronous — a queue has nothing async to wait on.)
2. **`RenderCoverageGuardCo`** — after an actor settles (3 frames), measures its RENDERED (`BakeMesh`) figure height; if it covers `< RenderCoverageFloor (0.6)` × its scale-target height, re-instantiates the actor **once** (a fresh bind is no longer first-in-frame) and logs `[CSC] #1666 render-coverage rebind`. One attempt per id (`_coverageRebound`, cleared on `Despawn`) — a still-degenerate re-bind can never loop. Catches ANY future partial-render bind, not just the race.

## Cert (`qa/player_cert.py`): `cast_renders_full_figure` (Primitive C)
For each foe token, projects a figure box and measures the vertical extent of foe-body pixels (`figure_body_extent_frac`); a fragment-rendered token turns the suite **RED**. A global color mask is unusable in the brazier-lit crypt (warm stone/flames read warm), so extent is only measured inside per-token projected boxes. Calibrated **red-first** against `crypt_g5.png`: fragment body extent **0.08–0.17** vs full goblins **0.47–0.82**, floor **0.35** (in the gap). `qa/test_player_cert.py` adds synthetic + real-frame calibration units (the real-frame test asserts fragment→RED, both full goblins→GREEN).

## Tests
`uv run pytest qa/test_player_cert.py -q` → **36 passed** (incl. the 4 new figure tests, real crypt_g5.png calibration exercised).
C# is not locally compilable — changes are surgical, mirror the file's idioms (guarded lazy-load, coroutine settle-then-act like `ResnapGroundedCo`), and are line-cited above.

## Box re-verify recipe
1. Build the macOS player from this branch; launch the sandbox on the adventure fixture seeded at the crypt (party + 3 'Goblin Warrior').
2. Every boot, all three goblins must render full-figure (the first-spawn goblin over the west stairs no longer a red fragment). Watch the player log for `[CSC] #1666 actor pipeline pre-warmed`; a `[CSC] #1666 render-coverage rebind` line means the backstop fired (still a PASS — the actor is re-bound full).
3. `python3 qa/player_cert.py --live --run <sandbox>` → `cast_renders_full_figure` GREEN (RED if any foe still renders a fragment).

Never touched: owner surfaces (:8766), :8866/:8972 (no sandbox brought up; pixel calibration used the saved frames).