### PR TITLE
build/qa: kit-scene contamination gate (in-memory strip, scene guard, sharedassets scan) — C# half of #1690

### DIFF
--- a/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
+++ b/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
 using UnityEditor.Build.Reporting;
+using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.Rendering;
+using UnityEngine.SceneManagement;
 
 /// <summary>
 /// W5a (#1322) — macOS standalone PLAYER build, batch-mode-free (the box forbids `-batchmode`,
@@ -188,6 +190,12 @@ public static class BuildMacOSPlayer
         // player can runtime-spawn actors for any campaign (not just the baked scene's cast).
         EnsurePackaged();
 
+        // Kit rooms (build_room_kit.cs) are QA constructions; a capture flow that saved the scene while one
+        // existed shipped it inside the player, drawing grey kit masses over every plate. Strip them for
+        // THIS BUILD ONLY — buildScenePath is redirected to a temp copy, never the tracked scene.
+        string buildScenePath = SceneToBuild;
+        string[] strippedQARoots = StripQAConstructions(ref buildScenePath);
+
         // --- Player identity (was DefaultCompany/WorldOS-Unity-spike) ---
         PlayerSettings.companyName = "worldos";
         PlayerSettings.productName = "WorldOSPlayer";
@@ -235,7 +243,7 @@ public static class BuildMacOSPlayer
 
         var options = new BuildPlayerOptions
         {
-            scenes = new[] { SceneToBuild },
+            scenes = new[] { buildScenePath },
             locationPathName = appPath,
             target = BuildTarget.StandaloneOSX,
             targetGroup = BuildTargetGroup.Standalone,
@@ -243,7 +251,9 @@ public static class BuildMacOSPlayer
         };
 
         Debug.Log("[BuildMacOSPlayer] Starting build -> " + appPath + " (arch=" + archResult + ")");
-        BuildReport report = BuildPipeline.BuildPlayer(options);
+        BuildReport report;
+        try { report = BuildPipeline.BuildPlayer(options); }
+        finally { if (buildScenePath != SceneToBuild) AssetDatabase.DeleteAsset(buildScenePath); }
         var s = report.summary;
 
         string reportPath = Path.Combine(outDir, "build-report.txt");
@@ -259,11 +269,108 @@ public static class BuildMacOSPlayer
             "platform=" + s.platform + "\n" +
             "architecture=" + archResult + "\n" +
             "alwaysIncludedShaders=" + string.Join(",", includedShaders) + "\n" +
+            "strippedQARoots=" + (strippedQARoots.Length == 0 ? "(none)" : string.Join(",", strippedQARoots)) + "\n" +
             "scenesBuilt=" + string.Join(",", options.scenes) + "\n");
 
         Debug.Log("[BuildMacOSPlayer] DONE result=" + s.result + " errors=" + s.totalErrors
             + " warnings=" + s.totalWarnings + " size=" + s.totalSize + " time=" + s.totalTime
             + " report=" + reportPath);
+    }
+
+    // QA-construction roots that must NEVER ship inside a player build. build_room_kit.cs assembles kit
+    // rooms as "KitRoom_<roomId>" roots in whatever scene is open; a capture/lighting flow that saved the
+    // scene mid-session baked them in, and the built player then rendered grey kit masses (fallback boxes,
+    // brazier plinths, parapets) in front of every plate. Measured three times (kit-crypt cleankit trap ×2,
+    // kit-tavern 2026-07-23 — the withheld tavern install). qa/qa_sandbox.py is the independent detector.
+    //
+    // The strip is a BUILD-LOCAL transform, never an edit of the tracked scene. Saving the canonical scene
+    // as a build side effect is exactly the bug this gate exists to prevent, so it must not be the fix for
+    // it: the scene is snapshotted to a temp scene asset (SaveScene saveAsCopy — the editor's own scene is
+    // neither dirtied nor reloaded, so unsaved in-editor work survives untouched), the KitRoom_* roots are
+    // destroyed in THAT copy, and BuildPlayerOptions.scenes points at the copy for this build only.
+    const string QARootPrefix = "KitRoom_";
+    const string StripScenePath = "Assets/Scenes/__BuildStripped_QARoots.unity";
+
+    // Returns the stripped root names (empty = nothing to strip) and, when a strip happened, redirects
+    // buildScenePath at the temp scene. A strip that cannot be completed FAILS the build (FailBuild) —
+    // a silent failure here would ship the contamination under a green build stamp.
+    static string[] StripQAConstructions(ref string buildScenePath)
+    {
+        var active = EditorSceneManager.GetActiveScene();
+        Scene src;
+        string restorePath = null;
+        if (active.IsValid() && active.path == SceneToBuild)
+        {
+            src = active;
+        }
+        else
+        {
+            // OpenScene(Single) DISCARDS unsaved changes in the open scene. Refuse loudly rather than
+            // throwing editor work away; a save prompt is not an option here, because this MenuItem runs
+            // in a headed-but-remotely-driven editor where a modal deadlocks the session (BOX.md #1196).
+            if (active.IsValid() && (active.isDirty || string.IsNullOrEmpty(active.path)))
+                FailBuild("refusing to build: the open scene '"
+                    + (string.IsNullOrEmpty(active.path) ? "Untitled" : active.path)
+                    + "' has UNSAVED changes and this build must open " + SceneToBuild
+                    + ". Save or discard those changes, then rebuild.");
+            restorePath = active.IsValid() ? active.path : null;
+            src = EditorSceneManager.OpenScene(SceneToBuild, OpenSceneMode.Single);
+        }
+
+        var qaRoots = new List<string>();
+        foreach (var go in src.GetRootGameObjects())
+            if (go != null && go.name.StartsWith(QARootPrefix, StringComparison.Ordinal)) qaRoots.Add(go.name);
+
+        // Route through the copy whenever the built content could differ from the scene asset on disk —
+        // i.e. there is something to strip, or the open scene has unsaved edits. Otherwise build the
+        // canonical path directly (the long-standing, well-exercised path).
+        if (qaRoots.Count > 0 || src.isDirty)
+        {
+            if (!EditorSceneManager.SaveScene(src, StripScenePath, true) || !File.Exists(StripScenePath))
+                FailBuild("QA-root strip FAILED: could not write the temp build scene " + StripScenePath
+                    + " (roots found: " + string.Join(",", qaRoots.ToArray())
+                    + "). Refusing to ship a build that would contain them.");
+            AssetDatabase.Refresh();
+
+            var tmp = EditorSceneManager.OpenScene(StripScenePath, OpenSceneMode.Additive);
+            int destroyed = 0;
+            foreach (var go in tmp.GetRootGameObjects())
+                if (go != null && go.name.StartsWith(QARootPrefix, StringComparison.Ordinal))
+                { UnityEngine.Object.DestroyImmediate(go); destroyed++; }
+            bool saved = EditorSceneManager.SaveScene(tmp);
+            EditorSceneManager.CloseScene(tmp, true);
+            if (!saved || destroyed != qaRoots.Count)
+                FailBuild("QA-root strip FAILED: saved=" + saved + " destroyed=" + destroyed + "/" + qaRoots.Count
+                    + " in " + StripScenePath + ". Refusing to ship a build that would contain "
+                    + string.Join(",", qaRoots.ToArray()) + ".");
+
+            buildScenePath = StripScenePath;
+            if (qaRoots.Count > 0)
+                Debug.LogWarning("[BuildMacOSPlayer] stripped QA construction roots for THIS BUILD ONLY ("
+                    + SceneToBuild + " on disk is unchanged): " + string.Join(",", qaRoots.ToArray()));
+        }
+
+        // Put the editor back on whatever scene it was showing (only reachable when it was clean).
+        if (!string.IsNullOrEmpty(restorePath) && restorePath != SceneToBuild && File.Exists(restorePath))
+            EditorSceneManager.OpenScene(restorePath, OpenSceneMode.Single);
+        return qaRoots.ToArray();
+    }
+
+    // A precondition failure must be LOUD and must not leave a green-looking artifact behind: stamp the
+    // build report red before throwing, so a consumer reading build-report.txt (qa_sandbox, the runbooks)
+    // cannot mistake the previous run's stamp beside a stale .app for a successful build.
+    static void FailBuild(string reason)
+    {
+        try
+        {
+            string outDir = Path.Combine(Directory.GetParent(Application.dataPath).FullName, OutputDir);
+            Directory.CreateDirectory(outDir);
+            File.WriteAllText(Path.Combine(outDir, "build-report.txt"),
+                "result=Failed\ntotalErrors=1\nfailedPrecondition=" + reason + "\n");
+        }
+        catch (Exception e) { Debug.LogError("[BuildMacOSPlayer] could not write failure report: " + e.Message); }
+        Debug.LogError("[BuildMacOSPlayer] " + reason);
+        throw new Exception("[BuildMacOSPlayer] " + reason);
     }
 
     // #1674: shaders CombatSurfaceClient resolves at runtime via Shader.Find and that NO asset references, so

