### PR TITLE
registry: allowlist model_google-gemini-pro-image-editing as the kit-chain edit model (OWNER GATE — adoption record)

### DIFF
--- a/docs/MODEL-REGISTRY.md
+++ b/docs/MODEL-REGISTRY.md
@@ -15,7 +15,7 @@ model, training-data class, measured results, ROLE, and a verdict.
 1. **The adopted canonical plates use NO trained WorldOS LoRA.** camp (truegrey), tavern, and the crypt
    incumbent (`crypt_armb_iter3`, panel 8.0) are all **plain `model_bfl-flux-1-dev` + depth-ControlNet
    base → `model_google-gemini-3-1-flash` style pass.** The base geometry lock is flux.1-dev; the paint
-   quality is Gemini 3.1. That two-model chain *is* the canonical pipeline.
+   quality is Gemini 3.1. That two-model chain *is* the canonical pipeline. (paint-first era. For the 3D-first KIT chain the edit model is `model_google-gemini-pro-image-editing` — see the 2026-09-02 adoption record at the end of this file.)
 2. **The Architectural FLUX LoRA (`model_G379…`) is trained AI-on-AI.** 8 of its 10 training images are
    our OWN generated plates (`camp_clearing_night_v1/v2`, `crypt_dense_v1`, `crypt_firelit_v2`,
    `church_firelit_v1`, `cc2_nave`, `tavern_firelit_v1`, `seedream_undercroft`). A quality ceiling is
@@ -164,3 +164,14 @@ instrument validity rests on the anchor this round — full caveat in RANKED.md.
 **When you train/adopt/deprecate a model:** update BOTH `qa/model_registry.json` (the allowlist the gate
 reads) and this file (the human rationale). A DEPRECATED model stays in the allowlist so old plates that
 used it remain promotable; the `verdict` is advisory to humans, membership is the gate.
