### PR TITLE
chore(privacy): remove public name references

### DIFF
--- a/content/worlds/baldurs-gate/characters/aran-elomar.json
+++ b/content/worlds/baldurs-gate/characters/aran-elomar.json
@@ -10,7 +10,7 @@
   "backstory": "Aran Elomar is a human wine taster who can be found at the Wine Festival at Highberry's Home in the Lower City of Baldur's Gate.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "human (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Aran_Elomar",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/art-cullagh.json
+++ b/content/worlds/baldurs-gate/characters/art-cullagh.json
@@ -10,7 +10,7 @@
   "backstory": "Art Cullagh is a Flaming Fist found at abed, unresponsive, and singing about Thaniel during Act Two.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "human (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Art_Cullagh",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content.",

--- a/content/worlds/baldurs-gate/characters/bernyr.json
+++ b/content/worlds/baldurs-gate/characters/bernyr.json
@@ -10,7 +10,7 @@
   "backstory": "Worker Bernyr is a gold dwarf in Baldur's Gate during Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "dwarf (voiced by Andrew Futaishi)",
+  "voice_hint": "dwarf (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Bernyr",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/blighted-barman.json
+++ b/content/worlds/baldurs-gate/characters/blighted-barman.json
@@ -10,7 +10,7 @@
   "backstory": "Blighted Barman is an undead zombie in Reithwin Town in Act Two.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "zombie (voiced by Andrew Spooner)",
+  "voice_hint": "zombie (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Blighted_Barman",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/brammels.json
+++ b/content/worlds/baldurs-gate/characters/brammels.json
@@ -10,7 +10,7 @@
   "backstory": "Cashguard Basher Brammels, is a human member of the Cashguard located in The Counting House in the Lower City of Baldur's Gate.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human paladin (voiced by Andrew Wincott)",
+  "voice_hint": "human paladin (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Brammels",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/crimson.json
+++ b/content/worlds/baldurs-gate/characters/crimson.json
@@ -10,7 +10,7 @@
   "backstory": "Crimson is a beast NPC found in Act Three. Crimson is kept in a cage at the Circus of the Last Days, in Rivington.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "dilophosaurus (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "dilophosaurus (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Crimson",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/d-hak.json
+++ b/content/worlds/baldurs-gate/characters/d-hak.json
@@ -10,7 +10,7 @@
   "backstory": "D'hak is a wolf in Crèche Y'llek during Act One.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "wolf (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "wolf (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/D%27hak",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/dave-hosmo.json
+++ b/content/worlds/baldurs-gate/characters/dave-hosmo.json
@@ -10,7 +10,7 @@
   "backstory": "Dave Hosmo is a human wine taster who can be found at the Wine Festival at Highberry's Home in the Lower City of Baldur's Gate.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human (voiced by Andrew Futaishi)",
+  "voice_hint": "human (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Dave_Hosmo",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/dorikel.json
+++ b/content/worlds/baldurs-gate/characters/dorikel.json
@@ -10,7 +10,7 @@
   "backstory": "Adept Dorikel is a drow Adept of the Absolute in Moonrise Towers during Act Two. He is stationed outside the main throne room, alongside Adept Furek.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "drow cleric (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "drow cleric (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Dorikel",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/dulbers-frint.json
+++ b/content/worlds/baldurs-gate/characters/dulbers-frint.json
@@ -10,7 +10,7 @@
   "backstory": "Dulbers Frint is a deep gnome member of Clan Ironhand.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "gnome wizard (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "gnome wizard (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Dulbers_Frint",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/echo-of-abazigal.json
+++ b/content/worlds/baldurs-gate/characters/echo-of-abazigal.json
@@ -10,7 +10,7 @@
   "backstory": "In life Abazigal was once a Bhaalspawn and a member of the Five, which was an alliance between five powerful Bhaalspawns formed by , Bhaal's high priestess, that sought to slaughter their siblings in exchange for power. Like the rest of the Five, he was defeated by his sibling and fellow Bhaalspawn \"Gorion's Ward\" and their party at his lair.\n\nBhaal was a century after Abazigal's death. After this Sarevok Anchev was able to bring Abazigal back as an Echo to serve in the Murder Tribunal along with Illasera, Sendai and Amelyssan.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "ghost (voiced by Andrew Spooner)",
+  "voice_hint": "ghost (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Echo_of_Abazigal",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/elder-roth.json
+++ b/content/worlds/baldurs-gate/characters/elder-roth.json
@@ -10,7 +10,7 @@
   "backstory": "The Elder Rothé is in Grymforge during Act One. It can be spoken to using .",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "deep rothé (voiced by Andrew Spooner, Glen McCready)",
+  "voice_hint": "deep rothé (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Elder_Roth%C3%A9",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/ernestus.json
+++ b/content/worlds/baldurs-gate/characters/ernestus.json
@@ -10,7 +10,7 @@
   "backstory": "Fist Ernestus is a human fighter and a member of the Flaming Fist. He can be found on the streets of the Lower City in Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human fighter (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "human fighter (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Ernestus",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content.",

--- a/content/worlds/baldurs-gate/characters/ettvard-needle.json
+++ b/content/worlds/baldurs-gate/characters/ettvard-needle.json
@@ -10,7 +10,7 @@
   "backstory": "Ettvard Needle is the human editor in chief for the Baldur's Mouth Gazette, found in their main building; the Baldur's Mouth, Lower City.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human (voiced by Andrew Spooner)",
+  "voice_hint": "human (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Ettvard_Needle",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/figaro-pennygood.json
+++ b/content/worlds/baldurs-gate/characters/figaro-pennygood.json
@@ -10,7 +10,7 @@
   "backstory": "Figaro 'Facemaker' Pennygood is a merchant who owns the store Facemaker's Boutique in the Lower City during Act Three. He is the brother of Carmen Pennygood the owner of Carm's Garms in Wyrm's Crossing.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "dwarf (voiced by Romayne Andrews)",
+  "voice_hint": "dwarf (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Figaro_Pennygood",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content.",

--- a/content/worlds/baldurs-gate/characters/follgast.json
+++ b/content/worlds/baldurs-gate/characters/follgast.json
@@ -10,7 +10,7 @@
   "backstory": "Follgast is an elven member of the Zhentarim that can be found in the Guildhall, during Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "high elf (voiced by Romayne Andrews)",
+  "voice_hint": "high elf (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Follgast",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content.",

--- a/content/worlds/baldurs-gate/characters/frell-olsin.json
+++ b/content/worlds/baldurs-gate/characters/frell-olsin.json
@@ -10,7 +10,7 @@
   "backstory": "Frell Olsin is a human member of the Church of Gond, found enslaved in the Steel Watch Foundry.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human (voiced by Andrew Spooner)",
+  "voice_hint": "human (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Frell_Olsin",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/grindo-biggs.json
+++ b/content/worlds/baldurs-gate/characters/grindo-biggs.json
@@ -10,7 +10,7 @@
   "backstory": "Grindo Biggs is a rock gnome member of the Church of Gond, found enslaved in the Steel Watch Foundry.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "gnome (voiced by Romayne Andrews)",
+  "voice_hint": "gnome (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Grindo_Biggs",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/grotpoll.json
+++ b/content/worlds/baldurs-gate/characters/grotpoll.json
@@ -10,7 +10,7 @@
   "backstory": "Saer Grotpoll is a high elven character, a Baldurian in Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "elf (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "elf (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Grotpoll",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/haarlep.json
+++ b/content/worlds/baldurs-gate/characters/haarlep.json
@@ -10,7 +10,7 @@
   "backstory": "Haarlep was sent by Mephistopheles to distract his naughty son Raphael. They serve as the devil's main sexual partner, indulging him in his fantasies.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "incubus (voiced by Andrew Wincott, Olivia Chappell)",
+  "voice_hint": "incubus (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Haarlep",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/halfar.json
+++ b/content/worlds/baldurs-gate/characters/halfar.json
@@ -10,7 +10,7 @@
   "backstory": "Halfar, named in-game as Dead Flaming Fist, is a Flaming Fist mercenary and cleric of Ilmater that can be found slain on the footsteps leading into High Hall.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human cleric (voiced by Andrew Wincott)",
+  "voice_hint": "human cleric (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Halfar",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content.",

--- a/content/worlds/baldurs-gate/characters/hari-nodles.json
+++ b/content/worlds/baldurs-gate/characters/hari-nodles.json
@@ -10,7 +10,7 @@
   "backstory": "Hari Nodles is a human civilian who is attempting to comfort Fevrokis after he found the bodies of his dead parents in the Brampton district of the Lower City in Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human (voiced by Andrew Futaishi)",
+  "voice_hint": "human (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Hari_Nodles",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/henk.json
+++ b/content/worlds/baldurs-gate/characters/henk.json
@@ -10,7 +10,7 @@
   "backstory": "Tender Henk is the owner of The Singing Lute, a restaurant in the Lower City of Baldur's Gate during Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "half-orc (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "half-orc (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Henk",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/hivune.json
+++ b/content/worlds/baldurs-gate/characters/hivune.json
@@ -12,7 +12,7 @@
   "relationships": [
     "(Only while Reapers of Bhaal are chanting)"
   ],
-  "voice_hint": "human wizard (voiced by Romayne Andrews)",
+  "voice_hint": "human wizard (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Hivune",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/huido.json
+++ b/content/worlds/baldurs-gate/characters/huido.json
@@ -12,7 +12,7 @@
   "relationships": [
     "Guido is accompanied by his gang."
   ],
-  "voice_hint": "halfling rogue (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "halfling rogue (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Huido",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/jezzy-topps.json
+++ b/content/worlds/baldurs-gate/characters/jezzy-topps.json
@@ -10,7 +10,7 @@
   "backstory": "Jezzy Topps is a human smuggler and part of Big Huido's gang.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human (voiced by Romayne Andrews)",
+  "voice_hint": "human (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Jezzy_Topps",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/karrik.json
+++ b/content/worlds/baldurs-gate/characters/karrik.json
@@ -10,7 +10,7 @@
   "backstory": "Karrik is a human druid in the Circle of the Emerald Grove in Act One.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human druid (voiced by Andrew Spooner)",
+  "voice_hint": "human druid (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Karrik",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/lann-tarv.json
+++ b/content/worlds/baldurs-gate/characters/lann-tarv.json
@@ -10,7 +10,7 @@
   "backstory": "Lann Tarv is a merchant on the ground floor of Moonrise Towers in Act Two. His special inventory is not available unless the party pass certain checks with Z'rell after the introduction scene further within Moonrise Towers.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "bugbear paladin (voiced by Andrew Spooner)",
+  "voice_hint": "bugbear paladin (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Lann_Tarv",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content.",

--- a/content/worlds/baldurs-gate/characters/lo.json
+++ b/content/worlds/baldurs-gate/characters/lo.json
@@ -10,7 +10,7 @@
   "backstory": "Iron Consul Lo is a cultist of Bane and one of Gortash's bodyguards.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "human (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Lo",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/lur-jox.json
+++ b/content/worlds/baldurs-gate/characters/lur-jox.json
@@ -10,7 +10,7 @@
   "backstory": "Lur Jox is a spider in Grymforge during Act One. It can be found near the cages west of the waypoint with several other spiders and Murmath.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "spider (voiced by Andrew Spooner)",
+  "voice_hint": "spider (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Lur_Jox",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/m-ran.json
+++ b/content/worlds/baldurs-gate/characters/m-ran.json
@@ -10,7 +10,7 @@
   "backstory": "Fist Mîran is a human ranger and a member of the Flaming Fist. He can be found in Rivington in Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human ranger (voiced by Andrew Spooner)",
+  "voice_hint": "human ranger (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/M%C3%AEran",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content.",

--- a/content/worlds/baldurs-gate/characters/malik-iron-consul.json
+++ b/content/worlds/baldurs-gate/characters/malik-iron-consul.json
@@ -10,7 +10,7 @@
   "backstory": "Iron Consul Malik the Cruel is a cultist of Bane found in the main floor of the Steel Watch Foundry at .",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "half-orc fighter (voiced by Andrew Futaishi)",
+  "voice_hint": "half-orc fighter (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Malik_%28iron_consul%29",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/miklaur.json
+++ b/content/worlds/baldurs-gate/characters/miklaur.json
@@ -10,7 +10,7 @@
   "backstory": "Miklaur is Lorroakan's assistant in the Upper City of Baldur's Gate during Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "halfling (voiced by Andrew Futaishi)",
+  "voice_hint": "halfling (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Miklaur",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/mohan.json
+++ b/content/worlds/baldurs-gate/characters/mohan.json
@@ -10,7 +10,7 @@
   "backstory": "Mohan is a trader in Baldur's Gate during Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "gnome (voiced by Andrew Futaishi)",
+  "voice_hint": "gnome (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Mohan",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content.",

--- a/content/worlds/baldurs-gate/characters/morann.json
+++ b/content/worlds/baldurs-gate/characters/morann.json
@@ -10,7 +10,7 @@
   "backstory": "Morann is a follower of Shar that guards the door to the Mapping Room in the House of Grief in Baldur's Gate. He does not allow the party to open the door without permission.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human (voiced by Andrew Spooner)",
+  "voice_hint": "human (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Morann",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/nonabune.json
+++ b/content/worlds/baldurs-gate/characters/nonabune.json
@@ -10,7 +10,7 @@
   "backstory": "Nonabune is a strongheart halfling walking by the docks east of Philgrave's Mansion in the Lower City.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "halfling (voiced by Romayne Andrews)",
+  "voice_hint": "halfling (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Nonabune",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/nozk.json
+++ b/content/worlds/baldurs-gate/characters/nozk.json
@@ -10,7 +10,7 @@
   "backstory": "Sharp-Eye Nozk is a goblin stationed in the Goblin Camp in Act One.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "goblin ranger (voiced by Andrew Spooner)",
+  "voice_hint": "goblin ranger (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Nozk",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/patrick.json
+++ b/content/worlds/baldurs-gate/characters/patrick.json
@@ -10,7 +10,7 @@
   "backstory": "Fist Patrick is a human fighter and a member of the Flaming Fist. He can be found in Rivington in Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human fighter (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "human fighter (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Patrick",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content.",

--- a/content/worlds/baldurs-gate/characters/pooldripp.json
+++ b/content/worlds/baldurs-gate/characters/pooldripp.json
@@ -10,7 +10,7 @@
   "backstory": "Pooldripp the Zealous is a Kuo-toa in the Underdark during Act One, leading the worship of BOOOAL.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "kuo-toa (voiced by Andrew Wincott)",
+  "voice_hint": "kuo-toa (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Pooldripp",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/raphael.json
+++ b/content/worlds/baldurs-gate/characters/raphael.json
@@ -10,7 +10,7 @@
   "backstory": "Raphael is heir to the archdevil Mephistopheles, a status granting him power and rank above that of other devils. He is proprietor to the House of Hope, a falsely welcoming home used to lure in those he wishes to bind into his service with infernal contracts. \n\nThe nature of Raphael's contracts are such that the contractee will inevitably owe him a debt. These individuals eventually become Eternal Debtors. \n\nOne such contractee was the architect of Moonrise Towers, who bargained to end Ketheric Thorm's Dark Justiciar army in exchange for their soul. Raphael contracted Yurgir and his legion of Merregons, who destroyed all but one of the Justiciars, who himself made a deal with Raphael to guarantee his survival in the form of many rats. As designed, Yurgir did not technically complete his end of the bargain, and remained trapped in the Gauntlet of Shar and under contract of Raphael.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "cambion /; theatrical (voiced by Andrew Wincott)",
+  "voice_hint": "cambion /; theatrical (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Raphael",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content.",

--- a/content/worlds/baldurs-gate/characters/rudd.json
+++ b/content/worlds/baldurs-gate/characters/rudd.json
@@ -10,7 +10,7 @@
   "backstory": "Rudd is a Doppelganger found in the Under Temple Cave Area under the Open Hand Temple in Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "doppelganger (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "doppelganger (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Rudd",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/saff-fargoer.json
+++ b/content/worlds/baldurs-gate/characters/saff-fargoer.json
@@ -10,7 +10,7 @@
   "backstory": "Saff Fargoer is one of the onlookers witnessing Volo's execution scene at the Grey Harbour Docks in Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "dwarf (voiced by Andrew Wincott)",
+  "voice_hint": "dwarf (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Saff_Fargoer",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/serrik.json
+++ b/content/worlds/baldurs-gate/characters/serrik.json
@@ -10,7 +10,7 @@
   "backstory": "Fist Serrik is an elven fighter and a member of the Flaming Fist. He can be found in Wyrm's Rock Fortress in Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "elf fighter (voiced by Romayne Andrews)",
+  "voice_hint": "elf fighter (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Serrik",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content.",

--- a/content/worlds/baldurs-gate/characters/slumgullion.json
+++ b/content/worlds/baldurs-gate/characters/slumgullion.json
@@ -10,7 +10,7 @@
   "backstory": "Slumgullion is a halfling civilian who can be found behind the Elfsong Tavern.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "halfling (voiced by Romayne Andrews)",
+  "voice_hint": "halfling (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Slumgullion",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/somi.json
+++ b/content/worlds/baldurs-gate/characters/somi.json
@@ -10,7 +10,7 @@
   "backstory": "Somi is a half-orc guard working for Entharl Danthelon in Danthelon's Dancing Axe in Wyrm's Crossing during Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "half-orc barbarian (voiced by Andrew Wincott)",
+  "voice_hint": "half-orc barbarian (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Somi",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/sparks-musgravel.json
+++ b/content/worlds/baldurs-gate/characters/sparks-musgravel.json
@@ -10,7 +10,7 @@
   "backstory": "Sparks Musgravel is a human member of The Guild.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "human wizard (voiced by Andrew Wincott)",
+  "voice_hint": "human wizard (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Sparks_Musgravel",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/stug-minedale.json
+++ b/content/worlds/baldurs-gate/characters/stug-minedale.json
@@ -10,7 +10,7 @@
   "backstory": "Stug Minedale is a dwarven patron at the Elfsong Tavern in Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "dwarf (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "dwarf (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Stug_Minedale",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/suspicious-foont.json
+++ b/content/worlds/baldurs-gate/characters/suspicious-foont.json
@@ -10,7 +10,7 @@
   "backstory": "'Suspicious' Foont is a halfling civilian attempting to hunt ghosts in the Lower City of Baldur's Gate during Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "halfling (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "halfling (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/%27Suspicious%27_Foont",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/topaz-blue-jay.json
+++ b/content/worlds/baldurs-gate/characters/topaz-blue-jay.json
@@ -10,7 +10,7 @@
   "backstory": "Topaz is a bird in the Circle of the Emerald Grove in Act One.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "bird (voiced by Andrew Spooner)",
+  "voice_hint": "bird (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Topaz_%28Blue_Jay%29",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/vix.json
+++ b/content/worlds/baldurs-gate/characters/vix.json
@@ -10,7 +10,7 @@
   "backstory": "Roustabout Vix is a High Half-Elf found in the Circus of the Last Days in Rivington. He is sleeping in the off-limits dressing room area, unless combat starts after which he will wander around.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "half-elf (voiced by Andrew Futaishi)",
+  "voice_hint": "half-elf (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Vix",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/zar-a-ath.json
+++ b/content/worlds/baldurs-gate/characters/zar-a-ath.json
@@ -10,7 +10,7 @@
   "backstory": "Youth Zar'a'ath is a member of a new githyanki generation hatched and raised in the Crèche Y’llek during Act One.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "githyanki (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "githyanki (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Zar%27a%27ath",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/content/worlds/baldurs-gate/characters/zog.json
+++ b/content/worlds/baldurs-gate/characters/zog.json
@@ -10,7 +10,7 @@
   "backstory": "Zog is a half-orc adventurer who is meeting up with his group in Rivington during Act Three.",
   "equipment": [],
   "relationships": [],
-  "voice_hint": "half-orc (voiced by Andrew Wheildon-Dennis)",
+  "voice_hint": "half-orc (credited voice performance)",
   "source_url": "https://bg3.wiki/wiki/Zog",
   "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions are CC BY-NC-SA 4.0 NonCommercial only)",
   "attribution": "Text from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Also subject to Larian Studios' and Wizards of the Coast's Fan Content Policies. Unofficial, non-commercial fan content."

--- a/qa/overlay_boxes.py
+++ b/qa/overlay_boxes.py
@@ -142,7 +142,7 @@ def blob_solve(boxes: dict, image: Path) -> dict:
 
 
 def _hull(points: list) -> list:
-    """Convex hull (Andrew monotone chain) of projected box corners."""
+    """Convex hull (monotone-chain) of projected box corners."""
     pts = sorted(set((round(x, 1), round(y, 1)) for x, y in points))
     if len(pts) <= 2:
         return pts

--- a/tools/derive_room_manifest.py
+++ b/tools/derive_room_manifest.py
@@ -73,7 +73,7 @@ def _prop_box_corners(footprint: list, kind: str, cols: int, rows: int,
 
 
 def _convex_hull(points: list) -> list:
-    """Andrew's monotone-chain convex hull (CCW). The prop box silhouette is convex under the ortho
+    """monotone-chain convex hull (CCW). The prop box silhouette is convex under the ortho
     dimetric camera, so its hull is exactly the silhouette outline."""
     pts = sorted(set((round(x, 3), round(y, 3)) for (x, y) in points))
     if len(pts) <= 2:


### PR DESCRIPTION
Removes public personal-name literals from attribution and algorithm-description text while preserving functional behavior.

Privacy-only cleanup; no runtime behavior changes.