--- a/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
+++ b/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
@@ -36,6 +36,7 @@ public static class BuildMacOSPlayer
     const string SceneToBuild = "Assets/Scenes/M1CombatV1_canonical.unity";
     const string OutputDir = "BuildOutput";
     const string AppName = "WorldOSPlayer.app";
+    const string ReportFileName = "build-report.txt";
 
     // #1436 (W5c Unit 1) packaging: the standalone player cannot AssetDatabase.Load an Assets/ path at
     // runtime, so the registry-referenced actor assets + the registry manifest must be packaged into the
@@ -256,7 +257,7 @@ public static class BuildMacOSPlayer
         finally { if (buildScenePath != SceneToBuild) AssetDatabase.DeleteAsset(buildScenePath); }
         var s = report.summary;
 
-        string reportPath = Path.Combine(outDir, "build-report.txt");
+        string reportPath = Path.Combine(outDir, ReportFileName);
         File.WriteAllText(reportPath,
             "result=" + s.result + "\n" +
             "totalErrors=" + s.totalErrors + "\n" +
@@ -361,16 +362,26 @@ public static class BuildMacOSPlayer
     // cannot mistake the previous run's stamp beside a stale .app for a successful build.
     static void FailBuild(string reason)
     {
+        StampFailedReport(reason);
+        Debug.LogError("[BuildMacOSPlayer] " + reason);
+        throw new Exception("[BuildMacOSPlayer] " + reason);
+    }
+
+    // Best effort, and deliberately narrow: a report the build could not write must never become the
+    // exception the caller sees in place of `reason`, so the two failure modes that actually occur here
+    // (a read-only/locked BuildOutput, a full disk) are swallowed with a log. Anything else is a real
+    // bug and is allowed to surface — the build still fails, which is the invariant that matters.
+    static void StampFailedReport(string reason)
+    {
         try
         {
             string outDir = Path.Combine(Directory.GetParent(Application.dataPath).FullName, OutputDir);
             Directory.CreateDirectory(outDir);
-            File.WriteAllText(Path.Combine(outDir, "build-report.txt"),
+            File.WriteAllText(Path.Combine(outDir, ReportFileName),
                 "result=Failed\ntotalErrors=1\nfailedPrecondition=" + reason + "\n");
         }
-        catch (Exception e) { Debug.LogError("[BuildMacOSPlayer] could not write failure report: " + e.Message); }
-        Debug.LogError("[BuildMacOSPlayer] " + reason);
-        throw new Exception("[BuildMacOSPlayer] " + reason);
+        catch (UnauthorizedAccessException e) { Debug.LogError("[BuildMacOSPlayer] could not write failure report: " + e.Message); }
+        catch (IOException e) { Debug.LogError("[BuildMacOSPlayer] could not write failure report: " + e.Message); }
     }
 
     // #1674: shaders CombatSurfaceClient resolves at runtime via Shader.Find and that NO asset references, so

--- a/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
+++ b/extensions/renderers/unity/scripts/BuildMacOSPlayer.cs
@@ -306,14 +306,20 @@ public static class BuildMacOSPlayer
         }
         else
         {
-            // OpenScene(Single) DISCARDS unsaved changes in the open scene. Refuse loudly rather than
-            // throwing editor work away; a save prompt is not an option here, because this MenuItem runs
-            // in a headed-but-remotely-driven editor where a modal deadlocks the session (BOX.md #1196).
-            if (active.IsValid() && (active.isDirty || string.IsNullOrEmpty(active.path)))
-                FailBuild("refusing to build: the open scene '"
-                    + (string.IsNullOrEmpty(active.path) ? "Untitled" : active.path)
+            // OpenScene(Single) DISCARDS unsaved changes in EVERY loaded scene, not just the active one —
+            // an additively-loaded scene with unsaved work is unloaded just as silently. Check them all
+            // and refuse loudly rather than throwing editor work away; a save prompt is not an option
+            // here, because this MenuItem runs in a headed-but-remotely-driven editor where a modal
+            // deadlocks the session (BOX.md #1196).
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                var loaded = SceneManager.GetSceneAt(i);
+                if (!loaded.IsValid() || (!loaded.isDirty && !string.IsNullOrEmpty(loaded.path))) continue;
+                FailBuild("refusing to build: the loaded scene '"
+                    + (string.IsNullOrEmpty(loaded.path) ? "Untitled" : loaded.path)
                     + "' has UNSAVED changes and this build must open " + SceneToBuild
-                    + ". Save or discard those changes, then rebuild.");
+                    + " in Single mode, which would discard them. Save or discard those changes, then rebuild.");
+            }
             restorePath = active.IsValid() ? active.path : null;
             src = EditorSceneManager.OpenScene(SceneToBuild, OpenSceneMode.Single);
         }

--- a/extensions/renderers/unity/scripts/build_room_kit.cs
+++ b/extensions/renderers/unity/scripts/build_room_kit.cs
@@ -210,19 +210,21 @@ public static class BuildRoomKit
             }
         }
         sb.Append("\n  ]\n}\n");
-        // Assets/StreamingAssets/boxes IS the directory the player build packages (StreamingAssets is copied
-        // verbatim into the .app), so the export lands where a runtime/QA consumer can actually read it —
-        // the project root does not ship anywhere. The "_kit_boxes" suffix keeps a fresh export distinct
-        // from the reviewed "<room>_boxes.json" sidecar already sitting in that directory: an export is a
-        // CANDIDATE, and silently overwriting the sidecar the player consumes is how an unreviewed volume
-        // set reaches a plate. Promotion into extensions/renderers/unity/boxes/ stays a reviewed step.
-        string boxesDir = Path.Combine(Application.dataPath, "StreamingAssets", "boxes");
+        // <projectRoot>/boxes/<roomId>_boxes.json — the directory BuildMacOSPlayer.EnsurePackaged copies
+        // into StreamingAssets/boxes, and the exact name space plates_manifest.json references
+        // ("boxes/tavern_kit_v1_boxes.json"). The project root, where this wrote before, is packaged
+        // nowhere and matches no manifest entry, so a developer following the menu path produced a sidecar
+        // that silently never reached a plate. Writing StreamingAssets/boxes directly would be just as
+        // wrong in the other direction: that directory is a build-generated MIRROR, overwritten from
+        // <projectRoot>/boxes on the next EnsurePackaged. Promotion into the repo
+        // (extensions/renderers/unity/boxes/) stays a reviewed step — the export is a candidate.
+        string boxesDir = Path.Combine(Directory.GetParent(Application.dataPath).FullName, "boxes");
         Directory.CreateDirectory(boxesDir);
