### PR TITLE
renderer: kit pillar grounding — seat bounds min.y on floor (r6, #83)

### DIFF
--- a/extensions/renderers/unity/scripts/build_room_kit.cs
+++ b/extensions/renderers/unity/scripts/build_room_kit.cs
@@ -381,19 +381,24 @@ public static class BuildRoomKit
         foreach (var ll in UnityEngine.Object.FindObjectsByType<Light>(FindObjectsSortMode.None))
         { if (ll == null || ll.transform.IsChildOf(root.transform)) continue; if (ll.enabled) { ll.enabled = false; disLights.Add(ll); } }
 
-        string outPath = null;
+        string outPath = null; string contractPath = null;
         try
         {
             string stamp = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmm'Z'", CultureInfo.InvariantCulture);
             outPath = Path.Combine(CaptureDir(), $"kit_{roomId}_{stamp}.png");
             RenderToPng(cam, W, H, outPath);
+            // r6: ALSO emit the 1344x768 CONTRACT frame — qa/registration_score.py refuses any other
+            // size (its projection math is defined in that frame), so every capture yields both.
+            contractPath = Path.Combine(CaptureDir(), $"kit_{roomId}_{stamp}_contract.png");
+            SetupContractCamera(cam, cols, rows, camFit, 1344f / 768f);
+            RenderToPng(cam, 1344, 768, contractPath);
         }
         finally
         {
             foreach (var rr in hidRends) if (rr != null) rr.enabled = true;
             foreach (var ll in disLights) if (ll != null) ll.enabled = true;
         }
-        Debug.Log($"[KitRoom] captured {W}x{H} → {outPath}");
+        Debug.Log($"[KitRoom] captured {W}x{H} → {outPath} + contract 1344x768 → {contractPath}");
     }
 
     // ════════════════════════════════════════════════════════════════════════════════════════════════

--- a/extensions/renderers/unity/scripts/build_room_kit.cs
+++ b/extensions/renderers/unity/scripts/build_room_kit.cs
@@ -549,7 +549,9 @@ public static class BuildRoomKit
             Debug.LogWarning($"[KitRoom] ⚠⚠ pillar '{name}' achieved world=({b1.size.x:F2},{b1.size.y:F2},{b1.size.z:F2}) " +
                              $"is OFF target ({PILLAR_TGT_XZ:F1},{PILLAR_TGT_H:F1},{PILLAR_TGT_XZ:F1}) by >10% — check prefab bounds/pivot.");
         Vector3 pivotOffset = inst.transform.position - b1.center;
-        inst.transform.position = new Vector3(center.x + pivotOffset.x, pivotOffset.y - b1.min.y, center.z + pivotOffset.z);
+        // r6: ground on min.y alone — the pivotOffset.y term double-counts the bounds centre for
+        // base-pivot meshes (measured: pillars sat at pos.y=-1.98, bounds -1.99..2.01, half underground).
+        inst.transform.position = new Vector3(center.x + pivotOffset.x, inst.transform.position.y - b1.min.y, center.z + pivotOffset.z);
         FixMaterials(inst, false, ref matFix, force: true);   // r5: pillars shipped grey → force stone/brick
         return inst;
     }


### PR DESCRIPTION
One-line grounding fix in `PlacePillar`, box-validated before commit.

**Bug (measured on the box, r5 build):** achieved pillar world size was exactly on target (1.20, 4.00, 1.20) — the r5 measured-multiplier works — but every pillar sat at `pos.y=-1.98` with world bounds `-1.99..+2.01`: half the column underground, rendering as a short stub.

**Root cause:** the seating formula `pivotOffset.y - b1.min.y` double-counts the bounds centre for base-pivot meshes (Synty pillar pivot is at its base → centre.y=+2.0 after scaling → pos.y=-2.0). The tomb reads correctly only because its pivot is centred.

**Fix:** ground on `min.y` alone: `position.y - b1.min.y`.

**Box verification (same session):** post-fix probe reports all 4 pillars `minY=0.00 maxY=4.00 sizeY=4.00`; capture `kit_crypt_20260722T1538Z` shows four full-height brick columns at the quadrant positions. Round log on #83.