+
+## 2026-09-02 adoption record — the kit-chain edit model (refresh charter #1702, step 7)
+`model_google-gemini-pro-image-editing` (Gemini 3.0 Pro image edit) is the CANONICAL edit pass of the **3D-first kit chain**:
+geometry → `build_room_kit` → seg-registration ≥ 0.99 → the kit scene's own depth → flux depth-CN base → **structure-holding,
+critique-targeted Gemini 3 Pro edit** → `qa/styled_align_check.py` (phase-corr ALIGNED ≤ 1 px) → `qa/object_align_check.py`
+(per-object) → two-anchor blind panel. It produced the adopted **kit crypt v1** (#1688, 2026-07-23; panel 7 vs 8, Δ−1.0 in-band,
+dx=0) and **kit tavern v1/v2** (#1689, #1690 → #1703). The plates' manifest provenance had carried this model as "pending owner
+allowlist"; this record + the `qa/model_registry.json` entry close that. `model_google-gemini-3-1-flash` stays registered as the
+paint-first-era style pass (historical plates); it is not used by the kit chain. Known gap: this editor exposes no seed
+(determinism), and one edit deleted a table (fixed by the per-object gate + composite) — the 2026-09 Track B head-to-head
+(Gemini 4K refs · Qwen Image 3.0 Pro · FLUX.2 seeded) is the measured route to a successor, never a silent swap.

--- a/docs/ROOM-PIPELINE-RUNBOOK.md
+++ b/docs/ROOM-PIPELINE-RUNBOOK.md
@@ -237,7 +237,7 @@ IS blocking: the candidate regressing coherence on cells the incumbent passes.
 
 ### 6. Style pass — the reference-images LAW + structure/dimetric locks
 
-**Gemini instruction-edit** (`model_google-gemini-3-1-flash`) over the flux depth-CN base, with two
+**Gemini instruction-edit** (`model_google-gemini-3-1-flash` for paint-first plates; the 3D-first KIT chain uses `model_google-gemini-pro-image-editing` — see MODEL-REGISTRY.md, 2026-09-02 record) over the flux depth-CN base, with two
 mandatory prompt clauses. **★ No single reusable CLI wraps this exact step today — don't confuse it
 with two DIFFERENT, already-wired mechanisms that also touch Gemini:**
 - `generate_room.py --style-pass <json>` is a **z-image + LoRA img2img** pass (model/loras/

--- a/qa/model_registry.json
+++ b/qa/model_registry.json
@@ -1,7 +1,7 @@
 {
-  "_doc": "Machine-readable Scenario model registry \u2014 the allowlist the promote.py provenance gate checks a plate's model_chain against. HUMAN-readable companion + full audit: docs/MODEL-REGISTRY.md (#1553, M-ALIGN). A room plate may be promoted only if every model id in its recorded model_chain is listed here (in `models` or `approved_bases`). ADDITIVE by design: the gate is a NO-OP when this file is absent (default-allow) or when a candidate carries no model_chain (legacy). Update this file (and MODEL-REGISTRY.md) whenever a model is trained/adopted/deprecated \u2014 never delete a Scenario model (account rule), deprecate it here (verdict=DEPRECATED still keeps it registry-VALID so old plates stay promotable; the verdict is advisory to humans, the allowlist membership is the gate).",
-  "updated": "2026-07-11",
-  "issue": "#1553; #1556 (style-pass bake-off v2 \u2014 evaluated_1556 below, non-gating)",
+  "_doc": "Machine-readable Scenario model registry — the allowlist the promote.py provenance gate checks a plate's model_chain against. HUMAN-readable companion + full audit: docs/MODEL-REGISTRY.md (#1553, M-ALIGN). A room plate may be promoted only if every model id in its recorded model_chain is listed here (in `models` or `approved_bases`). ADDITIVE by design: the gate is a NO-OP when this file is absent (default-allow) or when a candidate carries no model_chain (legacy). Update this file (and MODEL-REGISTRY.md) whenever a model is trained/adopted/deprecated — never delete a Scenario model (account rule), deprecate it here (verdict=DEPRECATED still keeps it registry-VALID so old plates stay promotable; the verdict is advisory to humans, the allowlist membership is the gate).",
+  "updated": "2026-09-02",
+  "issue": "#1553; #1556 (style-pass bake-off v2 — evaluated_1556 below, non-gating)",
   "approved_bases": [
     "model_bfl-flux-1-dev",
     "flux.1-dev",
@@ -17,14 +17,14 @@
       "name": "FLUX.1 Dev (base)",
       "base": "flux.1-dev",
       "training_data": "n/a (foundation model)",
-      "role": "CANONICAL registered base \u2014 depth-ControlNet geometry lock for every adopted plate (camp truegrey, tavern, crypt_armb_iter3).",
+      "role": "CANONICAL registered base — depth-ControlNet geometry lock for every adopted plate (camp truegrey, tavern, crypt_armb_iter3).",
       "verdict": "CANONICAL"
     },
     "model_google-gemini-3-1-flash": {
       "name": "Gemini 3.1 Flash (style pass)",
       "base": "gemini-3-1-flash",
       "training_data": "n/a (foundation model)",
-      "role": "CANONICAL style pass \u2014 instruction-edit structure-lock enrichment over the registered flux depth-CN base. The paint quality of every adopted plate.",
+      "role": "CANONICAL style pass — instruction-edit structure-lock enrichment over the registered flux depth-CN base. The paint quality of every adopted plate.",
       "verdict": "CANONICAL"
     },
     "model_MB22WaRCBLtfhi5R2CRpHoEL": {
@@ -86,14 +86,22 @@
       "base": "flux.1-dev",
       "type": "flux.1-lora",
       "training_images": 10,
-      "training_data_class": "AI-ON-AI \u2014 8/10 training images are our OWN generated plates (camp_clearing_night_v1/v2, crypt_dense_v1, crypt_firelit_v2, church_firelit_v1, cc2_nave, tavern_firelit_v1, seedream_undercroft) + 2 props",
+      "training_data_class": "AI-ON-AI — 8/10 training images are our OWN generated plates (camp_clearing_night_v1/v2, crypt_dense_v1, crypt_firelit_v2, church_firelit_v1, cc2_nave, tavern_firelit_v1, seedream_undercroft) + 2 props",
       "role": "Interior depth-CN LoRA used in the crypt-rich experiment (asset_rYC4). Quality ceiling baked in by training on its own predecessors' AI output.",
       "verdict": "DEPRECATED"
+    },
+    "model_google-gemini-pro-image-editing": {
+      "name": "Gemini 3.0 Pro image edit (kit-chain structure-holding edit)",
+      "base": "gemini-3-pro-image-editing",
+      "training_data": "n/a (foundation model)",
+      "role": "CANONICAL edit pass for the 3D-FIRST KIT CHAIN: structure-holding, critique-targeted edit over the kit scene's own depth-conditioned flux base; gated by styled_align_check (phase-corr ALIGNED <=1px) + object_align_check (per-object) + the two-anchor panel. Adopted with kit crypt v1 (#1688, 2026-07-23) and kit tavern v1/v2 (#1689/#1690->#1703). gemini-3-1-flash remains the paint-first-era style pass.",
+      "verdict": "CANONICAL (kit chain)",
+      "adopted": "2026-07-23; registry record 2026-09-02 (refresh charter #1702, step 7)"
     }
   },
   "evaluated_1556": {
-    "_doc": "STYLE-PASS BAKE-OFF v2 (#1556): challengers run as ONE style pass over the fixed crypt base asset_BKn1kiX2c8BaifYj559yKx7Y (flux.1-dev depth-CN). INFORMATIONAL ONLY \u2014 these ids are deliberately NOT added to approved_bases/models: none beat the Gemini 3.1 incumbent (panel 8.0) so none is adopted; the promotion gate is unchanged. Full evidence: qa/evidence/1556/RANKED.md + panel/panel_verdict.json + gate_results.json.",
-    "protocol": "gate order: (1) edge-recall vs fixed base >=0.95, (2) net-new invented cells vs base+incumbent baseline (the raw >=0/==0 bars are miscalibrated for the walled crypt \u2014 see RANKED.md), (3) blind 5-scorer panel, Gemini anchor reproduced 8.0.",
+    "_doc": "STYLE-PASS BAKE-OFF v2 (#1556): challengers run as ONE style pass over the fixed crypt base asset_BKn1kiX2c8BaifYj559yKx7Y (flux.1-dev depth-CN). INFORMATIONAL ONLY — these ids are deliberately NOT added to approved_bases/models: none beat the Gemini 3.1 incumbent (panel 8.0) so none is adopted; the promotion gate is unchanged. Full evidence: qa/evidence/1556/RANKED.md + panel/panel_verdict.json + gate_results.json.",
+    "protocol": "gate order: (1) edge-recall vs fixed base >=0.95, (2) net-new invented cells vs base+incumbent baseline (the raw >=0/==0 bars are miscalibrated for the walled crypt — see RANKED.md), (3) blind 5-scorer panel, Gemini anchor reproduced 8.0.",
     "cu_spent": 111,
     "cu_cap": 120,
     "results": {
@@ -103,7 +111,7 @@
         "invented_net_new": 1,
         "panel_median": 8.0,
         "cu": 20,
-        "verdict": "INCUMBENT HOLDS \u2014 best on panel; carries a faint signature (fake-text 5/5). Already CANONICAL in models{}."
+        "verdict": "INCUMBENT HOLDS — best on panel; carries a faint signature (fake-text 5/5). Already CANONICAL in models{}."
       },
       "model_microsoft-mai-image-2-5-edit": {
         "name": "MAI Image 2.5 Edit (Microsoft/Fal)",
@@ -114,7 +122,7 @@
         "invented_net_new": 0,
         "panel_median": 7.0,
         "cu": 12,
-        "verdict": "CANDIDATE \u2014 strongest challenger: defect-clean, artifact-free (no signature), perfect structure-lock, cheapest edit. Did NOT beat the 8.0 incumbent this single-seed round. Worth a multi-seed re-run before any adoption (owner call). NOT allowlisted."
+        "verdict": "CANDIDATE — strongest challenger: defect-clean, artifact-free (no signature), perfect structure-lock, cheapest edit. Did NOT beat the 8.0 incumbent this single-seed round. Worth a multi-seed re-run before any adoption (owner call). NOT allowlisted."
       },
       "model_openai-gpt-image-2": {
         "name": "GPT Image 2 (OpenAI)",
@@ -126,8 +134,8 @@
         "invented_net_new": 3,
         "panel_median": 6.0,
         "cu": 45,
-        "access": "Scenario ONLY (metered 45 CU/img @high); the codex CLI has NO image-gen connector \u2014 only -i vision input. The \"~free Codex connector\" path does not exist for this pipeline.",
-        "verdict": "REJECT \u2014 clean but mid AND costliest (2.25x Gemini). Not worth it."
+        "access": "Scenario ONLY (metered 45 CU/img @high); the codex CLI has NO image-gen connector — only -i vision input. The \"~free Codex connector\" path does not exist for this pipeline.",
+        "verdict": "REJECT — clean but mid AND costliest (2.25x Gemini). Not worth it."
       },
       "model_bytedance-seedream-5-0-pro": {
         "name": "Seedream 5.0 Pro (ByteDance)",
@@ -139,7 +147,7 @@
         "invented_net_new": 4,
         "panel_median": null,
         "cu": 9,
-        "verdict": "REJECT \u2014 highest raw beauty but INVENTED an arched doorway where the base has solid wall (ADDITIONS-LOCK violation, confirmed by zoom overlay). Recall cannot catch additions. Rejected pre-panel."
+        "verdict": "REJECT — highest raw beauty but INVENTED an arched doorway where the base has solid wall (ADDITIONS-LOCK violation, confirmed by zoom overlay). Recall cannot catch additions. Rejected pre-panel."
       },
       "model_eJg6GZwd59vg4ycufRLyKsxL": {
         "name": "Flux Kontext Blockout-to-Render (Scenario LoRA)",
@@ -151,7 +159,7 @@
         "invented_net_new": 4,
         "panel_median": null,
         "cu": 16,
-        "verdict": "REJECT \u2014 fed the raw greybox in native blockout mode it scored 0.854 recall (< 0.95): geometry-AWARE but not geometry-LOCKED, and invented a glowing water pool. Not a substitute for the depth-CN-base -> style-edit chain."
+        "verdict": "REJECT — fed the raw greybox in native blockout mode it scored 0.854 recall (< 0.95): geometry-AWARE but not geometry-LOCKED, and invented a glowing water pool. Not a substitute for the depth-CN-base -> style-edit chain."
       },
       "model_a2dvNsgst7PCnpiucRY7bEHW": {
         "name": "El Diablo (Scenario isometric-dungeon flux.1 LoRA)",
@@ -160,7 +168,7 @@
         "invented_net_new": 0,
         "panel_median": 3.0,
         "cu": 9,
-        "verdict": "REJECT \u2014 clean gates but under-cooked: barely transforms the base; walls read as broken tiling. Weakest on the panel."
+        "verdict": "REJECT — clean gates but under-cooked: barely transforms the base; walls read as broken tiling. Weakest on the panel."
       },
       "model_ideogram-v4": {
         "name": "Ideogram V4 (Ideogram/Fal)",
@@ -169,7 +177,7 @@
         ],
         "panel_median": null,
         "cu": 0,
-        "verdict": "INELIGIBLE \u2014 txt2img-only on Scenario (no img2img edit), so it cannot perform a geometry-locked style pass. Same class as flux.2. Not run (0 CU)."
+        "verdict": "INELIGIBLE — txt2img-only on Scenario (no img2img edit), so it cannot perform a geometry-locked style pass. Same class as flux.2. Not run (0 CU)."
       }
     }
   }


