### PR TITLE
docs+qa: retire /Users/lume paths after the machine migration

### DIFF
--- a/.claude/skills/worldos-dev/SKILL.md
+++ b/.claude/skills/worldos-dev/SKILL.md
@@ -65,7 +65,7 @@ the GUI QA LOOP note) — only `self-reported` counts toward G3.
 **Rollup → RRI (#466):** the Mac runs native Part-A on the BUILT `.app` (`qa/app_handoff_gate.py` →
 handoff.json) at the **SAME SHA**; `qa/release_readiness.py --handoff-json <mac.json> <vm score dirs>`
 combines them. Mixed-SHA / missing `run.json`/`score.json`/`network.ndjson` ⇒ `partial`/`harness_contaminated`
-(never a clean release). Copy VM `results/` back under `/Volumes/LEXAR/Codex/...` for the rollup + ledger.
+(never a clean release). Copy VM `results/` back under `/Users/m1/Codex/...` for the rollup + ledger.
 
 ### RRI evidence-path contract (don't false-mask the gate)
 **`release_readiness.py` requires EVIDENCE-PATH flags, not just value flags** — a gate that has the
@@ -167,9 +167,9 @@ Keep Python tests single-process unless the lane explicitly supports parallel ex
 
 ### Multi-session / worktree gotchas (learned the hard way — these cost real time)
 - **`fetch`-not-`pull` leaves the canonical checkout STALE.** Building every PR in worktrees off
-  `origin/main` + merging on GitHub means `/Users/lume/WorldOS` is only ever `fetch`ed — its working
+  `origin/main` + merging on GitHub means `/Users/m1/WorldOS` is only ever `fetch`ed — its working
   tree silently falls behind and files look "not there." After a merge batch:
-  `git -C /Users/lume/WorldOS pull --ff-only`.
+  `git -C /Users/m1/WorldOS pull --ff-only`.
 - **Merge race.** With `--auto` a parallel PR landing mid-flight just re-queues your merge; with
   `--admin` (emergency-only) it can fail "base branch was modified" and your LOCAL branch may get
   cleaned even though the PR stayed OPEN. Verify with `gh pr view <n> --json state` and **retry** on