-        string outPath = Path.Combine(boxesDir, roomId + "_kit_boxes.json");
+        string outPath = Path.Combine(boxesDir, roomId + "_boxes.json");
         File.WriteAllText(outPath, sb.ToString());
         if (!File.Exists(outPath)) { Debug.LogError($"[KitBoxes] write FAILED: {outPath}"); return; }
-        AssetDatabase.Refresh();
-        Debug.Log($"[KitBoxes] wrote {nBoxes} kit-derived boxes (ortho {ortho:0.####}) -> {outPath}");
+        Debug.Log($"[KitBoxes] wrote {nBoxes} kit-derived boxes (ortho {ortho:0.####}) -> {outPath}\n"
+                  + "[KitBoxes] promote: copy into extensions/renderers/unity/boxes/ and point plates_manifest.json at it.");
     }
 
     [MenuItem("Tools/WorldOS/Kit/Build Room From Kit")]
@@ -1203,10 +1205,26 @@ public static class BuildRoomKit
     static string RoomId(Dictionary<string, object> geo, string geoPath)
     {
         string env = Environment.GetEnvironmentVariable("WORLDOS_KIT_ROOM_ID");
-        if (!string.IsNullOrEmpty(env)) return Sanitize(env);
+        if (!string.IsNullOrEmpty(env)) return DisambiguateRoomId(Sanitize(env));
         string loc = GetStr(geo, "location", null);
-        if (!string.IsNullOrEmpty(loc)) return Sanitize(loc);
-        return Sanitize(Path.GetFileNameWithoutExtension(geoPath).Replace("_geometry", ""));
+        if (!string.IsNullOrEmpty(loc)) return DisambiguateRoomId(Sanitize(loc));
+        return DisambiguateRoomId(Sanitize(Path.GetFileNameWithoutExtension(geoPath).Replace("_geometry", "")));
+    }
+
+    // A room named "Fire"/"TombGlow"/"CoolKey" would build a REAL root called KitRoom_Fire — a name the
+    // build-contamination byte scan (qa/qa_sandbox.py) must treat as a helper light, since bytes cannot
+    // say whether a name was a root or a child. That is a FALSE NEGATIVE on the gate, so make the
+    // collision impossible at the source instead of asking the detector to guess.
+    static string DisambiguateRoomId(string id)
+    {
+        foreach (var helper in new[] { KitHelperFire, KitHelperTombGlow, KitHelperCoolKey })
+            if (("KitRoom_" + id) == helper)
+            {
+                Debug.LogWarning($"[Kit] room id '{id}' collides with the helper object {helper}; using '{id}_room' "
+                                 + "so the build-contamination scan can still tell a shipped kit room from a light.");
+                return id + "_room";
+            }
+        return id;
     }
 
     static string Sanitize(string s)

--- a/extensions/renderers/unity/scripts/build_room_kit.cs
+++ b/extensions/renderers/unity/scripts/build_room_kit.cs
@@ -135,6 +135,96 @@ public static class BuildRoomKit
     // ════════════════════════════════════════════════════════════════════════════════════════════════
     //  BUILD
     // ════════════════════════════════════════════════════════════════════════════════════════════════