### PR DESCRIPTION
Refresh charter #1702, Track A step 7. The adopted **kit crypt v1** (#1688) and **kit tavern v1/v2** (#1689, #1690 → #1703) plates were produced by the Gemini 3.0 Pro image edit — their manifest provenance says `model_google-gemini-pro-image-editing … pending owner allowlist` — but the machine-readable allowlist `qa/model_registry.json` (read by `qa/plate_loop.py` and the promotion-gate tests) and `docs/MODEL-REGISTRY.md` still name only `model_google-gemini-3-1-flash`.

This PR records the adoption:
- `qa/model_registry.json`: new entry `model_google-gemini-pro-image-editing`, verdict `CANONICAL (kit chain)`, with the gate chain it sits in; `updated` → 2026-09-02.
- `docs/MODEL-REGISTRY.md`: a 2026-09-02 adoption record (what it produced, what still gates it, the known determinism gap and the measured route to any successor); the 3-1-flash pass is kept as the paint-first-era style pass.
- `docs/ROOM-PIPELINE-RUNBOOK.md` step 6: names the kit-chain editor.

Tests: `qa/test_visual_promotion_gate.py` 34 passed (bare run). **Owner gate:** allowlisting a model is the July "registry allowlist (OWNER GATE)" item — auto-merge intentionally NOT armed; merging = approval. Claim class: `docs+allowlist-record`; proves nothing about plate quality beyond the cited gates.