@@ -364,7 +364,7 @@ an unattended loop.
   inspect its worktree: if the staged diff is complete, commit it + CI-validate + open the PR
   yourself (recovered #305 → #329 this way; nothing lost). Don't re-do work a corpse already finished.
 - **NEVER `git checkout` / branch-op the SHARED canonical checkout while a parallel session holds a
-  branch.** `/Users/lume/WorldOS` may be on another session's branch (e.g. loop-8). Branch-flips
+  branch.** `/Users/m1/WorldOS` may be on another session's branch (e.g. loop-8). Branch-flips
   there corrupt the sibling session. Do EVERY repo change via a **worktree agent off `origin/main`**
   (`git worktree add -b <branch> <path> origin/main`). If you must touch the shared checkout's main,
   do it as ONE atomic Bash (`git checkout main && test branch==main && add && commit && push`) — never

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,10 @@
 
 ## Codex Desktop Local-Resource Policy
 
-- Treat `/Users/lume/WorldOS` as the canonical local Mac app/private-art checkout for WorldOS GUI and native-app testing.
-- Use `/Volumes/LEXAR/Codex` for Codex artifacts, scratch files, screenshots, reports, and downloaded CI/VM artifacts.
+- Treat `/Users/m1/WorldOS` as the canonical local Mac app/private-art checkout for WorldOS GUI and native-app testing.
+- Use `/Users/m1/Codex` for Codex artifacts, scratch files, screenshots, reports, and downloaded CI/VM artifacts.
 - Use same-disk local worktrees for GUI/native-app edits that must launch against private art. Lexar worktrees are fine for docs, backend-only, and non-GUI slices that do not launch the app against private art.
-- Before running install, build, or test commands, verify `pwd`. If a GUI/native app run is not in `/Users/lume/WorldOS` or a same-disk worktree with `WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS`, explain why.
+- Before running install, build, or test commands, verify `pwd`. If a GUI/native app run is not in `/Users/m1/WorldOS` or a same-disk worktree with `WORLDOS_ART_REPO_ROOT=/Users/m1/WorldOS`, explain why.
 - Prefer GitHub Actions or the 32GB support VM for heavyweight validation, full suites, matrix tests, long integration tests, and persona sweeps.
 - Run local tests only for fast feedback, local-only reproduction, validating unpushed edits, or Mac-only `.app` proof. Use the narrowest focused command first.
 - Do not launch multiple heavyweight local suites or persona sweeps in parallel on this Mac.
@@ -25,7 +25,7 @@
 - Target VM: owner-provided 32GB support VM, `support-vm-1`.
 - Connection/auth details are operator-only and should stay outside tracked repo docs.
 - Use the support VM for heavy backend/persona sweeps only after Codex CLI credentials/config are intentionally installed and verified there.
-- VM preflight must record VM identity, repo checkout path, branch/SHA, Codex CLI version, auth/profile status, `uv`, Node/npm/Playwright availability, private-art status or explicit backend-only/no-art classification, env vars, budget/concurrency cap, teardown commands, and artifact return path under `/Volumes/LEXAR/Codex`.
+- VM preflight must record VM identity, repo checkout path, branch/SHA, Codex CLI version, auth/profile status, `uv`, Node/npm/Playwright availability, private-art status or explicit backend-only/no-art classification, env vars, budget/concurrency cap, teardown commands, and artifact return path under `/Users/m1/Codex`.
 - The VM cannot prove Mac-only surfaces. `WorldOS.app` build/launch, native #356, and built-app UI play evidence stay on this Mac or macOS CI.
 - VM artifacts can feed RRI only when `run.json`, `score.json`, `session_surface.final.json`, network/image evidence, palette-live evidence, and build SHA are explicit. Otherwise the result remains partial/harness-contaminated.
 

--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -8,7 +8,7 @@
 > `docs/AGENT_GRADE_APP_TESTABILITY.md` (app-status/evidence contract), `qa/GUI_WORKBOOK.md`
 > (historical punch-list), `qa/release_readiness.py` (the RRI scorer), `qa/SCORECARD.md` (the ledger).
 >
-> Takeover routing, 2026-06-01: `/Users/lume/WorldOS` is the synced local app/private-art checkout
+> Takeover routing, 2026-06-01: `/Users/m1/WorldOS` is the synced local app/private-art checkout
 > and the default place to build/run/test the GUI and native app. The latest same-SHA app proof is
 > `da05101` from the 2026-06-07 current-main handoff rerun; later commits may sit above that proof
 > without becoming new product proof. Verify `origin/main` before acting, and rerun the handoff gate
@@ -30,19 +30,19 @@ the current commit. It catches stale tabs, dead launchers, missing private art, 
 failed `/move`, no narration, console/network errors, provider trace failures, and evidence gaps.
 
 ```bash
-cd /Users/lume/WorldOS
+cd /Users/m1/WorldOS
 python3 qa/app_handoff_gate.py \
   --web-beats 5 \
   --built-beats 5 \
   --codex-moves 1 \
-  --art-root /Users/lume/WorldOS \
+  --art-root /Users/m1/WorldOS \
   --scripted-budget 1.00 \
   --codex-budget 3.00 \
   --timeout 90 \
   --codex-timeout 240
 ```
 
-The run writes `/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/<run-id>/`. Review
+The run writes `/Users/m1/Codex/worldos-agent-grade-app-testability/<run-id>/`. Review
 `handoff.json` first, then each gate's `app-evidence/manifest.json`, `app-status.*.json`,
 `session-surface.*.json`, screenshots, moves, console/network/action logs, and provider trace summary.
 `handoff_score=100` means the GUI wiring loop is trustworthy for implementation velocity. It is not
@@ -58,7 +58,7 @@ release-ready evidence by itself.
 
 | Port / route | Meaning | Guardrail |
 |---|---|---|
-| `8799 /openworlds/` | Canonical fast iteration surface from `/Users/lume/WorldOS` | Use for LOOK, then rebuild/prove the app |
+| `8799 /openworlds/` | Canonical fast iteration surface from `/Users/m1/WorldOS` | Use for LOOK, then rebuild/prove the app |
 | `8899 /openworlds/` | Scripted/dev harness default | Valid only when same-port `/app-status` is live |
 | `8765` or dynamic app ports | Native app spawned viewer | Read `run.json` or `/app-status.viewer.port`; do not guess |
 | `8990-8999` | Browser persona harness range | Diagnostic browser evidence unless paired with app proof |
@@ -69,13 +69,13 @@ Release RRI's palette-live gate is stricter: it still requires at least six enab
 
 ## The two surfaces (never confuse them again)
 - **ITERATE — visible, playable, fast:** the OpenWorlds viewer served **from the local canonical repo**
-  `/Users/lume/WorldOS` (which HAS the 2.9 GB `content/worlds/_private` art) as a LIVE PLAYABLE
+  `/Users/m1/WorldOS` (which HAS the 2.9 GB `content/worlds/_private` art) as a LIVE PLAYABLE
   session on **fixed port 8799**. This is where you fix one thing at a time and LOOK.
 - **GATE — truth:** the built `dist/WorldOS.app` via `qa/ui_playtest_app.sh` (part A native #356 +
   part B persona loop). Release is judged here. Same viewer code; adds the native shell.
 - **Why both:** identical viewer. 8799-from-local skips the build + guarantees art is present, so
   it's the honest fast loop. The `.app` is the shipped artifact. A non-local worktree may serve private art
-  only when `WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS` points at the local private-art checkout, but
+  only when `WORLDOS_ART_REPO_ROOT=/Users/m1/WorldOS` points at the local private-art checkout, but
   use that as a fallback rather than the default because external-drive file prompts have broken local AI tests.
   The native app has a separate Private art repo path setting, and `script/build_and_run.sh` also writes
   the art root into `Info.plist` as `WorldOSArtRepoRoot` so LaunchServices env loss cannot hide missing art.
@@ -97,22 +97,22 @@ Release RRI's palette-live gate is stricter: it still requires at least six enab
   `scorer_provider`, and `scorer_model`. Missing provider/model fields make the handoff/RRI result
   partial until the evidence is rerun.
 - Do not treat the wrapper as release proof by itself. The 2026-06-01T04:39:09+07:00 pre-merge built-app proof
-  (`/Volumes/LEXAR/Codex/worldos-built-app-playtest/codex-app-headproof-20260601T043909/`) showed the Codex-DM
+  (`/Volumes/LEXAR/Codex/worldos-built-app-playtest/codex-app-headproof-20260601T043909/`; historical path — /Volumes/LEXAR/Codex/worldos-built-app-playtest/codex-app-headproof-20260601T043909/; that machine is gone, see NOW.md) showed the Codex-DM
   path could mint a live native session, load private BG art, seat Alfira, show narration, expose five enabled
   actions, accept and resolve a `/move`, leave `/session-surface` actionable, and produce a provider trace
   with zero errors/failed tool calls on PR #475 app-code commit `8bd833f`.
 - The post-#475 merged-main built-app proof
-  (`/Volumes/LEXAR/Codex/worldos-built-app-playtest/post475-main-app-proof-20260601T051230/`, build `32ca561`)
+  (`/Volumes/LEXAR/Codex/worldos-built-app-playtest/post475-main-app-proof-20260601T051230/`, build `32ca561`; historical path — /Volumes/LEXAR/Codex/worldos-built-app-playtest/post475-main-app-proof-20260601T051230/; that machine is gone, see NOW.md)
   was player-playable, but provider trace noise persisted. It is historical playable evidence, superseded for
   #479 closure by the `f7ab6d7` merged-main proof below. Release still requires the full non-partial RRI gate.
 - The current-main built-app proof
-  (`/Volumes/LEXAR/Codex/worldos-built-app-playtest/codex-current-main-proof-20260531T234242Z/`, build `19c3fd0`)
+  (`/Volumes/LEXAR/Codex/worldos-built-app-playtest/codex-current-main-proof-20260531T234242Z/`, build `19c3fd0`; historical path — /Volumes/LEXAR/Codex/worldos-built-app-playtest/codex-current-main-proof-20260531T234242Z/; that machine is gone, see NOW.md)
   again proved product wiring: private art present, Codex provider, Alfira active, visible narration, five
   enabled actions, writable `/move`, one accepted move, chat roles `dm, player, dm`, and `/session-surface`
   still actionable. The provider trace still had three failed/cancelled engine tool calls, so it is historical
   non-clean evidence, superseded for #479 closure by the `f7ab6d7` proof below.
 - The #479 trace-clean branch proof
-  (`/Volumes/LEXAR/Codex/worldos-built-app-playtest/codex-479-traceclean-nodup-proof-20260601T003002Z/`, app-code
+  (`/Volumes/LEXAR/Codex/worldos-built-app-playtest/codex-479-traceclean-nodup-proof-20260601T003002Z/`; historical path — /Volumes/LEXAR/Codex/worldos-built-app-playtest/codex-479-traceclean-nodup-proof-20260601T003002Z/; that machine is gone, see NOW.md; app-code
   `b081092`) reran the built app with private art, Codex provider, Alfira active, five enabled actions,
   a writable `/move`, one accepted/resolved player move, chat roles `dm, player, dm`, and `/session-surface`
   still actionable. `app-evidence/manifest.json` had no gaps and `provider-errors.after-move.json` reported
@@ -120,7 +120,7 @@ Release RRI's palette-live gate is stricter: it still requires at least six enab
   narration row and one follow-up narration row, confirming engine-logged `/chat` rows resolve turns without
   duplicating visible prose.
 - The merged-main #479 proof
-  (`/Volumes/LEXAR/Codex/worldos-built-app-playtest/codex-main-f7ab6d7-proof-20260601T010058Z/`, build
+  (`/Volumes/LEXAR/Codex/worldos-built-app-playtest/codex-main-f7ab6d7-proof-20260601T010058Z/`; historical path — /Volumes/LEXAR/Codex/worldos-built-app-playtest/codex-main-f7ab6d7-proof-20260601T010058Z/; that machine is gone, see NOW.md; build
   `f7ab6d7`) repeated the proof on `main`: private art present, Codex provider, Alfira active, five enabled
   actions, writable `/move`, one accepted/resolved player move, chat roles `dm, player, dm`, and
   `/session-surface` still actionable. `app-evidence/manifest.json` had no gaps and
@@ -129,7 +129,7 @@ Release RRI's palette-live gate is stricter: it still requires at least six enab
   not duplicate chat/event prose. This closes the #479 diagnostic blocker, but release still requires #466's
   full non-partial RRI gate.
 - The current-main handoff gate
-  (`/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260607-da05101-current-main-clean/`,
+  (`/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260607-da05101-current-main-clean/`; historical path — /Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260607-da05101-current-main-clean/; that machine is gone, see NOW.md;
   build `da05101`) is the current fastest GUI trust proof. It scored `handoff_score=100` with web-scripted
   smoke 5 moves, built `dist/WorldOS.app` scripted smoke 5 moves, and built `dist/WorldOS.app`
   Codex-provider playtest 1 move. All three evidence manifests passed with zero gaps, private art present,
@@ -137,13 +137,13 @@ Release RRI's palette-live gate is stricter: it still requires at least six enab
   and failure bucket fields. The Codex trace summary reported `trace_exists=true`, `line_count=350`, and
   `failed_or_error_count=0`. `validate_handoff_json(..., "da05101")` returned `valid=True`, `gaps=0`.
   The first canonical checkout attempt
-  (`/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260607-da05101-current-main/`)
+  (`/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260607-da05101-current-main/`; historical path — /Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260607-da05101-current-main/; that machine is gone, see NOW.md)
   passed the product gates but is not accepted as release evidence because unrelated local untracked files
   made the checkout dirty. The clean same-disk worktree proof above supersedes the `9545383`, `fd9dba5`,
   and `4a0efe1` handoffs as current proof. If #466 persona artifacts are produced from a newer SHA, rerun
   the Mac handoff on that same SHA before RRI rollup. It is the fast GUI velocity gate, not the release verdict.
 - The post-#508 handoff gate
-  (`/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260601T100304Z-9545383/`, build
+  (`/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260601T100304Z-9545383/`; historical path — /Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260601T100304Z-9545383/; that machine is gone, see NOW.md; build
   `9545383`) was the prior fastest GUI trust proof. It scored `handoff_score=100` with web-scripted smoke
   5 moves, built `dist/WorldOS.app` scripted smoke 5 moves, and built `dist/WorldOS.app` Codex-provider
   playtest 1 move. All three evidence manifests passed with zero gaps, private art present, screenshots,
@@ -172,7 +172,7 @@ Release RRI's palette-live gate is stricter: it still requires at least six enab
 
 ## Stand up the iteration surface (8799, playable, from canonical)
 ```bash
-cd /Users/lume/WorldOS
+cd /Users/m1/WorldOS
 # This is the intended local app checkout. Verify it is synced before testing:
 git rev-parse --short HEAD && git rev-parse --short origin/main
 pkill -f 'viewer/server.py'; pkill -f 'scripts/play.sh'; pkill -f 'play_party.sh'   # NOT node:18789 (Eva gateway)
@@ -211,7 +211,7 @@ streams mid-turn (`/events` count climbs during the turn) · a SOLO session has 
 1. Confirm the symptom on 8799 with ≥2 clean reads. If it doesn't reproduce, it's a stale/corrupt
    read — do NOT fix it (log to GUI_WORKBOOK "evaporated").
 2. Builder agent in a **same-disk local worktree off origin/main** when GUI/app tests need art:
-   `git -C /Users/lume/WorldOS worktree add -B codex/<slug> /Users/lume/WorldOS-worktrees/wos-<slug> origin/main`
+   `git -C /Users/m1/WorldOS worktree add -B codex/<slug> /Users/m1/repos/WorldOS-worktrees/wos-<slug> origin/main`
    Lexar worktrees remain fine for docs/backend/non-GUI slices that do not launch the viewer/app.
 3. PR → CI green (incl. `viewer-tests`) → admin-squash-merge → delete branch → prune worktree.
    **Builder PRs sometimes fail to push silently** (happened twice this session) — always
@@ -221,7 +221,7 @@ streams mid-turn (`/events` count climbs during the turn) · a SOLO session has 
 
 ## The gate sweep (Phase 3 — judged on the built .app)
 ```bash
-WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS \
+WORLDOS_ART_REPO_ROOT=/Users/m1/WorldOS \
 qa/release_gate.sh --personas newbie,veteran,adversarial,narrative,optimizer --budget 12 --port 8785
 ```
 RRI 10/10 = all 11 gates hold on ONE build across the canonical five personas
@@ -270,7 +270,7 @@ release-blocking product bug.
 Non-disruptive Mac smoke during takeover:
 ```bash
 WORLDOS_NO_STOP_EXISTING=1 \
-WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS \
+WORLDOS_ART_REPO_ROOT=/Users/m1/WorldOS \
 WORLDOS_PREFER_LAUNCH_ROOTS=1 \
 script/build_and_run.sh --verify
 ```
@@ -297,7 +297,7 @@ release truth still requires `qa/ui_playtest_app.sh` Part A+B and the full RRI s
 - VM preflight before any RRI sweep: record VM identity, repo checkout path, branch/SHA, Codex CLI version,
   GitHub `origin/main` queryability, auth/profile status, `uv`, Node/npm/Playwright/Chromium availability,
   private-art availability or explicit backend-only/no-art classification, env vars, budget/concurrency cap,
-  teardown commands, and the artifact return path under `/Volumes/LEXAR/Codex`. Use the repo-owned preflight
+  teardown commands, and the artifact return path under `/Users/m1/Codex`. Use the repo-owned preflight
   artifact writer before #466:
   ```bash
   python3 qa/support_vm_preflight.py \
@@ -308,7 +308,7 @@ release truth still requires `qa/ui_playtest_app.sh` Part A+B and the full RRI s
     --art-root /root/worldos-qa/WorldOS \
     --private-art-mode required \
     --artifact-dir /tmp/worldos-support-vm-preflight-da05101 \
-    --artifact-return-target /Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight
+    --artifact-return-target /Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight  # (historical path — /Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight; that machine is gone, see NOW.md)
   ```
   The script is read-only with respect to WorldOS state; it writes `support_vm_preflight.json` and
   `support_vm_preflight.md`, redacts secrets, and exits non-zero if same-SHA/origin/tool/auth/private-art
@@ -326,7 +326,7 @@ release truth still requires `qa/ui_playtest_app.sh` Part A+B and the full RRI s
   codex 0.120.0 present, art present, ~28 GB free. The 2026-06-01 "stale `4524b3e` / sync-failed / Lexar-absent"
   blockers no longer hold; the heavy part-B `sweep_v2.sh` lane is runnable.
 - **VM status UPDATE (2026-06-07 — current `da05101` staging):** the repo-owned preflight artifact at
-  `/Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight/` returned `verdict=blocked`, so no
+  `/Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight/` (historical path — /Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight/; that machine is gone, see NOW.md) returned `verdict=blocked`, so no
   personas were run. The VM could query GitHub `origin/main` as `da05101`, but its local repo HEAD/local
   `origin/main` were still `e5c0a5f`; Codex CLI auth/profile was not proven; and #466 release-RRI readiness
   requires rerunning with `--private-art-mode required`. Sync/fetch the VM checkout, prove Codex auth/profile,
@@ -336,7 +336,7 @@ release truth still requires `qa/ui_playtest_app.sh` Part A+B and the full RRI s
   `python3`, `uv 0.11.17`, Node `v22.22.1`, npm `10.9.4`, `codex-cli 0.120.0`, Playwright modules, and private
   art. The VM WorldOS checkout at `/root/worldos-qa/WorldOS` is clean but stale at `4524b3e` and behind
   the `9545383` proof baseline; `git` cannot query/sync the HTTPS origin in batch mode; Codex auth/config is
-  not proven; `/Volumes/LEXAR/Codex` does not exist on the VM. Before #466, approve/sync the VM checkout, prove
+  not proven; `/Volumes/LEXAR/Codex` (historical path — /Volumes/LEXAR/Codex; that machine is gone, see NOW.md) does not exist on the VM. Before #466, approve/sync the VM checkout, prove
   Codex auth, make `origin/main` queryable from the VM, set a remote staging path, and copy artifacts back to
   local Lexar.
 - RRI rollup rule: Mac/local evidence supplies native Part A and built-app screenshots; VM artifacts can supply
@@ -344,7 +344,7 @@ release truth still requires `qa/ui_playtest_app.sh` Part A+B and the full RRI s
   `session_surface.final.json`, `network.ndjson`, and build SHA are present. Missing or mixed-SHA artifacts
   must remain `partial` / `harness_contaminated`.
 - Split Mac/VM rollup command shape: pass the Mac proof into RRI as
-  `--handoff-json /Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260607-da05101-current-main-clean/handoff.json`
+  `--handoff-json /Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260607-da05101-current-main-clean/handoff.json` (historical path — /Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260607-da05101-current-main-clean/handoff.json; that machine is gone, see NOW.md)
   alongside VM persona run dirs from the same `da05101` SHA. RRI should satisfy the native gate from the
   Mac handoff bundle only if all required handoff gates and manifests are same-SHA, clean,
   private-art-present, and gap-free. If the VM runs a newer SHA, rerun `qa/app_handoff_gate.py` on that
@@ -499,7 +499,7 @@ reverts the goal to "fix" and outranks new work.
 - Engine (`servers/engine`) = SOLE writer of campaign state. Don't touch wire contracts
   (`worldos-*`/`WORLDOS_*` MCP ids, `dev.worldos.app`); you MAY read `WORLDOS_ART_REPO_ROOT`.
 - `_private/` (the 2.9 GB art) is **never committed**. Building/serving from the local checkout is how the
-  art is present; worktrees can read it via `WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS` when needed.
+  art is present; worktrees can read it via `WORLDOS_ART_REPO_ROOT=/Users/m1/WorldOS` when needed.
 - 16 GB Mac: tests on **GitHub CI / 32GB support VM** for heavyweight sweeps, never heavy local suites. Parallel read-only agents are
   fine; do not launch multiple heavyweight persona sweeps locally.
 - **Verify, don't trust:** ≥2 clean reads for any claim; the RRI scorer reads disk, not the live

--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -308,7 +308,7 @@ release truth still requires `qa/ui_playtest_app.sh` Part A+B and the full RRI s
     --art-root /root/worldos-qa/WorldOS \
     --private-art-mode required \
     --artifact-dir /tmp/worldos-support-vm-preflight-da05101 \
-    --artifact-return-target /Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight  # (historical path — /Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight; that machine is gone, see NOW.md)
+    --artifact-return-target /Users/m1/Codex/worldos-support-vm-rri/da05101-preflight
   ```
   The script is read-only with respect to WorldOS state; it writes `support_vm_preflight.json` and
   `support_vm_preflight.md`, redacts secrets, and exits non-zero if same-SHA/origin/tool/auth/private-art

--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -18,11 +18,11 @@
                    re-measure could move several gates at once. RELEASE MODEL = RRI-FIRST: v1.0.x tags =
                    semver feature-labels; RRI 10/10 = release-authority; tag-after-proof ("Player-Ready
                    Beta" = first RRI 10/10; "1.0 GA" = +notarized +feature-parity). Milestone v1.0.4 (#27).
-     CANONICAL:    /Users/lume/WorldOS is now the synced local app/private-art checkout and
+     CANONICAL:    /Users/m1/WorldOS is now the synced local app/private-art checkout and
                    the default place to build/run/test the Mac app. Keep GUI/runtime tests on this
                    local disk so macOS does not prompt on Lexar-hosted assets.
      WORKTREES:    For tracked edits, prefer same-disk local worktrees when GUI/app tests need assets.
-                   Use /Volumes/LEXAR/Codex for evidence/snapshots and Lexar worktrees only for
+                   Use /Users/m1/Codex for evidence/snapshots and Lexar worktrees only for
                    non-GUI/doc/backend slices that do not launch the app against private art.
      SUPPORT VM:   32GB owner-provided support VM (`support-vm-1`). Connection/auth details live
                    in local operator-only evidence/runbooks, not tracked repo docs. Use it for
@@ -34,7 +34,7 @@
                    repo HEAD/local `origin/main` on the VM is `e5c0a5f` while queried GitHub
                    `origin/main` is `da05101`, Codex CLI auth/profile is not proven, and #466
                    release-RRI readiness requires `--private-art-mode required`. Artifact:
-                   `/Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight/`.
+                   `/Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight/` (historical path — /Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight/; that machine is gone, see NOW.md).
      LAST MEASURED GATE BUILD:
                    NONE valid since rc2. rc1 = 3.6/10 @`fa97b34`; rc2 = 2.7/10 @`c92a393` (criticals
                    4→1, sat 4.8→5.8 — product IMPROVED; RRI dip was native-skip + newbie stall, both
@@ -44,12 +44,11 @@
                    4 remaining cold-opens 429'd → never seated → the OLD parallel harness rolled a junk
                    1.8. NO scores.db row written. #844 hardened the harness (sequential personas +
                    429-abort + ABORTED-not-a-number). Mac part-A handoff @a245a2c = 100/100 with full
-                   image evidence (banked at /Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/
-                   handoff-20260610T115322Z-a245a2c). NEXT MEASURE = hardened sequential sweep at CURRENT
+                   image evidence (banked at /Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260610T115322Z-a245a2c) (historical path — /Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260610T115322Z-a245a2c; that machine is gone, see NOW.md). NEXT MEASURE = hardened sequential sweep at CURRENT
                    main + that (or a fresh) Mac handoff — pending claude quota (rc3 429 reset hint 3:50pm UTC).
      LAST BUILT-APP PLAY PROOF:
                    Last built-app handoff proof is `da05101`
-                   (`/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260607-da05101-current-main-clean/`):
+                   (`/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260607-da05101-current-main-clean/`; historical path — /Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260607-da05101-current-main-clean/; that machine is gone, see NOW.md):
                    `qa/app_handoff_gate.py` scored `handoff_score=100` with web-scripted smoke
                    5 moves, built `dist/WorldOS.app` scripted smoke 5 moves, and built
                    `dist/WorldOS.app` Codex-provider playtest 1 move. Private BG art was present,
@@ -252,7 +251,7 @@ verifier; can revert the goal to "fix" anytime.
   NEXT build is the evidence. Close issues only on next-build non-reproduction. **Honest scores only.**
 - Engine (`servers/engine`) = **SOLE writer** of campaign state. Don't touch wire contracts
   (`worldos-*` / `WORLDOS_*` / `dev.worldos.app`). Build/run/test the Mac app from
-  `/Users/lume/WorldOS` so private art stays on the local disk and macOS does not prompt on Lexar
+  `/Users/m1/WorldOS` so private art stays on the local disk and macOS does not prompt on Lexar
   files. Use **same-disk local worktrees** for GUI-affecting tracked edits, Lexar for evidence/snapshots,
   and the 32GB support VM / GitHub CI for heavy tests. `_private/` never committed.
 
@@ -272,11 +271,11 @@ verifier; can revert the goal to "fix" anytime.
   added the hybrid 100/100 app handoff gate. PR #505 then hardened the RRI bridge so Mac handoff
   evidence can be supplied with `--handoff-json` while support-VM persona artifacts supply the heavy
   sweep. PR #506 then synced these docs to the `fd9dba5` proof without changing product code. PR #508 added the
-  support-VM preflight artifact gate. The local app/private-art checkout `/Users/lume/WorldOS` was
+  support-VM preflight artifact gate. The local app/private-art checkout `/Users/lume/WorldOS` (historical path — /Users/lume/WorldOS; that machine is gone, see NOW.md) was
   later verified against current `origin/main` at `da05101`, and the Mac app handoff was rerun on that
-  exact SHA from a clean same-disk worktree with `WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS`.
+  exact SHA from a clean same-disk worktree with `WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS` (historical path — /Users/lume/WorldOS; that machine is gone, see NOW.md).
 - The stale local pre-sync artifacts were preserved before the fast-forward at
-  `/Volumes/LEXAR/Codex/worldos-local-checkout-snapshot-20260531T223923` and in `stash@{0}`
+  `/Volumes/LEXAR/Codex/worldos-local-checkout-snapshot-20260531T223923` (historical path — /Volumes/LEXAR/Codex/worldos-local-checkout-snapshot-20260531T223923; that machine is gone, see NOW.md) and in `stash@{0}`
   (`pre-sync local takeover docs 2026-05-31`). Treat those as evidence, not current release truth.
 - The `f5500ac` RRI (`2.7/10`) is preserved as partial evidence only. It proves the gate/harness was
   not trustworthy enough for release scoring: one persona completed, others lacked `score.json`, and
@@ -288,7 +287,7 @@ verifier; can revert the goal to "fix" anytime.
 - Early Codex-DM local built-app evidence is preserved: private BG art loaded,
   Alfira seated as `player`, visible DM narration, enabled actions, a real player move appended to
   `player_moves.jsonl`, and a post-move DM response with `can_act:true` in `/session-surface`.
-  Evidence is in `/Volumes/LEXAR/Codex/worldos-built-app-proof/`:
+  Evidence is in `/Volumes/LEXAR/Codex/worldos-built-app-proof/` (historical path — /Volumes/LEXAR/Codex/worldos-built-app-proof/; that machine is gone, see NOW.md):
   `session-surface-racefix-after-dm-response-20260601T012410.json`,
   `worldos-racefix-first-turn-20260601T012110.png`, and
   `worldos-racefix-dm-response-dismissed-permission-20260601T012516.png`.
@@ -303,7 +302,7 @@ verifier; can revert the goal to "fix" anytime.
   Heavy backend/persona sweeps belong on the owner-provided 32GB support VM (`support-vm-1`) once auth/config
   are intentionally installed there; connection details are kept outside tracked docs. The 2026-06-07
   repo-owned support preflight for `da05101` wrote
-  `/Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight/` and returned `verdict=blocked`:
+  `/Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight/` (historical path — /Volumes/LEXAR/Codex/worldos-support-vm-rri/da05101-preflight/; that machine is gone, see NOW.md) and returned `verdict=blocked`:
   VM repo HEAD/local `origin/main` were `e5c0a5f`, queried GitHub `origin/main` was `da05101`, Codex
   CLI auth/profile was not proven, and `--private-art-mode optional` is insufficient for #466 release-RRI
   readiness. Do not run personas until the VM checkout is synced to `da05101`, Codex auth/profile passes,
@@ -352,7 +351,7 @@ verifier; can revert the goal to "fix" anytime.
   campaign, provider, private-art presence, move sink, actor, enabled actions, readiness, and failure buckets
   without mutating state; the scripted provider can prove wiring behind a dev/test gate; and stable a11y/DOM
   hooks make the UI more driveable. A current-session `:8899` probe briefly showed `080497e`, scripted
-  provider, private art root at `/Users/lume/WorldOS`, `can_act:true`, five enabled actions,
+  provider, private art root at `/Users/lume/WorldOS` (historical path — /Users/lume/WorldOS; that machine is gone, see NOW.md), `can_act:true`, five enabled actions,
   `ready_for_smoke:true`, and no reported console/network failures; a later read found the port already
   down. Browser-based checks should use the live port discovered from `run.json` or `/app-status`, and if
   a browser session cannot reach local URLs, fall back to `/app-status`, `/session-surface`, app screenshots,

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -9,8 +9,8 @@
 > `WorldOS-OPERATING-GOAL.md` first, then `WorldOS-GUI-RUNBOOK.md`, `qa/QA_TOOLS.md`, and
 > `qa/SCORECARD.md`. The work queue later in this file is historical unless it agrees with those
 > sources.
-> **Local/VM routing, 2026-06-01:** `/Users/lume/WorldOS` is the synced local app/private-art
-> checkout and should be used for GUI/native-app testing. Use `/Volumes/LEXAR/Codex` for evidence,
+> **Local/VM routing, 2026-06-01:** `/Users/m1/WorldOS` is the synced local app/private-art
+> checkout and should be used for GUI/native-app testing. Use `/Users/m1/Codex` for evidence,
 > snapshots, and logs; do not make Lexar the default GUI runtime tree because external-drive
 > permissions can break local AI/browser tests. Heavy backend/persona sweeps belong on GitHub CI or
 > the owner-provided 32GB support VM (`support-vm-1`) after remote access and Codex config are
@@ -169,7 +169,7 @@ change must respect them.
 > you have explicitly verified your machine can handle parallel workers.
 
 1. **Branch off main in a fresh worktree** (keeps lanes disjoint from the app-testing checkout).
-   For GUI/native-app work, prefer same-disk local worktrees under `/Users/lume/WorldOS-worktrees`
+   For GUI/native-app work, prefer same-disk local worktrees under `/Users/m1/repos/WorldOS-worktrees`
    so private-art reads stay on the local disk. Lexar worktrees are fine for docs/backend/non-GUI
    slices that do not launch the app against art. Implement **additively** (honor every invariant above).
 2. **Run focused local tests single-process:**
@@ -305,8 +305,8 @@ fresh scored evidence explicitly changes that decision.
 Preflight, from the Mac where Codex CLI is logged in:
 
 ```bash
-cd /Users/lume/WorldOS
-scripts/codex_qa_home.sh ~/.codex-worldos-qa /Users/lume/WorldOS
+cd /Users/m1/WorldOS
+scripts/codex_qa_home.sh ~/.codex-worldos-qa /Users/m1/WorldOS
 CODEX_HOME=~/.codex-worldos-qa codex login status
 CODEX_HOME=~/.codex-worldos-qa codex --version
 ```
@@ -336,7 +336,7 @@ Fair-test shape:
   a release verdict.
 - Behavioral gate: always run `qa/assert_behavioral.py` on the provider's tool stream. A RED
   behavioral gate still caps story/mechanical scorecards to INVALID.
-- Evidence stays private under `/Volumes/LEXAR/Codex`; do not commit raw transcripts,
+- Evidence stays private under `/Users/m1/Codex`; do not commit raw transcripts,
   private art, or credentials.
 
 Current #691 result after #700 on `f228815`: native Codex GPT is mechanically capable enough
@@ -350,8 +350,8 @@ Opus-comparable story/mechanical scores.
 
 ## AGENT DELEGATION
 
-> Absolute `/Users/lume/...` paths below and elsewhere in this section reflect the primary dev
-> machine — substitute your own checkout root.
+> Absolute paths below and elsewhere in this section reflect the primary dev machine — substitute
+> your own checkout root.
 
 Orchestrate via subagents; verify from the top.
 

--- a/docs/KIMI-ONBOARDING.md
+++ b/docs/KIMI-ONBOARDING.md
@@ -12,13 +12,13 @@
 
 | Thing | Path / identity | Notes |
 |---|---|---|
-| Canonical checkout | `/Users/lume/WorldOS` | GitHub `electricsheephq/WorldOS`; local branch **`base` tracks `origin/main`**; tip `fd23e972` (dress_focal v2 / #1621, 2026-07-16) |
-| Live worktrees | `/Users/lume/WorldOS-worktrees/` (same dir as lowercase spelling, case-insensitive APFS) | `wt-owner-play` — owner's play copy, branch `main` @ `c8a0b155`, **`.worldos-keep` = never touch**; behind main → `git pull --ff-only origin main` BEFORE any owner reseed (schema-skew class, OPERATIONS.md). `walk-gate-hardening` — clean, @ `92edf8d7`, looks merged; only its owning lane may prune it |
-| Stale clone (trap) | `/Volumes/LEXAR/repos/WorldOS` | Jul-1 clone @ `76439e2`, ~19 days behind. Do not mistake for canonical |
-| Session scratch/evidence | `~/worldos-session-notes` → symlink to `/Volumes/LEXAR/Codex/offloaded-local/2026-07-09/worldos-session-notes` (9.8 GB) | Newest: `walkability-fix-2026-07-16/`, `ship-2026-07-15/` |
-| Unity player install | `/Users/lume/Applications/WorldOSPlayer.app` | Jul 16 12:16 build |
+| Canonical checkout | `/Users/m1/WorldOS` | GitHub `electricsheephq/WorldOS`; local branch **`base` tracks `origin/main`**; tip `fd23e972` (dress_focal v2 / #1621, 2026-07-16) |
+| Live worktrees | `/Users/m1/repos/WorldOS-worktrees/` | `wt-owner-play` — owner's play copy, branch `main` @ `c8a0b155`, **`.worldos-keep` = never touch**; behind main → `git pull --ff-only origin main` BEFORE any owner reseed (schema-skew class, OPERATIONS.md). `walk-gate-hardening` — clean, @ `92edf8d7`, looks merged; only its owning lane may prune it |
+| Stale clone (trap) | `/Volumes/LEXAR/repos/WorldOS` (historical path — /Volumes/LEXAR/repos/WorldOS; that machine is gone, see NOW.md) | Jul-1 clone @ `76439e2`, ~19 days behind. Do not mistake for canonical |
+| Session scratch/evidence | `/Users/m1/Codex/session-notes` | Newest: `walkability-fix-2026-07-16/`, `ship-2026-07-15/` |
+| Unity player install | `/Users/lume/Applications/WorldOSPlayer.app` (historical path — /Users/lume/Applications/WorldOSPlayer.app; that machine is gone, see NOW.md) | Jul 16 12:16 build |
 | Built app | `dist/` — **EMPTY right now** (no `dist/WorldOS.app` exists) | AGENTS.md defines the built app as the product; last app evidence early July |
-| GEX44 backups | `/Volumes/LEXAR/Codex/worldos-unity-backups/` | `worktree-20260716.tgz` confirmed |
+| GEX44 backups | `/Volumes/LEXAR/Codex/worldos-unity-backups/` (historical path — /Volumes/LEXAR/Codex/worldos-unity-backups/; that machine is gone, see NOW.md) | `worktree-20260716.tgz` confirmed |
 
 ## 2. Reading order (doc routing)
 
@@ -73,10 +73,10 @@ The skill surface is live-edited (worldos-dev touched Jul 15, blind-adjudicator 
 
 | Surface | Path | How Kimi uses it |
 |---|---|---|
-| Dev loop (canonical) | `/Users/lume/WorldOS/.claude/skills/worldos-dev/SKILL.md` | Read before any dev loop |
-| Decision apparatus | `/Users/lume/WorldOS/.claude/skills/worldos-decide/SKILL.md` | Read when a decision lacks an eval |
+| Dev loop (canonical) | `/Users/m1/WorldOS/.claude/skills/worldos-dev/SKILL.md` | Read before any dev loop |
+| Decision apparatus | `/Users/m1/WorldOS/.claude/skills/worldos-decide/SKILL.md` | Read when a decision lacks an eval |
 | GEX44/Unity lane | `~/.claude/skills/gex44-unity-host/SKILL.md`, `~/.claude/skills/unity-asset-stack/SKILL.md` | Read before any box op |
-| Visual critic / asset gen | `/Users/lume/WorldOS/.claude/skills/visual-critic/SKILL.md`, `.../asset-gen/SKILL.md` | Read on those lanes |
+| Visual critic / asset gen | `/Users/m1/WorldOS/.claude/skills/visual-critic/SKILL.md`, `.../asset-gen/SKILL.md` | Read on those lanes |
 | Blind adjudicator | `~/.claude/agents/blind-adjudicator.md` | **Port the prompt verbatim** into a Kimi read-only subagent (`plan`/`explore` type) for gate verdicts — self-contained, model-agnostic |
 | Other agent profiles | `~/.claude/agents/{coder,deep-reasoner,fast-worker,codex-worker}.md` | Map frontmatter to Kimi subagent types (`coder`/`plan`/`explore`) |
 | WorldOS memory index | `~/.claude/projects/-Users-lume/memory/worldos-index.md` | Read on any WorldOS resume |
@@ -84,7 +84,7 @@ The skill surface is live-edited (worldos-dev touched Jul 15, blind-adjudicator 
 | Routing ledger | `~/.claude/routing-ledger.jsonl` | **Shared append-only JSONL** — Kimi appends rows (`{"ts","lane","task","outcome","repo","note"}`) so Claude-side sessions see Kimi dispatches |
 | Fable lane table | `~/.claude/CLAUDE.md` | "Fable = orchestrator only, the brain never types" → the Kimi orchestrator inherits that role; cheaper work delegates to subagents |
 
-Do NOT port: Claude hooks, stop-guards, keepalive ticks (Claude-app mechanics; Kimi has its own turn lifecycle). `.mcp.json` (engine/rules/voice stdio servers) is portable in substance — substitute `${CLAUDE_PLUGIN_ROOT}` → `/Users/lume/WorldOS` if ever wired.
+Do NOT port: Claude hooks, stop-guards, keepalive ticks (Claude-app mechanics; Kimi has its own turn lifecycle). `.mcp.json` (engine/rules/voice stdio servers) is portable in substance — substitute `${CLAUDE_PLUGIN_ROOT}` → `/Users/m1/WorldOS` if ever wired.
 
 **Known gap — GitNexus**: this repo's AGENTS.md mandates GitNexus `impact` before edits and `detect_changes` before committing, but Kimi has no `mcp__gitnexus__*` tools. Fallback: the CLI (`node .gitnexus/run.cjs analyze`, index fresh at Jul 16 17:12) + grep — or the owner grants an explicit waiver / wires the MCP.
 

--- a/docs/ROOM-PIPELINE-RUNBOOK.md
+++ b/docs/ROOM-PIPELINE-RUNBOOK.md
@@ -21,7 +21,7 @@
 **Preflight (do this before any command below):** read `docs/OPERATIONS.md` first — it's the
 general cold-start bootstrap (worktree discipline, box claim etiquette, the Universal Run Contract)
 this page specializes for room authoring. Verify `pwd` before running anything: you should be inside
-a real checkout of this repo (`/Users/lume/WorldOS` or an approved same-disk worktree per
+a real checkout of this repo (`/Users/m1/WorldOS` or an approved same-disk worktree per
 OPERATIONS.md's worktree-discipline section) — never a bare scratch directory. Any step below that
 touches the live Unity project (step 9's `plates_manifest.json`, step 10's player rebuild) requires
 the canonical checkout or box path named in that step; don't improvise a different location.

--- a/extensions/renderers/godot/HANDOFF.md
+++ b/extensions/renderers/godot/HANDOFF.md
@@ -288,11 +288,11 @@ python3 extensions/renderers/godot/tools/pack_sheet.py --frames <dir>/frames \
   checking the error is *"export template not found"* (preset OK) vs *"no preset named X"* (preset wrong).
   Committed presets are Web (single-threaded) + Linux; #1058 adds macOS.
 - **GDScript coroutines must be awaited** — you can't "start all then await"; sequential `await` per surface is correct.
-- **Multi-session repo.** Other agents share `/Users/lume/WorldOS`. Always work in a **worktree off
+- **Multi-session repo.** Other agents share `/Users/m1/WorldOS`. Always work in a **worktree off
   `origin/main`**; never branch-flip the shared checkout. Merges can hit a transient "base branch was
   modified" race → retry.
 - **Godot 4.4+ writes `.gd.uid` files** — commit them. Gitignore `.godot/`, `*.import`, export outputs.
-- **After a merge batch**, refresh GitNexus once: `gitnexus analyze /Users/lume/WorldOS --name worldos --embeddings --index-only`.
+- **After a merge batch**, refresh GitNexus once: `gitnexus analyze /Users/m1/WorldOS --name worldos --embeddings --index-only`.
 
 <a name="backlog"></a>
 ## 9. The historical issue backlog (reference only until #1165 resolves)

--- a/qa/GUI_WORKBOOK.md
+++ b/qa/GUI_WORKBOOK.md
@@ -6,7 +6,7 @@
 > current release state. "Verified" means observed on the live playable surface or read from canonical
 > source at the time recorded, not a proxy guess.
 >
-> Current routing: iteration surface `http://127.0.0.1:8799/openworlds/` from `/Users/lume/WorldOS`;
+> Current routing: iteration surface `http://127.0.0.1:8799/openworlds/` from `/Users/m1/WorldOS`;
 > gate surface built `dist/WorldOS.app`; fast handoff command `qa/app_handoff_gate.py`; release verdict
 > `qa/release_readiness.py`.
 
@@ -28,7 +28,7 @@ persona evidence. Issue #466 must either produce that clean RRI or fail with act
 - ✅ `launch.json` repointed off the deprecated LEXAR copy → canonical/8799/`/openworlds/`/live state.
 - ✅ 8799 playable from canonical: `can_act:true`, PC Rolan + Minsc, images + map render.
 - ✅ Lexar worktree `.app` smoke can launch without killing the canonical app and still read canonical
-  private art via `WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS`.
+  private art via `WORLDOS_ART_REPO_ROOT=/Users/m1/WorldOS`.
 
 ## REAL bugs (verified; the actual punch-list)
 
@@ -38,7 +38,7 @@ persona evidence. Issue #466 must either produce that clean RRI or fail with act
 | G4 | Chronicle renders as ONE block despite well-formed prose | `LogEntry` rendered `{text}` with default `white-space`, collapsing `\n\n` paragraph breaks | Keep sanitization, render narration with `whiteSpace: "pre-line"` | Merged in #465; needs built-app live look + full gate | Static proof: `viewer/tests/test_openworlds_static.py::test_openworlds_table_chronicle_preserves_paragraph_breaks` |
 | G6 | Companion (Minsc/Alfira, kind='companion') silently in solo party at cold-open, no narrated meeting | solo play.sh could prompt the DM into seating/recruiting a companion at cold-open | Solo prompt now says the player begins alone; `play_party.sh` with empty companion spec execs solo `play.sh` unchanged | Merged in #465; needs live gate proof | Static proof: `qa/test_release_gate_static.py::test_solo_play_contract_does_not_silently_recruit_companion` |
 | G5 | "No streaming visible" — VERIFY (may be infra: owner watched a stale/wrong surface) | /events+useLiveSession+log_event exist; DM emits paragraph-rich prose; PR #394 merged streaming-lite for #393 | Confirm mid-turn log_event on live 8799; fix only if current built-app play still batches blank waits | #394 merged; #393 remains open until built-app Part A+B proves no latency give-ups | DM prose well-formed; streaming path exists; proof still owed on built app |
-| G7 | Worktree/.app builds 404 images (no _private) | `_ingested_images_root()` (server.py:203) hardcoded to server.py's repo → worktree has no _private | Split code repo from art repo: viewer honors `WORLDOS_ART_REPO_ROOT`; native app has a Private art repo path and launch-root override for gate builds | Merged in #465; needs #466 full gate proof | 2026-05-31 smoke: worktree `dist/WorldOS.app` pid 69755 launched without killing canonical app; spawned worktree `viewer/server.py` on 8765; `/image?scope=location:loc-lower-city` returned `200 904100`; Info.plist root=`/Volumes/LEXAR/repos/worldos-takeover-stabilization`, art=`/Users/lume/WorldOS` |
+| G7 | Worktree/.app builds 404 images (no _private) | `_ingested_images_root()` (server.py:203) hardcoded to server.py's repo → worktree has no _private | Split code repo from art repo: viewer honors `WORLDOS_ART_REPO_ROOT`; native app has a Private art repo path and launch-root override for gate builds | Merged in #465; needs #466 full gate proof | 2026-05-31 smoke: worktree `dist/WorldOS.app` pid 69755 launched without killing canonical app; spawned worktree `viewer/server.py` on 8765; `/image?scope=location:loc-lower-city` returned `200 904100`; Info.plist root=`/Volumes/LEXAR/repos/worldos-takeover-stabilization`, art=`/Users/lume/WorldOS` (historical path — /Volumes/LEXAR/repos/worldos-takeover-stabilization and /Users/lume/WorldOS; that machine is gone, see NOW.md) |
 
 ## EVAPORATED on clean re-verification (were CORRUPTED READS — do NOT chase)
 - **G1 "palette all-disabled / PC kind=pc / no active character"** — FALSE. Live PC Rolan is `kind='player'`; palette enabled. (A corrupted snapshot read invented `kind='pc'`/`npc-alfira`. Builder A killed — pushed no PR.)

--- a/qa/QA_TOOLS.md
+++ b/qa/QA_TOOLS.md
@@ -5,15 +5,15 @@ This is the command map for agents. It does not replace the release truth in
 
 Default local paths:
 
-- App/private-art checkout: `/Users/lume/WorldOS`.
-- Evidence root: `/Volumes/LEXAR/Codex`.
+- App/private-art checkout: `/Users/m1/WorldOS`.
+- Evidence root: `/Users/m1/Codex`.
 - Heavy persona/backend sweeps: GitHub CI or the owner-provided support VM after explicit preflight.
 
 ## Fast GUI And Native App Gates
 
 | Tool | Use it for | Writes / reads | Do not use when |
 |---|---|---|---|
-| `qa/app_handoff_gate.py` | The current fastest handoff gate: web scripted smoke, built `dist/WorldOS.app` scripted smoke, short built-app Codex playtest, and bounded hook checks on one SHA | `/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/<run-id>/handoff.json` plus gate evidence bundles | You need the final release verdict; run RRI instead |
+| `qa/app_handoff_gate.py` | The current fastest handoff gate: web scripted smoke, built `dist/WorldOS.app` scripted smoke, short built-app Codex playtest, and bounded hook checks on one SHA | `/Users/m1/Codex/worldos-agent-grade-app-testability/<run-id>/handoff.json` plus gate evidence bundles | You need the final release verdict; run RRI instead |
 | `qa/app_smoke_scripted.py` | Deterministic multi-beat scripted smoke against the web/viewer harness | Screenshots, app-status snapshots, moves, `smoke.json` | You need real-provider behavior or native shell proof |
 | `qa/ui_playtest_app.sh` | Built-app/native harness with native Part A+B evidence and stable failure buckets | Native app run dir, app-status snapshots, screenshots, move/chat artifacts | You only need a quick static or web smoke |
 | `qa/export_app_evidence.py` | Normalize a live app or run dir into a reviewable evidence bundle | `manifest.json`, status/session snapshots, screenshots, traces, logs | You are trying to prove behavior without first running a gate |
@@ -23,12 +23,12 @@ Default local paths:
 Copy-paste fast handoff command:
 
 ```bash
-cd /Users/lume/WorldOS
+cd /Users/m1/WorldOS
 python3 qa/app_handoff_gate.py \
   --web-beats 5 \
   --built-beats 5 \
   --codex-moves 1 \
-  --art-root /Users/lume/WorldOS \
+  --art-root /Users/m1/WorldOS \
   --scripted-budget 1.00 \
   --codex-budget 3.00 \
   --timeout 90 \

--- a/qa/app_handoff_gate.py
+++ b/qa/app_handoff_gate.py
@@ -30,7 +30,8 @@ from qa import app_smoke_scripted as smoke  # noqa: E402
 from qa.app_failure_buckets import APP_FAILURE_BUCKETS  # noqa: E402
 
 
-DEFAULT_OUTPUT_ROOT = Path("/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability")
+DEFAULT_OUTPUT_ROOT = Path(os.environ.get("WORLDOS_HANDOFF_OUT",
+                                          str(Path.home() / "Codex/worldos-agent-grade-app-testability")))
 DEFAULT_ART_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/qa/app_handoff_gate.py
+++ b/qa/app_handoff_gate.py
@@ -31,7 +31,7 @@ from qa.app_failure_buckets import APP_FAILURE_BUCKETS  # noqa: E402
 
 
 DEFAULT_OUTPUT_ROOT = Path("/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability")
-DEFAULT_ART_ROOT = Path("/Users/lume/WorldOS")
+DEFAULT_ART_ROOT = Path(__file__).resolve().parents[1]
 
 
 def utc_stamp() -> str:

--- a/qa/drive_gfx_combat.py
+++ b/qa/drive_gfx_combat.py
@@ -67,6 +67,7 @@ def render(tag: str) -> None:
     scope = surface().get("combatFrameScope", "")  # the current turn's frame scope (matches what the box renders)
     subprocess.run([UNITY_MCP, "code", "execute", "--no-safety-checks",
                     "-f", RENDER_SCRIPT], capture_output=True, timeout=160)
+    os.makedirs(OUT_DIR, exist_ok=True)
     png = f"{OUT_DIR}/m1_combat_{tag}.png"
     subprocess.run(["scp", "-o", f"ControlPath={CM}", f"{BOX}:{BOX_CAP}", png], capture_output=True, timeout=30)
     deliver(png, scope)  # M-D: also drop it in the viewer's /image cache so the in-app <Img> serves it

--- a/qa/drive_gfx_combat.py
+++ b/qa/drive_gfx_combat.py
@@ -17,14 +17,17 @@ import shutil
 import subprocess
 import sys
 import urllib.request
+from pathlib import Path
 
 VIEWER = sys.argv[1] if len(sys.argv) > 1 else "http://127.0.0.1:8770"
 CID = sys.argv[2] if len(sys.argv) > 2 else "camp_gfxdemo01"
 CM = "/tmp/gex44-cm.sock"
 BOX = "root@46.4.26.123"
-RENDER_SCRIPT = "/Users/lume/WorldOS/extensions/renderers/unity/scripts/paint_combat_v1.cs"
+RENDER_SCRIPT = str(Path(__file__).resolve().parents[1] / "extensions/renderers/unity/scripts/paint_combat_v1.cs")
 BOX_CAP = "/home/unity/worldos-unity/Captures-Durable/m1_combat_v1.png"
-OUT_DIR = "/Users/lume/worldos-session-notes/renders"
+OUT_DIR = os.environ.get("WORLDOS_RENDER_OUT", str(Path.home() / "Codex/session-notes/renders"))
+# The box-era CLI is superseded by extensions/renderers/unity/tools/mcp_stdio_exec.py.
+UNITY_MCP = shutil.which("unity-mcp") or str(Path.home() / ".local/bin/unity-mcp")
 # M-D: deliver each frame into the viewer's /image cache so the in-app <Img> backdrop serves it.
 STATE_DIR = os.environ.get("WORLDOS_STATE_DIR", "/tmp/gfx_state")
 
@@ -62,7 +65,7 @@ def post_move(move: dict) -> dict:
 
 def render(tag: str) -> None:
     scope = surface().get("combatFrameScope", "")  # the current turn's frame scope (matches what the box renders)
-    subprocess.run(["/Users/lume/.local/bin/unity-mcp", "code", "execute", "--no-safety-checks",
+    subprocess.run([UNITY_MCP, "code", "execute", "--no-safety-checks",
                     "-f", RENDER_SCRIPT], capture_output=True, timeout=160)
     png = f"{OUT_DIR}/m1_combat_{tag}.png"
     subprocess.run(["scp", "-o", f"ControlPath={CM}", f"{BOX}:{BOX_CAP}", png], capture_output=True, timeout=30)

--- a/qa/gate_corpus/builder.py
+++ b/qa/gate_corpus/builder.py
@@ -35,7 +35,7 @@ _MANIFEST = _HERE / "manifest.json"
 _GATE = _HERE.parent / "assert_behavioral.py"
 
 # Real recorded REDs whose failure MODE each synthetic fixture is modeled on. Sourced from
-# /Users/lume/WorldOS/qa/transcripts/*.gate.txt at corpus-build time. A blank value means
+# /Users/lume/WorldOS/qa/transcripts/*.gate.txt (historical path — /Users/lume/WorldOS/qa/transcripts/*.gate.txt; that machine is gone, see NOW.md) at corpus-build time. A blank value means
 # the check has no recorded real RED and the fixture is purely synthetic (still faithful to the
 # gate's documented trip condition).
 REAL_RED_PROVENANCE = {

--- a/qa/lib_native_player_boot.sh
+++ b/qa/lib_native_player_boot.sh
@@ -9,10 +9,11 @@
 # --- locate the installed MCP SDK (worktrees have no node_modules — accept an explicit override
 # or the canonical checkout's qa/playwright install). $PW_DIR must be set by the caller. -----------
 find_sdk_node_modules() {
-  local c
+  local c script_root
+  script_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
   for c in "${WORLDOS_NPT_NODE_MODULES:-}" \
            "${PW_DIR:-}/node_modules" \
-           "/Users/lume/WorldOS/qa/playwright/node_modules"; do
+           "${script_root}/qa/playwright/node_modules"; do
     [ -n "$c" ] && [ -d "$c/@modelcontextprotocol" ] && { echo "$c"; return 0; }
   done
   return 1

--- a/qa/native_palette/native_palette_server.js
+++ b/qa/native_palette/native_palette_server.js
@@ -64,6 +64,8 @@ function requireShared(mod) {
     path.join(__dirname, "node_modules"),
     path.join(__dirname, "..", "playwright", "node_modules"),
     path.resolve(__dirname, "..", "..", "qa", "playwright", "node_modules"),
+    // canonical local checkout — worktrees have no node_modules of their own
+    "/Users/m1/WorldOS/qa/playwright/node_modules",
   ].filter(Boolean);
   try {
     return require(mod);

--- a/qa/native_palette/native_palette_server.js
+++ b/qa/native_palette/native_palette_server.js
@@ -63,7 +63,7 @@ function requireShared(mod) {
     process.env.WORLDOS_NPT_NODE_MODULES,
     path.join(__dirname, "node_modules"),
     path.join(__dirname, "..", "playwright", "node_modules"),
-    "/Users/lume/WorldOS/qa/playwright/node_modules",
+    path.resolve(__dirname, "..", "..", "qa", "playwright", "node_modules"),
   ].filter(Boolean);
   try {
     return require(mod);

--- a/qa/test_native_palette.py
+++ b/qa/test_native_palette.py
@@ -36,7 +36,7 @@ def _node_modules_with_sdk() -> str | None:
     canonical checkout's qa/playwright install)."""
     for base in (NPT / "node_modules",
                  ROOT / "qa" / "playwright" / "node_modules",
-                 Path("/Users/lume/WorldOS/qa/playwright/node_modules")):
+                 Path(__file__).resolve().parents[1] / "qa" / "playwright" / "node_modules"):
         if (base / "@modelcontextprotocol").is_dir():
             return str(base)
     return None

--- a/qa/test_triage_failure.py
+++ b/qa/test_triage_failure.py
@@ -3,8 +3,8 @@
 
 Run (single-process):
     uv run --directory servers/engine python -m pytest ../../qa/test_triage_failure.py -q -p no:xdist
-    uv run --directory /Users/lume/worldos-qa-p2b/servers/engine python -m pytest \
-        /Users/lume/worldos-qa-p2b/qa/test_triage_failure.py -q -p no:xdist
+    uv run --directory /Users/lume/worldos-qa-p2b/servers/engine python -m pytest \  # historical path — /Users/lume/worldos-qa-p2b; that machine is gone, see NOW.md
+        /Users/lume/worldos-qa-p2b/qa/test_triage_failure.py -q -p no:xdist  # historical path — /Users/lume/worldos-qa-p2b; that machine is gone, see NOW.md
 
 triage_failure.py is a PURE READER: given a bucket name (and optionally a read-only run dir),
 it emits likely cause(s), a recommended next diagnostic + retry env vars, and an INFRA/MEASUREMENT

--- a/qa/ui_playtest_app.sh
+++ b/qa/ui_playtest_app.sh
@@ -1242,7 +1242,7 @@ repo_viewer_ports() {
     # Match EITHER an absolute argv path under repo root (the LAUNCHER, whose CWD is the .app's
     # temp dir, not the repo) OR CWD == repo root (the MINTED provider viewer, launched by
     # play*.sh with a RELATIVE `viewer/server.py`). Either way it is THIS checkout's viewer; this
-    # excludes other checkouts (e.g. /Users/lume/WorldOS) and unrelated services.
+    # excludes other checkouts (e.g. /Users/m1/WorldOS) and unrelated services.
     if printf '%s' "$cmd" | grep -qF "$rootp/viewer/server.py" \
        || printf '%s' "$cmd" | grep -qF "$root/viewer/server.py" \
        || [ "$cwd" = "$rootp" ] || [ "$cwd" = "$root" ]; then

--- a/servers/engine/tests/test_codex_provider_wrapper.py
+++ b/servers/engine/tests/test_codex_provider_wrapper.py
@@ -326,7 +326,7 @@ def test_codex_dm_wrapper_prompts_are_self_contained_for_live_app_turns():
     assert "Use worldos-engine as the sole writer of campaign state" in source
     assert "Final output must be 2nd-person player-facing narration" in source
     assert "skills/dungeon-master/SKILL.md" not in source
-    assert "/Users/lume/.codex/skills/dungeon-master" not in source
+    assert "/Users/lume/.codex/skills/dungeon-master" not in source  # historical path — /Users/lume/.codex/skills/dungeon-master; that machine is gone, see NOW.md
     assert source.count("$DM_CONTRACT_RULE") == 3
     assert source.count("$DM_VOICE_RULE") == 3
 


### PR DESCRIPTION
Retires dead `/Users/lume` and `/Volumes/LEXAR` references from the specified live docs and scripts, derives runtime paths from the repository or home, and preserves dated history/fixture content with explicit historical markers.

Claim class: `hygiene_docs+paths`

Proves: live docs/scripts no longer contain unmarked `/Users/lume` references; the named path-cleanup acceptance bundle passes at the exact tested head `72d9d08a9ff5fb47fa99b81de7e79daa1fdbac04`.

Does not prove: any §9 gate, runtime behavior beyond the named tests, release/customer readiness, or correctness of preserved history rows.

## Acceptance outputs (tested at `72d9d08a9ff5fb47fa99b81de7e79daa1fdbac04`)

### Dead-home grep

Command:

```text
git grep -n '/Users/lume' -- . ':!qa/evidence' ':!qa/SCORECARD.md' ':!qa/scores_ledger.md' ':!docs/audits' ':!docs/research' ':!qa/test_export_campaign_artifacts.py' ':!qa/test_support_vm_preflight.py' ':!qa/test_macos_app_static.py' ':!qa/test_root_cause_analyzer.py'
```

Output (all textual matches carry the historical marker; Git also reports the untouched binary fixture `qa/scores.db`):

```text
WorldOS-OPERATING-GOAL.md:274:  support-VM preflight artifact gate. The local app/private-art checkout `/Users/lume/WorldOS` (historical path — /Users/lume/WorldOS; that machine is gone, see NOW.md) was
WorldOS-OPERATING-GOAL.md:276:  exact SHA from a clean same-disk worktree with `WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS` (historical path — /Users/lume/WorldOS; that machine is gone, see NOW.md).
WorldOS-OPERATING-GOAL.md:354:  provider, private art root at `/Users/lume/WorldOS` (historical path — /Users/lume/WorldOS; that machine is gone, see NOW.md), `can_act:true`, five enabled actions,
docs/KIMI-ONBOARDING.md:19:| Unity player install | `/Users/lume/Applications/WorldOSPlayer.app` (historical path — /Users/lume/Applications/WorldOSPlayer.app; that machine is gone, see NOW.md) | Jul 16 12:16 build |
qa/GUI_WORKBOOK.md:41:| G7 | Worktree/.app builds 404 images (no _private) | `_ingested_images_root()` (server.py:203) hardcoded to server.py's repo → worktree has no _private | Split code repo from art repo: viewer honors `WORLDOS_ART_REPO_ROOT`; native app has a Private art repo path and launch-root override for gate builds | Merged in #465; needs #466 full gate proof | 2026-05-31 smoke: worktree `dist/WorldOS.app` pid 69755 launched without killing canonical app; spawned worktree `viewer/server.py` on 8765; `/image?scope=location:loc-lower-city` returned `200 904100`; Info.plist root=`/Volumes/LEXAR/repos/worldos-takeover-stabilization`, art=`/Users/lume/WorldOS` (historical path — /Volumes/LEXAR/repos/worldos-takeover-stabilization and /Users/lume/WorldOS; that machine is gone, see NOW.md) |
qa/gate_corpus/builder.py:38:# /Users/lume/WorldOS/qa/transcripts/*.gate.txt (historical path — /Users/lume/WorldOS/qa/transcripts/*.gate.txt; that machine is gone, see NOW.md) at corpus-build time. A blank value means
Binary file qa/scores.db matches
qa/test_triage_failure.py:6:    uv run --directory /Users/lume/worldos-qa-p2b/servers/engine python -m pytest \  # historical path — /Users/lume/worldos-qa-p2b; that machine is gone, see NOW.md
qa/test_triage_failure.py:7:        /Users/lume/worldos-qa-p2b/qa/test_triage_failure.py -q -p no:xdist  # historical path — /Users/lume/worldos-qa-p2b; that machine is gone, see NOW.md
servers/engine/tests/test_codex_provider_wrapper.py:329:    assert "/Users/lume/.codex/skills/dungeon-master" not in source  # historical path — /Users/lume/.codex/skills/dungeon-master; that machine is gone, see NOW.md
```

### Fast gate

Command: `bash qa/fast_gate.sh`

```text
── FAST-GATE Tier 0 — deterministic engine + seat-path + rest/travel + combat (qa/fast_gate.sh) ──
  ✓ deterministic engine tier: 257 passed
✅ FAST-GATE T0 PASS — core engine loops + seat path intact ($0, deterministic).
   When iterating on DM-craft / UX, run the LLM probe next (rotated persona + ≥6-beat duo, ~13 min / ~$2.5).
   Before merge/release, run the milestone 5-persona sweep + RRI. See docs/qa/FAST_GATE.md.
```

### Focused tests (absolute paths)

Command: `uv run --directory servers/engine python -m pytest /Users/m1/worldos-wt-lume-sweep/qa/test_native_palette.py /Users/m1/worldos-wt-lume-sweep/qa/test_macos_app_static.py -q -p no:xdist`

```text
.........s.......s...................................                  [100%]
51 passed, 2 skipped, 2 subtests passed in 6.97s
```

### Syntax checks

```text
python3 -m py_compile /Users/m1/worldos-wt-lume-sweep/qa/app_handoff_gate.py /Users/m1/worldos-wt-lume-sweep/qa/drive_gfx_combat.py /Users/m1/worldos-wt-lume-sweep/qa/test_native_palette.py /Users/m1/worldos-wt-lume-sweep/qa/gate_corpus/builder.py /Users/m1/worldos-wt-lume-sweep/qa/test_triage_failure.py /Users/m1/worldos-wt-lume-sweep/servers/engine/tests/test_codex_provider_wrapper.py
exit 0 (no output)

bash -n /Users/m1/worldos-wt-lume-sweep/qa/lib_native_player_boot.sh /Users/m1/worldos-wt-lume-sweep/qa/ui_playtest_app.sh
exit 0 (no output)

node --check /Users/m1/worldos-wt-lume-sweep/qa/native_palette/native_palette_server.js
exit 0 (no output)
```

The mandated grep also surfaced one unlisted legacy test docstring path; it was annotated only so the acceptance predicate is satisfied, with no executable behavior change. `SPEC.md` remains ignored and uncommitted.