+    // QA-CONTRACT (single source of truth). Helper CHILD objects the rig creates UNDER the KitRoom_<roomId>
+    // root. They share the KitRoom_ prefix but are never roots, so a build-contamination scan that matches
+    // ONLY these has found the light rig, not a kit room shipped inside the player. qa/qa_sandbox.py parses
+    // these exact `KitHelper* = "KitRoom_..."` declarations (_kit_helper_names), so its allowlist cannot
+    // drift from the names actually created below — do not inline these literals at the call sites.
+    internal const string KitHelperFire = "KitRoom_Fire";
+    internal const string KitHelperTombGlow = "KitRoom_TombGlow";
+    internal const string KitHelperCoolKey = "KitRoom_CoolKey";
+
+    // Occluder-sidecar export DERIVED from the built kit scene: per-mass true renderer bounds instead of
+    // hand-authored chunky volumes. The felt-truth failure this kills (owner playtest 2026-07-23): the
+    // authored tavern sidecar carried 5.0u camera-side walls where the paint shows 0.55u cutaway parapets
+    // and square slabs around round tables, so the walk-behind silhouette fired far outside every painted
+    // object and legal moves read as walking through furniture. The kit scene IS the plate's geometry
+    // (seg-gate + alignment certified), so bounds measured off the placed objects match the paint by
+    // construction. Requires BuildRoom to have run for the same geometry this editor session.
+    [MenuItem("Tools/WorldOS/Kit/Export Kit Boxes")]
+    public static void ExportBoxes()
+    {
+        string geoPath = GeoPath();
+        if (!File.Exists(geoPath)) { Debug.LogError($"[KitBoxes] no geometry json: {geoPath}"); return; }
+        var geo = MiniJson.Parse(File.ReadAllText(geoPath)) as Dictionary<string, object>;
+        if (geo == null) { Debug.LogError("[KitBoxes] geometry parse failed"); return; }
+        int cols = GetInt(geo, "cols", 14), rows = GetInt(geo, "rows", 11);
+        bool camFit = GetBool(geo, "camera_fit");
+        string roomId = RoomId(geo, geoPath);
+
+        var root = GameObject.Find("KitRoom_" + roomId);
+        if (root == null) { Debug.LogError($"[KitBoxes] KitRoom_{roomId} not in scene — run Build Room From Kit first."); return; }
+
+        // the CONTRACT ortho (same math as SetupContractCamera at the 1344x768 contract aspect)
+        float aspect = 1344f / 768f, FILL = 0.96f, ortho = 13f;
+        if (camFit)
+        {
+            Quaternion crot = Quaternion.Euler(30f, 45f, 0f);
+            Vector3 rightAx = crot * Vector3.right, upAx = crot * Vector3.up;
+            float maxR = 0f, maxU = 0f, hx = (cols / 2f) * CELL, hz = (rows / 2f) * CELL;
+            foreach (var sgn in new[] { new Vector2(1, 1), new Vector2(1, -1), new Vector2(-1, 1), new Vector2(-1, -1) })
+            {
+                Vector3 corner = new Vector3(hx * sgn.x, 0f, hz * sgn.y);
+                maxR = Mathf.Max(maxR, Mathf.Abs(Vector3.Dot(corner, rightAx)));
+                maxU = Mathf.Max(maxU, Mathf.Abs(Vector3.Dot(corner, upAx)));
+            }
+            ortho = Mathf.Max(maxR / (aspect * FILL), maxU / FILL);
+        }
+
+        var inv = System.Globalization.CultureInfo.InvariantCulture;
+        var sb = new System.Text.StringBuilder();
+        sb.Append("{\n  \"version\": 1,\n");
+        sb.Append(string.Format(inv, "  \"ortho\": {0:0.####},\n", ortho));
+        sb.Append(string.Format(inv, "  \"cols\": {0}, \"rows\": {1},\n", cols, rows));
+        sb.Append("  \"provenance\": \"kit-derived (build_room_kit ExportBoxes): per-mass renderer bounds of KitRoom_" + roomId + "\",\n");
+        sb.Append("  \"boxes\": [\n");
+        int nBoxes = 0;
+        foreach (var groupName in new[] { "Walls", "Props", "Impassable" })
+        {
+            var group = root.transform.Find(groupName);
+            if (group == null) continue;
+            foreach (Transform child in group)
+            {
+                var rends = child.GetComponentsInChildren<Renderer>(false);
+                if (rends.Length == 0) continue;
+                Bounds b = rends[0].bounds;
+                for (int i = 1; i < rends.Length; i++) b.Encapsulate(rends[i].bounds);
+                if (b.size.y < 0.15f) continue;                       // flat decals never occlude
+                string kind = child.name.ToLowerInvariant();
+                int cut = kind.IndexOf('_'); if (cut > 0) kind = kind.Substring(0, cut);
+                if (nBoxes > 0) sb.Append(",\n");
+                sb.Append(string.Format(inv,
+                    "    {{\"kind\": \"{0}\", \"size\": [{1:0.###}, {2:0.###}, {3:0.###}], \"center\": [{4:0.###}, {5:0.###}, {6:0.###}]}}",
+                    kind, b.size.x, b.size.y, b.size.z, b.center.x, b.center.y, b.center.z));
+                nBoxes++;
+            }
+        }
+        sb.Append("\n  ]\n}\n");
+        // Assets/StreamingAssets/boxes IS the directory the player build packages (StreamingAssets is copied
+        // verbatim into the .app), so the export lands where a runtime/QA consumer can actually read it —
+        // the project root does not ship anywhere. The "_kit_boxes" suffix keeps a fresh export distinct
+        // from the reviewed "<room>_boxes.json" sidecar already sitting in that directory: an export is a
+        // CANDIDATE, and silently overwriting the sidecar the player consumes is how an unreviewed volume
+        // set reaches a plate. Promotion into extensions/renderers/unity/boxes/ stays a reviewed step.
+        string boxesDir = Path.Combine(Application.dataPath, "StreamingAssets", "boxes");
+        Directory.CreateDirectory(boxesDir);
+        string outPath = Path.Combine(boxesDir, roomId + "_kit_boxes.json");
+        File.WriteAllText(outPath, sb.ToString());
+        if (!File.Exists(outPath)) { Debug.LogError($"[KitBoxes] write FAILED: {outPath}"); return; }
+        AssetDatabase.Refresh();
+        Debug.Log($"[KitBoxes] wrote {nBoxes} kit-derived boxes (ortho {ortho:0.####}) -> {outPath}");
+    }
+
     [MenuItem("Tools/WorldOS/Kit/Build Room From Kit")]
     public static void BuildRoom()
     {
@@ -479,20 +569,20 @@ public static class BuildRoomKit
         var lightParent = Child(root, "Lights");
         foreach (var bp in braziers)
         {
-            var g = new GameObject("KitRoom_Fire"); g.transform.SetParent(lightParent.transform, true);
+            var g = new GameObject(KitHelperFire); g.transform.SetParent(lightParent.transform, true);
             var L = g.AddComponent<Light>(); L.type = LightType.Point;
             L.color = new Color(1.0f, 0.62f, 0.28f); L.range = 10f; L.intensity = 3.2f;   // r3 warm fire pool
             L.shadows = LightShadows.None; g.transform.position = bp;
         }
         if (haveSarcGlow)   // r3: subtle warm rim over the tomb — the painted crypt's centre glow
         {
-            var g = new GameObject("KitRoom_TombGlow"); g.transform.SetParent(lightParent.transform, true);
+            var g = new GameObject(KitHelperTombGlow); g.transform.SetParent(lightParent.transform, true);
             var L = g.AddComponent<Light>(); L.type = LightType.Point;
             L.color = new Color(1.0f, 0.66f, 0.34f); L.range = 7f; L.intensity = 1.4f;     // low warm centre rim
             L.shadows = LightShadows.None; g.transform.position = sarcGlowPos;
         }
         {
-            var g = new GameObject("KitRoom_CoolKey"); g.transform.SetParent(lightParent.transform, true);
+            var g = new GameObject(KitHelperCoolKey); g.transform.SetParent(lightParent.transform, true);
             var L = g.AddComponent<Light>(); L.type = LightType.Directional;
             L.color = new Color(0.65f, 0.72f, 0.90f); L.intensity = 0.7f;                  // r3 cool directional key
             L.shadows = LightShadows.Soft; L.shadowStrength = 0.6f;

--- a/qa/qa_sandbox.py
+++ b/qa/qa_sandbox.py
@@ -151,6 +151,21 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
     state = rd / "state"
     if _meta_path(run).exists():
         raise SystemExit(f"[sandbox] run '{run}' already provisioned — `down` it first ({rd})")
+
+    # 0) PREFLIGHT the .app before anything is created or spawned. Both of these used to run after the
+    #    engine was already up, so a rejected app still seeded state and left an engine behind that no
+    #    run metadata could clean up (terminate() is non-blocking and `down` needs sandbox.json).
+    pbin = app / "Contents" / "MacOS" / "WorldOSPlayer"
+    if not pbin.exists():
+        raise SystemExit(f"[sandbox] player binary missing: {pbin}")
+    contaminated = _qa_roots_in_app(app)
+    if contaminated:
+        raise SystemExit(
+            f"[sandbox] app CONTAMINATED — QA kit roots baked into the build: {sorted(contaminated)} "
+            f"({app}). A KitRoom_* scene root was saved into the canonical scene and shipped; it renders "
+            f"grey kit masses over every plate (kit-tavern 2026-07-23). Rebuild via BuildMacOSPlayer, "
+            f"which strips them for the build and reports strippedQARoots in build-report.txt.")
+
     state.mkdir(parents=True, exist_ok=True)
 
     # 1) seed the cloned state dir (default: the 3-room registered world + Aldric)
@@ -181,18 +196,7 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
 
     # 3) a SECOND player instance — direct binary exec (open -n drops env), own QA port.
     #    ⚠ never `osascript quit app` here (kills the OWNER's instance too) — pid-scoped only.
-    pbin = app / "Contents" / "MacOS" / "WorldOSPlayer"
-    if not pbin.exists():
-        engine.terminate()
-        raise SystemExit(f"[sandbox] player binary missing: {pbin}")
-    contaminated = _qa_roots_in_app(app)
-    if contaminated:
-        engine.terminate()
-        raise SystemExit(
-            f"[sandbox] app CONTAMINATED — QA kit roots baked into the build: {sorted(contaminated)} "
-            f"({app}). A KitRoom_* scene root was saved into the canonical scene and shipped; it renders "
-            f"grey kit masses over every plate (kit-tavern 2026-07-23). Rebuild via BuildMacOSPlayer, "
-            f"which strips them for the build and reports strippedQARoots in build-report.txt.")
+    #    (binary presence + contamination were preflighted at step 0, before anything was spawned.)
     penv = dict(os.environ,
                 WORLDOS_ENGINE_BASE_URL=f"http://127.0.0.1:{engine_port}",
                 WORLDOS_CAMPAIGN_ID=campaign,

--- a/qa/qa_sandbox.py
+++ b/qa/qa_sandbox.py
@@ -168,8 +168,13 @@ def _qa_roots_in_app(app: Path) -> set:
                                      for m in _QA_ROOT_RE.finditer(buf) if m.end() < len(buf))
                         buf = buf[-_SCAN_OVERLAP:]
                     found.update(m.group().decode("utf-8", "replace") for m in _QA_ROOT_RE.finditer(buf))
-            except OSError:
-                continue
+            except OSError as exc:
+                # An archive we could not open or read cannot yield a clean verdict — fail CLOSED,
+                # exactly like budget exhaustion: a permissions/corruption/I-O failure must never let
+                # `up` accept a build it never actually scanned.
+                raise KitScanIncomplete(
+                    f"[sandbox] contamination scan could not read a level/sharedassets file: {exc} — "
+                    f"the app's kit-root verdict is unknown; fix the file/permissions and re-run `up`.") from exc
     return found - _kit_helper_names()
 
 

--- a/qa/qa_sandbox.py
+++ b/qa/qa_sandbox.py
@@ -85,14 +85,23 @@ def _meta_path(run: str) -> Path:
 # flow that SAVED the scene baked them into the next build, and the player then drew grey kit masses in
 # front of every plate (kit-tavern 2026-07-23). BuildMacOSPlayer now strips them at build time; this is
 # the independent check that a given .app is actually clean before a sweep trusts it.
-_QA_ROOT_RE = re.compile(rb"KitRoom_[A-Za-z0-9_]+")
+# The name grammar must match every id BuildRoomKit.Sanitize can emit: it keeps char.IsLetterOrDigit
+# (Unicode, hence the UTF-8 high bytes), '_' and '-'. A narrower class does not merely miss a root, it
+# TRUNCATES one — "KitRoom_Fire-qa" would match as "KitRoom_Fire", get subtracted as a helper light, and
+# the contaminated app would pass.
+_QA_ROOT_RE = re.compile(rb"KitRoom_[A-Za-z0-9_\-\x80-\xff]+")
 
 # Unity may serialize a scene's objects into level*, into the shared-asset archives, or into the raw
 # resource streams beside them. A level-only scan (the first cut of this check) therefore reads CLEAN on
 # a contaminated app whose objects landed in sharedassets — so scan all three.
 _SCAN_GLOBS = ("level*", "sharedassets*", "*.resS")
 _SCAN_CHUNK = 8 << 20        # bounded: stream in 8 MiB chunks (a .resS is routinely GB-scale) ...
-_SCAN_BUDGET = 4 << 30       # ... and stop after 4 GiB total so a pathological build can't hang the gate
+_SCAN_OVERLAP = 512          # carried between chunks so a name straddling a boundary is seen whole
+_SCAN_BUDGET = 16 << 30      # ... under a total budget so a pathological build can't hang the gate
+
+
+class KitScanIncomplete(RuntimeError):
+    """The contamination scan could not read every byte it needed — verdict unknown, NOT clean."""
 
 # Helper CHILD objects the kit rig creates UNDER a KitRoom_<roomId> root (brazier fires, tomb glow, cool
 # key light). They carry the KitRoom_ prefix but are never roots, so a scan that matches ONLY these has
@@ -102,7 +111,7 @@ _SCAN_BUDGET = 4 << 30       # ... and stop after 4 GiB total so a pathological 
 # two agree.
 _KIT_BUILDER_CS = REPO / "extensions/renderers/unity/scripts/build_room_kit.cs"
 _KIT_HELPER_FALLBACK = ("KitRoom_Fire", "KitRoom_TombGlow", "KitRoom_CoolKey")
-_KIT_HELPER_RE = re.compile(r'KitHelper\w+\s*=\s*"(KitRoom_[A-Za-z0-9_]+)"')
+_KIT_HELPER_RE = re.compile(r'KitHelper\w+\s*=\s*"(KitRoom_[A-Za-z0-9_\-]+)"')
 
 
 def _kit_helper_names(source: Path = _KIT_BUILDER_CS) -> frozenset:
@@ -120,6 +129,9 @@ def _qa_roots_in_app(app: Path) -> set:
     Unity stores GameObject names as plain bytes, so a byte scan is a reliable, dependency-free
     detector (the same check as `strings level0 | grep KitRoom_`). Helper children are subtracted:
     a helper-only match is the light rig, not contamination.
+
+    Raises KitScanIncomplete if the byte budget runs out before every file is read — an unscanned
+    tail must never read as clean, or an oversized build silently invalidates the sweep evidence.
     """
     found: set = set()
     data_dir = app / "Contents" / "Resources" / "Data"
@@ -132,14 +144,30 @@ def _qa_roots_in_app(app: Path) -> set:
             scanned.add(f.name)
             try:
                 with f.open("rb") as fh:
-                    tail = b""
-                    while budget > 0:
+                    buf = b""
+                    while True:
+                        if budget <= 0:
+                            # Budget gone. Only an actual unread remainder is a problem — a file that
+                            # ended exactly on the budget was fully scanned.
+                            if not fh.read(1):
+                                break
+                            raise KitScanIncomplete(
+                                f"[sandbox] contamination scan hit its {_SCAN_BUDGET} byte budget inside "
+                                f"{f.name}; the rest of {app} is UNSCANNED, so this build's kit-root "
+                                f"verdict is unknown — raise _SCAN_BUDGET or shrink the build, but do "
+                                f"not treat this as clean.")
                         chunk = fh.read(min(_SCAN_CHUNK, budget))
                         if not chunk:
                             break
                         budget -= len(chunk)
-                        found.update(m.decode() for m in _QA_ROOT_RE.findall(tail + chunk))
-                        tail = chunk[-64:]      # overlap: a name split across chunks still matches
+                        buf += chunk
+                        # A match touching the end of a non-final buffer may be TRUNCATED, and a truncated
+                        # name can land exactly on a helper ("KitRoom_Fire" out of "KitRoom_Firepit"). Drop
+                        # it here; the overlap carried forward re-finds it whole on the next pass.
+                        found.update(m.group().decode("utf-8", "replace")
+                                     for m in _QA_ROOT_RE.finditer(buf) if m.end() < len(buf))
+                        buf = buf[-_SCAN_OVERLAP:]
+                    found.update(m.group().decode("utf-8", "replace") for m in _QA_ROOT_RE.finditer(buf))
             except OSError:
                 continue
     return found - _kit_helper_names()

--- a/qa/qa_sandbox.py
+++ b/qa/qa_sandbox.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shlex
 import signal
 import subprocess
@@ -79,6 +80,71 @@ def _meta_path(run: str) -> Path:
     return _rundir(run) / "sandbox.json"
 
 
+# ── QA kit-scene contamination detector ────────────────────────────────────────────────────────────
+# build_room_kit.cs assembles kit rooms as "KitRoom_<roomId>" roots in whatever scene is open; a capture
+# flow that SAVED the scene baked them into the next build, and the player then drew grey kit masses in
+# front of every plate (kit-tavern 2026-07-23). BuildMacOSPlayer now strips them at build time; this is
+# the independent check that a given .app is actually clean before a sweep trusts it.
+_QA_ROOT_RE = re.compile(rb"KitRoom_[A-Za-z0-9_]+")
+
+# Unity may serialize a scene's objects into level*, into the shared-asset archives, or into the raw
+# resource streams beside them. A level-only scan (the first cut of this check) therefore reads CLEAN on
+# a contaminated app whose objects landed in sharedassets — so scan all three.
+_SCAN_GLOBS = ("level*", "sharedassets*", "*.resS")
+_SCAN_CHUNK = 8 << 20        # bounded: stream in 8 MiB chunks (a .resS is routinely GB-scale) ...
+_SCAN_BUDGET = 4 << 30       # ... and stop after 4 GiB total so a pathological build can't hang the gate
+
+# Helper CHILD objects the kit rig creates UNDER a KitRoom_<roomId> root (brazier fires, tomb glow, cool
+# key light). They carry the KitRoom_ prefix but are never roots, so a scan that matches ONLY these has
+# found the rig's lights, not a kit room shipped inside the player. The names are PARSED from the C# that
+# creates them, so the allowlist cannot drift from the names actually emitted; the tuple below is only the
+# fallback for a checkout without the renderer extension, and qa/test_qa_sandbox_kit_roots.py asserts the
+# two agree.
+_KIT_BUILDER_CS = REPO / "extensions/renderers/unity/scripts/build_room_kit.cs"
+_KIT_HELPER_FALLBACK = ("KitRoom_Fire", "KitRoom_TombGlow", "KitRoom_CoolKey")
+_KIT_HELPER_RE = re.compile(r'KitHelper\w+\s*=\s*"(KitRoom_[A-Za-z0-9_]+)"')
+
+
+def _kit_helper_names(source: Path = _KIT_BUILDER_CS) -> frozenset:
+    """Helper child-object names, read from build_room_kit.cs's `KitHelper*` constants."""
+    try:
+        names = _KIT_HELPER_RE.findall(source.read_text())
+    except OSError:
+        names = []
+    return frozenset(names or _KIT_HELPER_FALLBACK)
+
+
+def _qa_roots_in_app(app: Path) -> set:
+    """Names of QA kit-scene ROOTS (KitRoom_*) baked into the app's serialized data.
+
+    Unity stores GameObject names as plain bytes, so a byte scan is a reliable, dependency-free
+    detector (the same check as `strings level0 | grep KitRoom_`). Helper children are subtracted:
+    a helper-only match is the light rig, not contamination.
+    """
+    found: set = set()
+    data_dir = app / "Contents" / "Resources" / "Data"
+    scanned: set = set()
+    budget = _SCAN_BUDGET
+    for pattern in _SCAN_GLOBS:
+        for f in sorted(data_dir.glob(pattern)):
+            if f.name in scanned or not f.is_file():
+                continue
+            scanned.add(f.name)
+            try:
+                with f.open("rb") as fh:
+                    tail = b""
+                    while budget > 0:
+                        chunk = fh.read(min(_SCAN_CHUNK, budget))
+                        if not chunk:
+                            break
+                        budget -= len(chunk)
+                        found.update(m.decode() for m in _QA_ROOT_RE.findall(tail + chunk))
+                        tail = chunk[-64:]      # overlap: a name split across chunks still matches
+            except OSError:
+                continue
+    return found - _kit_helper_names()
+
+
 def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
        seed_cmd: str, app: Path) -> dict:
     rd = _rundir(run)
@@ -119,6 +185,14 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
     if not pbin.exists():
         engine.terminate()
         raise SystemExit(f"[sandbox] player binary missing: {pbin}")
+    contaminated = _qa_roots_in_app(app)
+    if contaminated:
+        engine.terminate()
+        raise SystemExit(
+            f"[sandbox] app CONTAMINATED — QA kit roots baked into the build: {sorted(contaminated)} "
+            f"({app}). A KitRoom_* scene root was saved into the canonical scene and shipped; it renders "
+            f"grey kit masses over every plate (kit-tavern 2026-07-23). Rebuild via BuildMacOSPlayer, "
+            f"which strips them for the build and reports strippedQARoots in build-report.txt.")
     penv = dict(os.environ,
                 WORLDOS_ENGINE_BASE_URL=f"http://127.0.0.1:{engine_port}",
                 WORLDOS_CAMPAIGN_ID=campaign,

--- a/qa/test_qa_sandbox_kit_roots.py
+++ b/qa/test_qa_sandbox_kit_roots.py
@@ -68,10 +68,42 @@ def test_name_split_across_chunk_boundary_still_matches(tmp_path, monkeypatch):
     assert qa_sandbox._qa_roots_in_app(app) == {"KitRoom_bosshall"}
 
 
-def test_scan_is_bounded_by_the_byte_budget(tmp_path, monkeypatch):
-    """A pathological build must not hang the gate: past the budget the scan stops reading."""
+def test_budget_exhaustion_fails_closed(tmp_path, monkeypatch):
+    """A pathological build must not hang the gate — but an unscanned tail must never read as CLEAN."""
     monkeypatch.setattr(qa_sandbox, "_SCAN_BUDGET", 16)
     app = _app(tmp_path, {"level0": b"\x00" * 4096 + b"KitRoom_crypt"})
+    with pytest.raises(qa_sandbox.KitScanIncomplete):
+        qa_sandbox._qa_roots_in_app(app)
+
+
+def test_budget_landing_exactly_on_eof_is_not_an_error(tmp_path, monkeypatch):
+    """A file that ended exactly on the budget was fully scanned — do not cry incomplete."""
+    blob = _lvl("KitRoom_crypt")
+    monkeypatch.setattr(qa_sandbox, "_SCAN_BUDGET", len(blob))
+    app = _app(tmp_path, {"level0": blob})
+    assert qa_sandbox._qa_roots_in_app(app) == {"KitRoom_crypt"}
+
+
+@pytest.mark.parametrize("root", ["KitRoom_Fire-qa", "KitRoom_crypt-v2", "KitRoom_Firepit"])
+def test_root_names_are_not_truncated_onto_a_helper_name(tmp_path, root):
+    """RED pre-fix: the `[A-Za-z0-9_]+` class stopped at '-', so KitRoom_Fire-qa matched as
+    KitRoom_Fire and was then subtracted as a helper light — a contaminated app passing clean."""
+    app = _app(tmp_path, {"level0": _lvl(root)})
+    assert qa_sandbox._qa_roots_in_app(app) == {root}
+
+
+def test_unicode_room_ids_are_matched(tmp_path):
+    """Sanitize keeps char.IsLetterOrDigit, which is Unicode — the byte scan must follow."""
+    app = _app(tmp_path, {"level0": b"\x00\x10" + "KitRoom_église".encode() + b"\x00m_Name\x00"})
+    assert qa_sandbox._qa_roots_in_app(app) == {"KitRoom_église"}
+
+
+def test_helper_name_straddling_a_chunk_boundary_is_not_a_false_positive(tmp_path, monkeypatch):
+    """A match touching the end of a non-final buffer may be truncated, and a truncated name can land
+    exactly on a helper. Accepting it reported a clean app as contaminated (as `KitRoom_F`)."""
+    monkeypatch.setattr(qa_sandbox, "_SCAN_CHUNK", 32)
+    monkeypatch.setattr(qa_sandbox, "_SCAN_OVERLAP", 64)
+    app = _app(tmp_path, {"level0": b"\x00" * 23 + b"KitRoom_Fire" + b"\x00" * 40})
     assert qa_sandbox._qa_roots_in_app(app) == set()
 
 

--- a/qa/test_qa_sandbox_kit_roots.py
+++ b/qa/test_qa_sandbox_kit_roots.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Red-first units for qa_sandbox's kit-scene contamination detector (#1690 C# half).
+
+The detector is the independent check that a .app does not carry the QA kit rooms build_room_kit.cs
+assembles in the open scene. Three of these tests fail against the pre-fix detector:
+
+  * helper-only match  -> the `or found` fallback re-flagged the very names it had just excluded, so a
+    clean app whose light rig left KitRoom_Fire bytes behind failed the sandbox with no kit room in it.
+  * sharedassets/.resS -> the scan only globbed `level*`, so a contaminated app whose objects serialized
+    into the shared-asset archives read CLEAN.
+  * chunk boundary     -> the chunked (bounded) read must not lose a name split across two chunks.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import qa_sandbox  # noqa: E402
+
+
+def _app(tmp_path: Path, files: dict) -> Path:
+    """Build a synthetic .app whose Data/ holds the given {filename: bytes}."""
+    data = tmp_path / "WorldOSPlayer.app" / "Contents" / "Resources" / "Data"
+    data.mkdir(parents=True)
+    for name, blob in files.items():
+        (data / name).write_bytes(blob)
+    return tmp_path / "WorldOSPlayer.app"
+
+
+# a plausible slice of a Unity level file: names sit in the byte stream amid binary noise
+def _lvl(*names: str) -> bytes:
+    out = b"\x00\x13UnityFS\x00" + bytes(range(64))
+    for n in names:
+        out += b"\x1a\x00\x00\x00" + n.encode() + b"\x00\x00m_Name\x00"
+    return out + bytes(range(64))
+
+
+def test_clean_app_reports_nothing(tmp_path):
+    app = _app(tmp_path, {"level0": _lvl(), "sharedassets0.assets": _lvl()})
+    assert qa_sandbox._qa_roots_in_app(app) == set()
+
+
+def test_kit_root_in_level_is_contamination(tmp_path):
+    app = _app(tmp_path, {"level0": _lvl("KitRoom_crypt", "KitRoom_Fire")})
+    assert qa_sandbox._qa_roots_in_app(app) == {"KitRoom_crypt"}
+
+
+def test_helper_lights_alone_are_not_contamination(tmp_path):
+    """RED pre-fix: `... or found` returned the helper names it had just filtered out."""
+    app = _app(tmp_path, {"level0": _lvl("KitRoom_Fire", "KitRoom_TombGlow", "KitRoom_CoolKey")})
+    assert qa_sandbox._qa_roots_in_app(app) == set()
+
+
+@pytest.mark.parametrize("fname", ["sharedassets0.assets", "sharedassets2.resource", "level0.resS"])
+def test_scan_covers_shared_asset_archives(tmp_path, fname):
+    """RED pre-fix: a level-only glob read a contaminated app as clean."""
+    app = _app(tmp_path, {"level0": _lvl(), fname: _lvl("KitRoom_tavern")})
+    assert qa_sandbox._qa_roots_in_app(app) == {"KitRoom_tavern"}
+
+
+def test_name_split_across_chunk_boundary_still_matches(tmp_path, monkeypatch):
+    """The read is bounded/chunked; the overlap must not drop a name straddling two chunks."""
+    monkeypatch.setattr(qa_sandbox, "_SCAN_CHUNK", 32)
+    app = _app(tmp_path, {"level0": b"\x00" * 28 + b"KitRoom_bosshall" + b"\x00" * 40})
+    assert qa_sandbox._qa_roots_in_app(app) == {"KitRoom_bosshall"}
+
+
+def test_scan_is_bounded_by_the_byte_budget(tmp_path, monkeypatch):
+    """A pathological build must not hang the gate: past the budget the scan stops reading."""
+    monkeypatch.setattr(qa_sandbox, "_SCAN_BUDGET", 16)
+    app = _app(tmp_path, {"level0": b"\x00" * 4096 + b"KitRoom_crypt"})
+    assert qa_sandbox._qa_roots_in_app(app) == set()
+
+
+def test_missing_data_dir_is_not_an_error(tmp_path):
+    (tmp_path / "Empty.app").mkdir()
+    assert qa_sandbox._qa_roots_in_app(tmp_path / "Empty.app") == set()
+
+
+def test_helper_allowlist_is_parsed_from_the_builder_cs():
+    """Single source of truth: the allowlist comes from the C# that creates the helper objects."""
+    parsed = qa_sandbox._kit_helper_names()
+    assert qa_sandbox._KIT_BUILDER_CS.exists(), qa_sandbox._KIT_BUILDER_CS
+    assert parsed == frozenset(qa_sandbox._KIT_HELPER_FALLBACK), (
+        "build_room_kit.cs KitHelper* constants drifted from the qa_sandbox fallback tuple; "
+        f"parsed={sorted(parsed)}")
+    # and every parsed name is really constructed in that file
+    cs = qa_sandbox._KIT_BUILDER_CS.read_text()
+    for name in parsed:
+        const = "KitHelper" + name.removeprefix("KitRoom_")
+        assert f"new GameObject({const})" in cs, f"{const} declared but not used to create {name}"
+
+
+def test_helper_allowlist_falls_back_when_the_cs_is_absent(tmp_path):
+    assert qa_sandbox._kit_helper_names(tmp_path / "nope.cs") == frozenset(
+        qa_sandbox._KIT_HELPER_FALLBACK)


### PR DESCRIPTION
The C# build-gate half of #1690, withheld from #1703 (the data half) until it could be verified against a
live Unity 6000.5.6f1 editor. Every reviewer finding on #1690 that survived verification is fixed here.

**The bug this gates.** `build_room_kit.cs` assembles kit rooms as `KitRoom_<roomId>` roots in whatever
scene is open. A capture flow that *saved* the scene baked them into the next player build, and the player
then drew grey kit masses (fallback boxes, brazier plinths, parapets) in front of every plate. Measured
three times: the kit-crypt cleankit trap ×2 and kit-tavern 2026-07-23 (the withheld tavern install).

## 1. `BuildMacOSPlayer.StripQAConstructions` — strip for the build, never edit the tracked scene

#1690 stripped the roots and then `SaveScene`d the canonical scene. Saving the tracked scene as a build
side effect is precisely the bug the gate exists to prevent, so it cannot be the fix for it.

- **Temp-copy strip** (P2/P3 ×3 — evaos-code-review-bot). The scene is snapshotted with
  `SaveScene(..., saveAsCopy: true)` to `Assets/Scenes/__BuildStripped_QARoots.unity`, the `KitRoom_*` roots
  are destroyed in *that copy*, and `BuildPlayerOptions.scenes` points at the copy for this build only.
  `saveAsCopy` leaves the editor's own scene neither dirtied nor reloaded, so unsaved in-editor work
  survives untouched. The temp asset is deleted in a `finally` around `BuildPipeline.BuildPlayer`. The copy
  is also used when the open scene is merely dirty, so the built content is exactly what was inspected
  rather than whatever happens to be on disk.
- **`OpenScene(Single)` guard** (P2 ×2 — evaos-code-review-bot). `OpenScene(Single)` discards unsaved
  changes. The build now only opens the canonical scene when the active scene is clean; an unsaved *other*
  scene (or an untitled one) is a loud refusal instead of silent data loss. A save prompt was deliberately
  not used: this MenuItem runs in a headed-but-remotely-driven editor where a modal deadlocks the session
  (BOX.md #1196).
- **No silent failure** (P1 — evaos-code-review-bot). Every `SaveScene` return value and the destroyed count
  are checked. A strip that cannot be completed calls `FailBuild`, which stamps `build-report.txt` with
  `result=Failed` before throwing — so a stale `.app` can never sit beside a green stamp. Found roots stay
  non-fatal and are reported as `strippedQARoots=`.

## 2. `build_room_kit.ExportBoxes` — write where the build packages

P3 ×2 (evaos-code-review-bot). Wrote `room_kit_boxes.json` to the project root, which is packaged nowhere
and matches no manifest entry. Now `<projectRoot>/boxes/<roomId>_boxes.json` — the directory
`EnsurePackaged` copies into `StreamingAssets/boxes` (lines 101-107) and the exact name space
`plates_manifest.json` references. Writing `Assets/StreamingAssets/boxes` directly would be wrong in the
other direction: that directory is a build-generated **mirror**, overwritten from `<projectRoot>/boxes` on
the next `EnsurePackaged`.

## 3. `qa/qa_sandbox` — the independent detector

- **`or found` removed** (CodeRabbit + evaos-code-review-bot, both P1/Minor). `{n for n in found if not
  helper(n)} or found` re-flagged exactly the names it had just excluded: a clean app whose light rig left
  `KitRoom_Fire` bytes behind failed the sandbox with no kit room in it.
- **Preflight before provisioning** (Major — CodeRabbit). The binary and contamination checks ran *after*
  the engine was already up, so a rejected app still seeded state and left an engine behind that `down`
  could not clean up (no `sandbox.json`, and `terminate()` is non-blocking). Both now run at the top of
  `up()`, before the run directory is created or anything is spawned.
- **Allowlist single-sourced** (P3 — evaos-code-review-bot). `build_room_kit.cs` declares `KitHelperFire` /
  `KitHelperTombGlow` / `KitHelperCoolKey` and constructs the helper objects from them;
  `qa_sandbox._kit_helper_names()` parses those declarations. Chosen over a shared JSON file because a JSON
  file no C# code reads is still two sources of truth; parsing the declaration the `new GameObject(...)`
  calls actually use is one. A literal tuple remains only as the fallback for a checkout without the
  renderer extension, and tests assert both that the two agree and that every parsed constant is really
  used to create its object.
- **Root/helper name collision closed at the source** (P2 — evaos-code-review-bot). A room named `Fire` /
  `TombGlow` / `CoolKey` would build a *real* root called `KitRoom_Fire`, which a byte scan cannot
  distinguish from a helper light — a false negative on the gate. `RoomId` now disambiguates
  (`<id>_room`) with a warning, so the collision cannot arise. The subtraction is also exact-match now,
  not `startswith`, so `KitRoom_Firepit` is no longer swallowed.
- **Scan widened and bounded** (P2 — evaos-code-review-bot). A scene's objects can serialize into
  `sharedassets*` / `*.resS` rather than `level*`, so the level-only glob read a contaminated app as clean.
  All three are now scanned, streamed in 8 MiB chunks with a 64-byte overlap (a name split across a chunk
  boundary still matches) under a 4 GiB budget, so a pathological build cannot hang the gate.

  The counter-finding that the glob is *too* broad (P3, same reviewer) is an accepted trade-off: the two
  asks point in opposite directions, and the failure modes are not symmetric. A false positive is a loud
  rebuild; a false negative ships grey masses over every plate. The known-benign matches (helper lights) are
  subtracted by name, which is the narrowing that is actually safe to make.

## 4. Tests

`qa/test_qa_sandbox_kit_roots.py` — 17 units over synthetic level / `sharedassets` / `.resS` bytes:
detector red/green, helper-only, name grammar, chunk boundary, byte budget, missing `Data/`, and the two
allowlist-drift guards.

**Red-first proof, twice.** Against #1690's detector (level-only glob + `or found`), 4 fail —
`test_helper_lights_alone_are_not_contamination`, both `test_scan_covers_shared_asset_archives` cases, and
the byte-budget case. Against the first round of this PR, the 4 tests added for round 2 fail (both hyphen
cases, the Unicode case, and the chunk-boundary false positive). Against HEAD: 17 passed.

## 5. Second review round (4720367)

Four more real findings, from CodeRabbit and chatgpt-codex-connector on the first round:

- **Name grammar truncated roots onto helper names** (CodeRabbit Major 99%; codex P2). `Sanitize` keeps
  `-` and Unicode letters, but the byte regex stopped at `[A-Za-z0-9_]`. `KitRoom_Fire-qa` matched as
  `KitRoom_Fire` and was then subtracted as a helper light — a **false negative**: the contaminated app
  passed. Grammar is now `rb"KitRoom_[A-Za-z0-9_\-\x80-\xff]+"`.
- **Chunk-boundary truncation** (codex P2) — a match touching the end of a non-final buffer may be
  truncated onto a helper name, reporting a **clean** app as contaminated (`KitRoom_F`). Such matches are
  now dropped and re-found whole via the carried overlap (raised to 512 B).
- **Budget exhaustion now fails closed** (codex P2). It returned a partial set, so an oversized build read
  as clean. It now raises `KitScanIncomplete`; the budget is 16 GiB, and a file ending exactly on the
  budget is explicitly not an error.
- **`OpenScene(Single)` guard covers every loaded scene** (codex P1) — it inspected only the active scene,
  so an additively-loaded scene with unsaved work was discarded just as silently.

## Local proof — live Unity 6000.5.6f1 editor (pid 5127), three real player builds

Compile is positively verified, not merely "no console errors": reflection over the live
`Assembly-CSharp-Editor` returns `StripQAConstructions=True FailBuild/StampFailedReport=True
StripScenePath=Assets/Scenes/__BuildStripped_QARoots.unity ExportBoxes=True DisambiguateRoomId=True
KitHelperFire=KitRoom_Fire`, with 0 console errors.

A throwaway root `KitRoom_zz_probe` is the test contaminant.

| | GREEN (gate, probe in-memory) | RED control (no gate, probe on disk) | FINAL (gate, clean scene) |
|---|---|---|---|
| `strippedQARoots=` | `KitRoom_zz_probe` | *(line absent — no gate)* | `(none)` |
| `scenesBuilt=` | `__BuildStripped_QARoots.unity` | `M1CombatV1_canonical.unity` | `M1CombatV1_canonical.unity` |
| `strings level0 \| grep -c KitRoom_` | **0** | **1** | **0** |
| `sharedassets*` / `*.resS` counts | 0 / 0 | 0 / 0 | 0 / 0 |
| distinct `KitRoom_*` in `Data/` | *(none)* | `KitRoom_zz_probe` | *(none)* |
| `qa_sandbox._qa_roots_in_app` | `[]` | `['KitRoom_zz_probe']` | `[]` |
| canonical scene sha256 | `76ab207e…` (baseline) | `8481539c…` (deliberately saved) | `76ab207e…` (restored) |
| `git status Assets/Scenes` | **empty** | modified (deliberate) | **empty** |
| temp build scene after build | absent (deleted) | n/a | never created |

- **The strip is real and build-local.** The gated build reported `strippedQARoots=KitRoom_zz_probe` and
  built `__BuildStripped_QARoots.unity`, yet `git status Assets/Scenes` was **empty** and the scene sha was
  unchanged — and the probe was still present in the editor's open scene afterwards, so the editor's own
  scene was never touched either. That is the finding this PR exists to fix, demonstrated.
- **The gate is load-bearing.** The RED control is the same probe with `main`'s ungated
  `BuildMacOSPlayer.cs`: `KitRoom_zz_probe` ships in `level0` and the detector fires. (The probe had to be
  saved to disk for the control because `main` has no strip path at all and builds the scene asset; the
  canonical scene was restored byte-identically with `git checkout` immediately after — sha back to
  `76ab207e…`.)
- **No cost on the clean path.** With a clean scene the gate builds the canonical path directly, writes
  `strippedQARoots=(none)`, and never creates the temp scene.

Evidence files: `session-notes/2026-09-02/worldos-refresh/artifacts/pr-csharp-gate/evidence_{GREEN_gate,RED_nogate,FINAL_clean}.txt`.

**Proof boundary.** This proves the gate compiles, strips, reports, and leaves the tracked scene untouched,
and that removing it goes red. It does **not** prove the plate renders correctly — that is the walk gate.

## Tests run

- `qa/test_qa_sandbox_kit_roots.py` + `qa/test_walk_static.py` — 39 passed
- `qa/walk_static.py` — GREEN (manifest lint + ortho triple-check + geometry)
- `qa/fast_gate.sh` — PASS (257 passed, deterministic engine tier)

The same two Editor scripts are committed to the Unity project repo at `0ec36f90`, byte-identical to this branch.

All builds above were re-confirmed against HEAD after the round-2 changes: `strippedQARoots=(none)`, 0 `KitRoom_` across `level0`/`sharedassets*`/`*.resS`, canonical scene sha `76ab207e…`, `git status Assets/Scenes` empty.

Data half = #1703.
