### PR TITLE
qa: registry builder owns the four audited exclusions + off-repo refs default (follow-on to #1706)

### DIFF
--- a/.claude/skills/visual-critic/SKILL.md
+++ b/.claude/skills/visual-critic/SKILL.md
@@ -109,10 +109,10 @@ RENDER  (Unity CL pipeline: Tools/WorldOS/CL/0 → step-4 Scenario → step-5 as
   │       carry its stats into ④ synthesis alongside the verdict.
   │
   ├─② REFERENCE PICK  choose 2-3 refs/ frames matching scene.kind, **PoE2-first** (PoE2 is the bar;
-  │     a BG2 ref is added ONLY for the tactical-readability cross-check, a Disco ref ONLY for the
-  │     dark-pocket/mood cross-check): tavern→poe2_tavern (+bg2ee_temple for L5, +disco_cafeteria
-  │     for dark-pocket); outdoor→poe2_cliff (+bg2ee_forest for L5); dark→poe2_market
-  │     (+disco_office for mood, +bg2ee_cavern for L5). See refs/INDEX.md "How to use in the critic."
+  │     a Disco ref is added ONLY for the dark-pocket/mood cross-check; NO BG2EE frame — all four are
+  │     excluded as UI-chrome-contaminated, see the reference list below): tavern→poe2_tavern
+  │     (+disco_cafeteria for dark-pocket); outdoor→poe2_cliff; dark→poe2_market (+disco_office for
+  │     mood). See refs/INDEX.md "How to use in the critic."
   │
   ├─③ PANEL  fan out 6-7 LENS SUBAGENTS in parallel (Agent tool, model opus, run_in_background ok;
   │     L7 MOTION runs only when a reel was rendered). Each gets: the render path (L7 gets the reel

--- a/.claude/skills/visual-critic/SKILL.md
+++ b/.claude/skills/visual-critic/SKILL.md
@@ -180,7 +180,7 @@ to a sidecar JSON next to the capture. Run:
 
 ```bash
 python qa/visual_pregate.py --render /tmp/scene-r2.png \
-  --scenegrid /Volumes/LEXAR/WorldOS-Unity-spike/fixtures/tavern.scenegrid.json \
+  --scenegrid /Users/m1/worldos-unity/fixtures/tavern.scenegrid.json \
   --actors @/tmp/scene-r2.actors.json --json     # exit 2 == FLAG (CRITICAL/HIGH fired)
 ```
 
@@ -195,7 +195,7 @@ reproducible; treat it as a CI-style gate, not a hint.
 The critic does NOT score against a remembered look. It scores the GAP to 2-3 SPECIFIC reference
 frames it is shown alongside the render, with **PoE2 as the bar** and BG2/Disco only as the narrow
 cross-checks (see the §★ art-direction bar at the top). References live at
-`/Volumes/LEXAR/WorldOS-Unity-spike/refs/` (13 calibration frames, see `refs/INDEX.md`).
+`/Users/m1/Codex/worldos-refs/` (13 calibration frames, see `refs/INDEX.md`).
 Pick by scene kind (PoE2 ref ALWAYS leads; the bracketed cross-check ref is added only for its
 narrow lens):
 - **tavern / interior**: `poe2_tavern_interior_combat_02` (the bar: warm hearth key, cool room
@@ -428,7 +428,7 @@ Filler-first: ONE hero + ONE monster animating well before any roster.
 - **gen-scene**: author/lay-out an iso scene (`*.scenegrid.json`) → painterly plate (the CL
   pipeline step-4 Scenario canny) → place a probe actor → pre-gate + panel → iterate.
 - **assemble-encounter**: scene + hero + monster + the engine combat grid → render a beat →
-  full panel → iterate. (The CL pipeline at `/Volumes/LEXAR/WorldOS-Unity-spike/CLOSED-LOOP-PIPELINE.md`
+  full panel → iterate. (The CL pipeline at `/Users/m1/worldos-unity/CLOSED-LOOP-PIPELINE.md`
   is the canonical Unity render path; step-6 there IS this critic gate.)
 
 ## Anti-patterns
@@ -445,8 +445,8 @@ Filler-first: ONE hero + ONE monster animating well before any roster.
   (G1-G4) is the only single-run hard gate.
 
 ## Cross-refs
-- References + per-dimension map: `/Volumes/LEXAR/WorldOS-Unity-spike/refs/INDEX.md`.
-- Render pipeline: `/Volumes/LEXAR/WorldOS-Unity-spike/CLOSED-LOOP-PIPELINE.md` (the CL menu + Scenario step).
+- References + per-dimension map: `/Users/m1/Codex/worldos-refs/INDEX.md`.
+- Render pipeline: `/Users/m1/worldos-unity/CLOSED-LOOP-PIPELINE.md` (the CL menu + Scenario step).
 - `qa/visual_pregate.py` (deterministic gates G1–G5; G5 = motion-liveness), `qa/motion_reel.py`
   (build the L7 motion reel contact-sheet + JSON sidecar — MODE A engine-state reel / MODE B
   timeline reel), `qa/visual_regression.py` (worse-vs-baseline, still + motion arms),

--- a/.claude/skills/visual-critic/SKILL.md
+++ b/.claude/skills/visual-critic/SKILL.md
@@ -200,13 +200,15 @@ Pick by scene kind (PoE2 ref ALWAYS leads; the bracketed cross-check ref is adde
 narrow lens):
 - **tavern / interior**: `poe2_tavern_interior_combat_02` (the bar: warm hearth key, cool room
   ambient at ~3:1, blue-violet shadows, grounded soft contact shadows on plank floor)
-  [+ `bg2ee_temple_combat_lighting_04` for L5 tactical-readability; + `disco_cafeteria_bar_interior_03`
-  for the dark-pocket/mood cross-check].
-- **outdoor / wilderness**: `poe2_cliff_party_brushwork_03` (the bar) [+ `bg2ee_forest_party_tactical_01`
-  for L5 tactical-readability].
+  [+ `disco_cafeteria_bar_interior_03` for the dark-pocket/mood cross-check].
+- **outdoor / wilderness**: `poe2_cliff_party_brushwork_03` (the bar) — no L5 cross-check until a UI-free
+  BG2 frame is re-sourced (see the exclusion note below).
 - **dark zone / cavern / dungeon**: `poe2_market_interior_lighting_04` (the bar: chroma surviving
-  into shadow) [+ `disco_office_interior_lighting_04` for the dark-pocket/mood cross-check;
-  + `bg2ee_cavern_darkzone_lighting_03` for L5 blocked-cells-in-shadow readability].
+  into shadow) [+ `disco_office_interior_lighting_04` for the dark-pocket/mood cross-check].
+- ⛔ **BG2EE frames are EXCLUDED from every panel**: all four (`fortress_02`, `forest_01`, `cavern_03`,
+  `temple_04`) are UI-chrome-contaminated gameplay screenshots (registry `excluded` block; 2026-07-08 panel +
+  2026-07-09 audit) and the builder refuses to register them. Re-source cropped, UI-free BG2 frames before
+  any L5 tactical-readability cross-check returns.
 - **best single light-coherence anchor** (for L3, any scene): `poe2_market_interior_lighting_04`
   (warm-key + cool-fill + colored deferred lights, the PoE2 deferred look).
 These are INTERNAL calibration references only (not redistributed/reproduced/served, never a

--- a/qa/build_visual_controls.py
+++ b/qa/build_visual_controls.py
@@ -32,6 +32,7 @@ read from the pixels), only ``reference_frame_present`` is stamped false for the
 from __future__ import annotations
 
 import argparse
+import os
 import hashlib
 import json
 import sys
@@ -46,7 +47,7 @@ from control_band import control_band  # noqa: E402 — shared with build_artifa
 # The visual-critic reference frames live on the LEXAR spike drive (INTERNAL-only calibration set,
 # never shipped). A control's identity is intrinsic (its anchor/band/provenance), so the registry is
 # built from this manifest even when the drive is unmounted — only presence is probed.
-DEFAULT_REFS_DIR = Path("/Users/m1/Codex/worldos-refs")
+DEFAULT_REFS_DIR = Path(os.environ.get("WORLDOS_REFS_DIR", "/Users/m1/Codex/worldos-refs"))  # off-repo by design
 IDENTITY_PATH = QA_DIR / "visual_controls_identity.json"
 
 # The 0-10 visual panel scale (vs the 1-5 text rubric) — passed to the SHARED band helper.

--- a/qa/build_visual_controls.py
+++ b/qa/build_visual_controls.py
@@ -46,7 +46,7 @@ from control_band import control_band  # noqa: E402 — shared with build_artifa
 # The visual-critic reference frames live on the LEXAR spike drive (INTERNAL-only calibration set,
 # never shipped). A control's identity is intrinsic (its anchor/band/provenance), so the registry is
 # built from this manifest even when the drive is unmounted — only presence is probed.
-DEFAULT_REFS_DIR = Path("/Volumes/LEXAR/WorldOS-Unity-spike/refs")
+DEFAULT_REFS_DIR = Path("/Users/m1/Codex/worldos-refs")
 IDENTITY_PATH = QA_DIR / "visual_controls_identity.json"
 
 # The 0-10 visual panel scale (vs the 1-5 text rubric) — passed to the SHARED band helper.
@@ -82,16 +82,27 @@ def _frame_hash(filename: str) -> str:
 # The registered visual controls. Each is a REAL shipped plate (game = the painterly bar it exemplifies)
 # with a thematic tag for panel selection. class="room" — the visual class promote.py's gate serves
 # today (a backdrop plate is a room-class artifact); the field mirrors the text registry's per-class key.
-# bg2ee_fortress_party_tactical_02.jpg is intentionally ABSENT (disclosed-defective; see module docstring).
+# Disclosed-DEFECTIVE frames, excluded from the registry with the audit rationale (2026-07-08 panel +
+# the 2026-07-09 plate-style-regression audit). The builder owns this list so regenerating the
+# registry can never re-admit an audited-out control (review round on #1706).
+_EXCLUDED: dict[str, str] = {
+    "bg2ee_fortress_party_tactical_02.jpg":
+        "disclosed-defective control (baked-in UI chrome + wrong scene; 5/5 scorers flagged, scored 2-3/10 for reasons unrelated to painterly craft) \u2014 backdrop-cadence-20260708 market_square panel. A defective plate can never be a registered control.",
+    "bg2ee_forest_party_tactical_01.jpg":
+        "disclosed-defective control (full gameplay screenshot with baked-in UI chrome \u2014 portrait rail, action bar, dialogue text box \u2014 not a UI-free plate crop, violating the calibration protocol's own 'comparable resolution/crop/UI-free' requirement) \u2014 found during the plate-style-regression audit (2026-07-09) camp_clearing_night re-panel: scorer flagged it 1/10 for reasons unrelated to painterly craft. It had been registered as an active control (tag outdoor_forest) despite this defect predating this audit \u2014 removed from `controls` below; a defective plate can never be a registered control.",
+    "bg2ee_cavern_darkzone_lighting_03.jpg":
+        "disclosed-defective control \u2014 SAME defect class, found by direct visual inspection during the plate-style-regression audit (2026-07-09), not by a scorer this round: full gameplay screenshot with baked-in UI chrome (portrait rail, action bar, on-screen quest-text overlay). Never actually used as a panel control yet, so no scorer had flagged it, but it fails the calibration protocol's UI-free requirement on inspection. Removed from `controls` below.",
+    "bg2ee_temple_combat_lighting_04.jpg":
+        "disclosed-defective control \u2014 SAME defect class, found by direct visual inspection during the plate-style-regression audit (2026-07-09): full gameplay screenshot with baked-in UI chrome (portrait rail, action bar, floating combat-log text 'Lizard Man Elite did 10 damage to Gallus'). Removed from `controls` below. NOTE: with this entry, all 4 of the registry's baldurs-gate-2-ee controls (forest, fortress, cavern, temple) are now confirmed UI-chrome-contaminated and excluded \u2014 the whole BG2EE bucket needs re-sourcing (cropped, UI-free frames) before it can serve as a control again; the poe2_* and disco_* buckets were spot-checked (poe2_ruins_brazier_integration_01.jpg confirmed clean) and are not implicated by this finding, but were not exhaustively re-audited.",
+}
+
+# The four _EXCLUDED bg2ee frames are intentionally ABSENT from _FRAMES.
 _FRAMES: list[dict] = [
     {"file": "poe2_ruins_brazier_integration_01.jpg", "game": "pillars-of-eternity-2", "tag": "ruins_warm_key"},
     {"file": "poe2_tavern_interior_combat_02.jpg", "game": "pillars-of-eternity-2", "tag": "tavern_interior"},
     {"file": "poe2_cliff_party_brushwork_03.jpg", "game": "pillars-of-eternity-2", "tag": "outdoor_cliff"},
     {"file": "poe2_market_interior_lighting_04.jpg", "game": "pillars-of-eternity-2", "tag": "market_lit"},
     {"file": "poe2_temple_interior_lighting_05.jpg", "game": "pillars-of-eternity-2", "tag": "temple_cool_key"},
-    {"file": "bg2ee_forest_party_tactical_01.jpg", "game": "baldurs-gate-2-ee", "tag": "outdoor_forest"},
-    {"file": "bg2ee_cavern_darkzone_lighting_03.jpg", "game": "baldurs-gate-2-ee", "tag": "dark_zone"},
-    {"file": "bg2ee_temple_combat_lighting_04.jpg", "game": "baldurs-gate-2-ee", "tag": "combat_lit_interior"},
     {"file": "disco_whirling_plaza_brushwork_01.jpg", "game": "disco-elysium", "tag": "plaza_brushwork"},
     {"file": "disco_village_integration_02.jpg", "game": "disco-elysium", "tag": "outdoor_integration"},
     {"file": "disco_cafeteria_bar_interior_03.jpg", "game": "disco-elysium", "tag": "bar_interior"},
@@ -135,12 +146,7 @@ def build(refs_dir: Path) -> dict:
         "noise_law": NOISE_LAW,
         "scale_max": SCALE_MAX,
         "band_ruler": ruler,
-        "excluded": {
-            "bg2ee_fortress_party_tactical_02.jpg":
-                "disclosed-defective control (baked-in UI chrome + wrong scene; 5/5 scorers flagged, "
-                "scored 2-3/10 for reasons unrelated to painterly craft) — backdrop-cadence-20260708 "
-                "market_square panel. A defective plate can never be a registered control.",
-        },
+        "excluded": dict(_EXCLUDED),
         "controls": controls,
     }
 

--- a/qa/test_visual_promotion_gate.py
+++ b/qa/test_visual_promotion_gate.py
@@ -323,7 +323,8 @@ def test_visual_registry_bands_are_0_10_scale():
     # 13 frames minus the 4 disclosed-defective bg2ee frames (2026-07-08 panel + 2026-07-09 audit) —
     # the builder owns the exclusion list, so this count can only change with an audited decision.
     assert len(r["controls"]) == 9
-    assert set(r["excluded"]) == set(build_visual_controls._EXCLUDED) and len(r["excluded"]) == 4
+    assert set(r["excluded"]) == set(build_visual_controls._EXCLUDED)
+    assert len(r["excluded"]) == 4
 
 
 def test_committed_visual_registry_matches_builder():

--- a/qa/test_visual_promotion_gate.py
+++ b/qa/test_visual_promotion_gate.py
@@ -336,6 +336,7 @@ def test_committed_visual_registry_matches_builder():
         reg = json.loads(json.dumps(reg))
         for c in reg["controls"].values():
             c.pop("reference_frame_present", None)
+            c.pop("reference_frame", None)  # mount-dependent (WORLDOS_REFS_DIR); identity = file + provenance
         return reg
     assert _strip(committed)["controls"] == _strip(built)["controls"]
 

--- a/qa/test_visual_promotion_gate.py
+++ b/qa/test_visual_promotion_gate.py
@@ -320,7 +320,10 @@ def test_visual_registry_bands_are_0_10_scale():
     for c in r["controls"].values():
         assert c["band"] == cb.control_band(c["anchor"], noise=1.2, scale_max=10.0)
         assert c["band"][1] <= 10.0 and c["class"] == "room"
-    assert len(r["controls"]) == 12  # 13 frames minus the 1 excluded defective
+    # 13 frames minus the 4 disclosed-defective bg2ee frames (2026-07-08 panel + 2026-07-09 audit) —
+    # the builder owns the exclusion list, so this count can only change with an audited decision.
+    assert len(r["controls"]) == 9
+    assert set(r["excluded"]) == set(build_visual_controls._EXCLUDED) and len(r["excluded"]) == 4
 
 
 def test_committed_visual_registry_matches_builder():


### PR DESCRIPTION
#1706 auto-merged (05:26Z, head d3efcab4) minutes before its second review round was pushed, so the round's fixes never reached `main`. This carries them as one commit (files taken verbatim from the reviewed branch head 17a37da9):

- **Builder default** `DEFAULT_REFS_DIR` → `/Users/m1/Codex/worldos-refs` (the recovered, off-repo reference frames: 11 frames + INDEX.md).
- **Audited exclusions owned by the builder.** Regenerating the registry from the builder had silently re-admitted the three BG2EE frames the 2026-07-09 plate-style-regression audit excluded by hand (the builder only knew the fortress frame). `_EXCLUDED` carries all four with the audit rationale; `_FRAMES` omits them; the committed registry is the builder's exact output (9 controls, 4 excluded) — `test_committed_visual_registry_matches_builder` is no longer vacuous now that the refs dir exists on this host.
- **Test** asserts the count against `_EXCLUDED`.
- **visual-critic skill** refs/fixtures/CL-pipeline pointers → recovered locations (worldos-refs; the local Unity checkout).

Evidence: `qa/test_visual_promotion_gate.py` 34 passed (bare run, exit 0; log in session-notes artifacts). Claim class: `qa-registry-hygiene` — proves the registry cannot drift from the audited exclusions on regeneration; proves nothing about panel calibration.