### PR TITLE
qa_sandbox: windowed, badged, leak-safe QA player launch (never fullscreen again) — #1672

### DIFF
--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -501,14 +501,29 @@ reverts the goal to "fix" and outranks new work.
 it launched with no Unity window args, inherited the shared plist's fullscreen + native resolution,
 took over the developer's only display and the Mac had to be rebooted. Now:
 
-- Every sandbox launch is **windowed** (`-screen-fullscreen 0 -screen-width 1280 -screen-height 697
+- Every sandbox launch is **windowed** (`-screen-fullscreen 0 -screen-width 1280 -screen-height 700
   -logFile <rundir>/unity_player.log`) and fitted to the real desktop. Never fullscreen.
+  **Units:** `-screen-width/-screen-height` are a Unity RESOLUTION — *backing pixels* — while the
+  desktop budget and every CGWindowList bound are *points*. Measured host: **1512x835 points,
+  3024x1670 pixels, scale 2**; the 1280x700 request rendered a **640x382 point** window and `/health`
+  reported `1280x700`.
 - An **owner-active guard** (ioreg `HIDIdleTime` < 120 s) refuses to launch and exits **75** with
   `SANDBOX-DEFERRED (owner active)`. Override with `FORCE_PLAYER_QA=1` when you are not at the Mac.
-- A permission-free CGWindowList **watchdog** tears the run down within ~25 s if the window comes up
-  fullscreen or effectively offscreen. `/health` geometry is then asserted (1x or 2x HiDPI).
-- The bundle id is SHARED, so the rig never writes the plist; `down` snapshots → diffs → **restores**
-  `~/Library/Preferences/com.worldos.WorldOSPlayer.plist` and writes `<rundir>/prefs_leak.json`.
+- A permission-free CGWindowList **watchdog** runs on every readiness poll — and on demand via
+  `qa/qa_sandbox.py watchdog --run <run>`, which is what you run periodically during a long sweep. A
+  fullscreen verdict kills the rig's own player immediately and exits **3**; an offscreen one tears
+  the run down. `/health` is then held to a coverage bound (< 60 % of the display's backing-pixel
+  area), not to an exact size — Unity is allowed to adjust the resolution it was asked for.
+- `CFFIXED_USER_HOME=<rundir>/home` gives the rig its own `Application Support`, so its `/shot`
+  frames land under the run dir instead of racing the owner's instance in the shared shot directory.
+  Consumers need no change (`walk_test._capture_shot`, and `adventure_walk` / `player_cert` through
+  it, copy the absolute path `/shot` returns). It does **not** redirect PlayerPrefs.
+- The bundle id is SHARED, so the rig never writes the plist itself — Unity does, on quit. `down`
+  snapshots the whole domain, diffs it, and restores **attribution-safely**: a key is rewritten only
+  if it changed AND still holds the exact value this rig writes (`Fullscreen mode`=3, the requested
+  `Resolution Width/Height`, `Use Native`=0). The cosmetic `Window Position X/Y`, anything the owner
+  wrote last, and any non-integer value are REPORTED and left alone. See `<rundir>/prefs_leak.json`
+  and the `stopped` block in `sandbox.json.stopped`.
 - **Telling them apart today:** window geometry, `lsof -nP -iTCP:8972 -sTCP:LISTEN -t` (owner = 8971),
   and `sandbox.json`. The rig's window TITLE is still `WorldOSPlayer` — the badge is Phase 2,
   `docs/qa/QA-RIG-WINDOW-BADGE.md`.

--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -495,6 +495,26 @@ every PR touching `viewer/ | macos/ | skills/ | servers/engine/` → rebuild + R
 any regression (a critical bug, a sub-7 persona, sub-threshold score, image <95%, dead palette)
 reverts the goal to "fix" and outranks new work.
 
+## QA rig vs the owner's game (#1672 — incident 2026-09-02)
+
+`qa/qa_sandbox.py` runs a SECOND instance of the same `.app` with the same bundle id. On 2026-09-02
+it launched with no Unity window args, inherited the shared plist's fullscreen + native resolution,
+took over the developer's only display and the Mac had to be rebooted. Now:
+
+- Every sandbox launch is **windowed** (`-screen-fullscreen 0 -screen-width 1280 -screen-height 697
+  -logFile <rundir>/unity_player.log`) and fitted to the real desktop. Never fullscreen.
+- An **owner-active guard** (ioreg `HIDIdleTime` < 120 s) refuses to launch and exits **75** with
+  `SANDBOX-DEFERRED (owner active)`. Override with `FORCE_PLAYER_QA=1` when you are not at the Mac.
+- A permission-free CGWindowList **watchdog** tears the run down within ~25 s if the window comes up
+  fullscreen or effectively offscreen. `/health` geometry is then asserted (1x or 2x HiDPI).
+- The bundle id is SHARED, so the rig never writes the plist; `down` snapshots → diffs → **restores**
+  `~/Library/Preferences/com.worldos.WorldOSPlayer.plist` and writes `<rundir>/prefs_leak.json`.
+- **Telling them apart today:** window geometry, `lsof -nP -iTCP:8972 -sTCP:LISTEN -t` (owner = 8971),
+  and `sandbox.json`. The rig's window TITLE is still `WorldOSPlayer` — the badge is Phase 2,
+  `docs/qa/QA-RIG-WINDOW-BADGE.md`.
+- Stray rig left by a crashed run: `qa/qa_sandbox.py orphans`. **Never**
+  `osascript -e 'quit app "WorldOSPlayer"'` — that kills the owner's instance too.
+
 ## Hard rules (carried from CLAUDE.md + this session's lessons)
 - Engine (`servers/engine`) = SOLE writer of campaign state. Don't touch wire contracts
   (`worldos-*`/`WORLDOS_*` MCP ids, `dev.worldos.app`); you MAY read `WORLDOS_ART_REPO_ROOT`.

--- a/docs/ROOM-PIPELINE-RUNBOOK.md
+++ b/docs/ROOM-PIPELINE-RUNBOOK.md
@@ -504,12 +504,17 @@ python3 qa/walk_test.py --room <room> --engine http://127.0.0.1:8866 --qa http:/
 **★ The rig is WINDOWED and refuses to launch over you (#1672 — incident 2026-09-02).** `up` exits
 **75** with `SANDBOX-DEFERRED (owner active)` if you touched the Mac in the last 120 s
 (`FORCE_PLAYER_QA=1` overrides; `WORLDOS_PLAYER_IDLE_THRESHOLD` retunes). The player launches
-`-screen-fullscreen 0 -screen-width 1280 -screen-height 697`, is watchdogged against fullscreen /
-offscreen from the window server's own bounds, and hands keyboard focus back afterwards. Size knobs:
-`WORLDOS_PLAYER_WIN_W` / `_WIN_H` (fit-clamped; never below the display's aspect, or sample cells
-crop out of the ortho frame). `down` leak-checks and restores the SHARED
-`com.worldos.WorldOSPlayer` plist and writes `<rundir>/prefs_leak.json`; `qa/qa_sandbox.py orphans`
-finds a rig stranded by a crashed run. The rig's window TITLE is still `WorldOSPlayer` until the
+`-screen-fullscreen 0 -screen-width 1280 -screen-height 700` (a Unity RESOLUTION, i.e. **backing
+pixels** — on this 2x host, 1512x835 points / 3024x1670 pixels, that is a 640x382 point window), is
+watchdogged against fullscreen / offscreen from the window server's own bounds on every readiness
+poll, and hands keyboard focus back **by pid** afterwards. Run `qa/qa_sandbox.py watchdog --run
+<run>` periodically during a long sweep: a fullscreen verdict kills the rig player and exits **3**.
+Size knobs: `WORLDOS_PLAYER_WIN_W` / `_WIN_H` (fit-clamped; never below the display's aspect, or
+sample cells crop out of the ortho frame). The rig gets its own `CFFIXED_USER_HOME=<rundir>/home`, so
+its `/shot` frames cannot collide with the owner instance's. `down` leak-checks the SHARED
+`com.worldos.WorldOSPlayer` plist and restores only keys that still hold the value this rig writes
+(everything else is reported, never rewritten) into `<rundir>/prefs_leak.json`; `qa/qa_sandbox.py
+orphans` finds a rig stranded by a crashed run. The rig's window TITLE is still `WorldOSPlayer` until the
 Phase 2 badge lands — `docs/qa/QA-RIG-WINDOW-BADGE.md`.
 
 TRAPS (each cost a real debugging round):

--- a/docs/ROOM-PIPELINE-RUNBOOK.md
+++ b/docs/ROOM-PIPELINE-RUNBOOK.md
@@ -501,6 +501,17 @@ python3 qa/walk_test.py --room <room> --engine http://127.0.0.1:8866 --qa http:/
     --visual 5 --out qa/evidence/walk-<room>
 ```
 
+**★ The rig is WINDOWED and refuses to launch over you (#1672 — incident 2026-09-02).** `up` exits
+**75** with `SANDBOX-DEFERRED (owner active)` if you touched the Mac in the last 120 s
+(`FORCE_PLAYER_QA=1` overrides; `WORLDOS_PLAYER_IDLE_THRESHOLD` retunes). The player launches
+`-screen-fullscreen 0 -screen-width 1280 -screen-height 697`, is watchdogged against fullscreen /
+offscreen from the window server's own bounds, and hands keyboard focus back afterwards. Size knobs:
+`WORLDOS_PLAYER_WIN_W` / `_WIN_H` (fit-clamped; never below the display's aspect, or sample cells
+crop out of the ortho frame). `down` leak-checks and restores the SHARED
+`com.worldos.WorldOSPlayer` plist and writes `<rundir>/prefs_leak.json`; `qa/qa_sandbox.py orphans`
+finds a rig stranded by a crashed run. The rig's window TITLE is still `WorldOSPlayer` until the
+Phase 2 badge lands — `docs/qa/QA-RIG-WINDOW-BADGE.md`.
+
 TRAPS (each cost a real debugging round):
 - **Gate the room the party is IN.** `walk_test --room B` while the fixture spawned the party in
   room A silently measures room A (identical counts, wrong camera). Multi-room fixtures take a

--- a/docs/qa/QA-RIG-WINDOW-BADGE.md
+++ b/docs/qa/QA-RIG-WINDOW-BADGE.md
@@ -1,0 +1,94 @@
+# QA rig vs the owner's game — window policy and the #1672 badge
+
+Incident, 2026-09-02: `qa/qa_sandbox.py up` launched a second instance of
+`/Users/m1/worldos-unity/BuildOutput/WorldOSPlayer.app` with **no Unity window arguments**. It
+inherited the SHARED preferences domain's `Screenmanager Fullscreen mode = 1` +
+`Screenmanager Resolution Use Native = 1`, came up fullscreen on the developer's only display during
+a gate run, and the Mac had to be rebooted.
+
+## Phase 1 — SHIPPED (launch side, current build, no rebuild)
+
+In `qa/qa_sandbox.py` + `qa/lib_qa_window.py`. See the `qa_sandbox.py` module docstring for the
+operator-facing summary. In brief:
+
+| Fence | Where |
+|---|---|
+| `-screen-fullscreen 0 -screen-width 1280 -screen-height 697 -logFile <rundir>/unity_player.log` | `qa_sandbox._player_windowed_args()` |
+| owner-active guard (ioreg `HIDIdleTime`, `FORCE_PLAYER_QA=1`, exit `75`) | `qa_sandbox.owner_active_guard()` |
+| player is its own `Popen`; `caffeinate -is -w <pid>` is a **sibling** watcher | `qa_sandbox.up()` |
+| `sandbox.json` written **before** the readiness wait (anti-orphan fence) | `qa_sandbox.up()` |
+| CGWindowList fullscreen/offscreen watchdog (~25 s, permission-free) | `lib_qa_window.{fullscreen,offscreen}_verdict()` |
+| `/health` achieved-geometry assertion (polled; accepts 1x and 2x) | `qa_sandbox._assert_windowed()` |
+| focus restored via `open -a <frontmost-before>` (Launch Services, no TCC/AX) | `lib_qa_window.restore_front()` |
+| shared-plist snapshot → diff → restore, and a two-sensor orphan scan | `qa_sandbox.down()` |
+
+**Size rationale.** The display is one screen, 2984x1634 backing / **1492x817 points** (aspect
+1.826), ~792 usable after the menu bar — so the shell lane's 1280x**800** does not fit. 1280x**700**
+is aspect 1.829 ≥ 1.826, so the ortho crop (`walk_test.world_to_window_px`) shows *at least as much*
+horizontal world as the fullscreen baseline and no sample cell that was in frame falls out.
+
+**What Phase 1 does NOT do.** The rig's macOS window title is still `WorldOSPlayer`
+(`ProjectSettings.asset:16 productName`, re-asserted in `BuildMacOSPlayer.cs`). Today the rig is
+distinguished by window geometry, `lsof -nP -iTCP:8972 -sTCP:LISTEN -t` (owner = 8971), and
+`sandbox.json`. #1672 item 4 (the badge) is Phase 2.
+
+## Phase 2 — NOT IN THIS PR (needs an Editor rebuild)
+
+`extensions/renderers/unity/scripts/CombatSurfaceClient.cs`. **Zero `ProjectSettings` /
+`PlayerSettings` changes**, so an un-env'd launch stays byte-identical for the owner. The whole
+change hangs off the existing `WORLDOS_QA_INPUT == "1"` gate — the one line that already separates
+rig from owner.
+
+1. **`:563`** — `if (Environment.GetEnvironmentVariable("WORLDOS_QA_INPUT") == "1") StartQaInput();`
+   becomes `{ ApplyQaWindowPolicy(); StartQaInput(); }`.
+
+2. **New `ApplyQaWindowPolicy()`**, beside the QA block at `:2547-2596`:
+   - re-assert `Application.runInBackground = true` (already set at `:508`);
+   - read `WORLDOS_QA_WIN_W` / `WORLDOS_QA_WIN_H` (defaults 1280/700), clamped against
+     `Screen.mainWindowDisplayInfo`;
+   - snapshot the four shared `Screenmanager` PlayerPrefs into `_qaPrefsBefore`;
+   - `if (Screen.fullScreen || Screen.width != w || Screen.height != h)
+      Screen.SetResolution(w, h, FullScreenMode.Windowed);`
+   - build a **static** `_qaBadge` string:
+     `"QA RIG — NOT YOUR GAME · qa :" + WORLDOS_QA_INPUT_PORT + " · pid " + pid`;
+   - start `QaPlaceWindowCo(w, h)`.
+
+3. **`QaPlaceWindowCo`** — wait out the async `SetResolution`, then
+   `Screen.MoveMainWindowTo(ref di, pos)` parking bottom-right but **fully on-screen** (clamp so
+   ≥ 220x120 points stay on the display), awaiting `op.isDone`. **Never** minimize, hide, push
+   offscreen, or use `-batchmode`: `runInBackground` governs the update loop, not presentation, and a
+   window with no on-screen surface hands `ScreenCapture` (`:2353-2354`) a black or frozen
+   backbuffer **with no HTTP error** — `walk_test` reads that as "the actor never moved". Log
+   `"[CSC] QA window WxH windowed @(x,y) fullScreen=False"` so the run dir carries the receipt.
+
+4. **`DrawQaBadge()` must be the FIRST statement of `OnGUI()` (`:2368`).** `:2371` is
+   `if (string.IsNullOrEmpty(_advMsg)) return;` — anything placed after it renders only while an
+   advisory is up. Fixed `Rect(8, 8, 560, 26)` top-left, red `DrawTexture` + `GUI.Label`, no click
+   consumption. **STRICTLY STATIC** content: no clock, counter, fade or pulse. An animated badge is a
+   large stable-position diff blob that can win the nearest-neighbour race at
+   `walk_test.py:236-254`. Enforced by `qa/test_qa_sandbox_window.py::test_csharp_qa_window_policy`
+   (currently `xfail`).
+
+5. **`OnApplicationQuit()` (`:2706`)** → `{ StopQaInput(); QaRestoreScreenPrefs(); }`, restoring
+   `_qaPrefsBefore`. This is a **backstop only** — Unity's ScreenManager may persist after
+   `OnApplicationQuit`, so the Python snapshot/diff/restore in `qa_sandbox.down()` stays the
+   authority and its verdict is what the gate reads.
+
+**Keep BOTH halves, permanently.** `ApplyQaWindowPolicy` runs in `Start()`, i.e. after the window
+already exists, and both `SetResolution` and `MoveMainWindowTo` are async — a flag-less launch would
+still FLASH fullscreen on the owner's only display for several frames. The CLI flags prevent the
+flash; the C# guarantees windowed+badged however the rig is started (double-click, `open`, a future
+lane that forgets the flags). **Do not remove the launch flags after the rebuild.**
+
+**Not achievable, do not promise it.** There is no Unity API to set the macOS window **title** — it
+is `productName`. A true title badge needs a native plugin, or a separate QA build with its own
+`productName` + bundle id (which would also dissolve the shared plist and the shared
+`persistentDataPath`, at the cost of a second build to maintain and an ad-hoc re-sign). The IMGUI
+banner is the no-plugin answer.
+
+## Still open after Phase 2
+
+- Shared `persistentDataPath` `/shot` collision: both instances write `wos_shot_<id>.png` into
+  `~/Library/Application Support/com.worldos.WorldOSPlayer` with per-**process** counters
+  (`CombatSurfaceClient.cs:2594, 2650-2653`). #1582 fixed intra-process races only. The owner-active
+  guard makes concurrency unlikely; it is **not** an interlock.

--- a/docs/qa/QA-RIG-WINDOW-BADGE.md
+++ b/docs/qa/QA-RIG-WINDOW-BADGE.md
@@ -13,19 +13,31 @@ operator-facing summary. In brief:
 
 | Fence | Where |
 |---|---|
-| `-screen-fullscreen 0 -screen-width 1280 -screen-height 697 -logFile <rundir>/unity_player.log` | `qa_sandbox._player_windowed_args()` |
+| `-screen-fullscreen 0 -screen-width 1280 -screen-height 700 -logFile <rundir>/unity_player.log` (a Unity RESOLUTION, i.e. **backing pixels**) | `qa_sandbox._player_windowed_args()` |
+| per-run `CFFIXED_USER_HOME=<rundir>/home` (own `Application Support`; `/shot` cannot collide) | `qa_sandbox.up()` |
 | owner-active guard (ioreg `HIDIdleTime`, `FORCE_PLAYER_QA=1`, exit `75`) | `qa_sandbox.owner_active_guard()` |
 | player is its own `Popen`; `caffeinate -is -w <pid>` is a **sibling** watcher | `qa_sandbox.up()` |
 | `sandbox.json` written **before** the readiness wait (anti-orphan fence) | `qa_sandbox.up()` |
-| CGWindowList fullscreen/offscreen watchdog (~25 s, permission-free) | `lib_qa_window.{fullscreen,offscreen}_verdict()` |
-| `/health` achieved-geometry assertion (polled; accepts 1x and 2x) | `qa_sandbox._assert_windowed()` |
-| focus restored via `open -a <frontmost-before>` (Launch Services, no TCC/AX) | `lib_qa_window.restore_front()` |
-| shared-plist snapshot → diff → restore, and a two-sensor orphan scan | `qa_sandbox.down()` |
+| CGWindowList fullscreen/offscreen watchdog on EVERY readiness poll + `qa_sandbox.py watchdog` (permission-free; fullscreen ⇒ kill the rig player, exit `3`) | `qa_sandbox._watchdog()` |
+| `/health` coverage bound (polled; < 60 % of the display's backing-pixel area — not an exact size) | `qa_sandbox._assert_windowed()` |
+| focus restored **by pid** via System Events (never `open -a`, which would LAUNCH a player) | `lib_qa_window.restore_front()` |
+| whole-domain plist snapshot → diff → **attribution-safe** restore, and a two-sensor orphan scan | `qa_sandbox.down()` |
+| recorded pgid re-verified before anything is signalled (pid reuse) | `qa_sandbox._kill_group()` |
 
-**Size rationale.** The display is one screen, 2984x1634 backing / **1492x817 points** (aspect
-1.826), ~792 usable after the menu bar — so the shell lane's 1280x**800** does not fit. 1280x**700**
-is aspect 1.829 ≥ 1.826, so the ortho crop (`walk_test.world_to_window_px`) shows *at least as much*
-horizontal world as the fullscreen baseline and no sample cell that was in frame falls out.
+**Size rationale + UNITS.** `-screen-width/-screen-height` are a Unity RESOLUTION — *backing
+pixels* — while the desktop budget and every CGWindowList bound are *points*, so the fit clamp
+converts the point budget with the display's backing scale before comparing. Measured 2026-09-02:
+**1512x835 points / 3024x1670 pixels, scale 2**; the 1280x700 request produced a **640x382 point**
+window and `/health` reported `1280x700`. 1280x700 is aspect 1.829 ≥ the display's, so the ortho crop
+(`walk_test.world_to_window_px`) shows *at least as much* horizontal world as the fullscreen baseline
+and no sample cell that was in frame falls out.
+
+**Restore rule (what `down` will and will not write).** The domain is SHARED, so a blind restore
+would silently revert the owner's own settings. A key is rewritten only when it changed since `up`
+AND still holds the exact value this rig deterministically writes — `Screenmanager Fullscreen mode`
+`3`, `Screenmanager Resolution Width/Height` = the size actually requested, `Screenmanager Resolution
+Use Native` `0` — and only after integer validation. `Screenmanager Window Position X/Y` (cosmetic),
+any key the owner wrote last, and the `unity.player_*` churn keys are reported and left alone.
 
 **What Phase 1 does NOT do.** The rig's macOS window title is still `WorldOSPlayer`
 (`ProjectSettings.asset:16 productName`, re-asserted in `BuildMacOSPlayer.cs`). Today the rig is

--- a/qa/lib_qa_window.py
+++ b/qa/lib_qa_window.py
@@ -336,7 +336,7 @@ def front_app():
     try:
         p = subprocess.run(
             ["/usr/bin/osascript", "-e",
-             'tell application "System Events" to tell (first application process whose '
+             'tell application "System Events" to tell (first application process whose ' +
              'frontmost is true) to get {name, unix id}'],
             capture_output=True, text=True, timeout=10)
     except Exception:  # noqa: BLE001

--- a/qa/lib_qa_window.py
+++ b/qa/lib_qa_window.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""READ-ONLY macOS window sensors for the QA sandbox lane (#1672 / incident 2026-09-02).
+
+Why this exists: `qa/qa_sandbox.py` launches a SECOND instance of the owner's player. On
+2026-09-02 it came up FULLSCREEN on the developer's only display and took over the machine.
+The launch-side fix is Unity's own `-screen-fullscreen 0 -screen-width/-screen-height`, but a
+flag that is ignored (a future Unity, a bad build, a plist regression) must not be able to lock
+the machine again. This module is the INDEPENDENT sensor that proves the window really is
+windowed and really is on the display, from the window server's own bounds — not from the
+player's self-reported /health.
+
+Hard design rules, all load-bearing:
+  * READ ONLY. Nothing here moves, resizes, minimizes, hides, activates or quits a window.
+  * NO Accessibility (AX) / `System Events` window scripting. AX availability here is
+    NONDETERMINISTIC (TCC attributes the grant to the responsible parent app: the same probe
+    returned `-1719 not allowed assistive access` from one launch context and `83, 30` rc=0 from
+    another), and `ProjectSettings.asset:103 resizableWindow = 0` makes AXSize unsettable anyway.
+    Sizing comes from the CLI flags; this module only VERIFIES.
+  * NO pyobjc (`import Quartz` is ModuleNotFoundError on this host's system python3) — ctypes
+    against CoreGraphics/CoreFoundation only.
+  * `CGWindowListCopyWindowInfo` needs NO TCC grant for bounds/pid/layer. Only kCGWindowName is
+    withheld without Screen Recording, so every check here keys on BOUNDS, never on a title.
+  * Identity is always a PID we started. Never a process name — the owner's live game is the same
+    executable with the same bundle id.
+"""
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import os
+import subprocess
+import time
+
+# fraction of the main display's area at or above which a window counts as a takeover
+FULLSCREEN_COVER_FRAC = float(os.environ.get("WORLDOS_QA_MAX_COVER_FRAC", "0.85"))
+# a window must keep at least this much of itself on the display, or ScreenCapture can hand back
+# black/stale frames with no HTTP error (runInBackground governs the update loop, not presentation)
+MIN_ONSCREEN_W, MIN_ONSCREEN_H = 220, 120
+
+kCGWindowListOptionOnScreenOnly = 1 << 0
+kCGWindowListExcludeDesktopElements = 1 << 4
+kCFStringEncodingUTF8 = 0x08000100
+kCFNumberDoubleType = 13
+
+
+def _load():
+    cf = ctypes.CDLL(ctypes.util.find_library("CoreFoundation"))
+    cg = ctypes.CDLL(ctypes.util.find_library("CoreGraphics"))
+    cf.CFArrayGetCount.restype = ctypes.c_long
+    cf.CFArrayGetCount.argtypes = [ctypes.c_void_p]
+    cf.CFArrayGetValueAtIndex.restype = ctypes.c_void_p
+    cf.CFArrayGetValueAtIndex.argtypes = [ctypes.c_void_p, ctypes.c_long]
+    cf.CFDictionaryGetValue.restype = ctypes.c_void_p
+    cf.CFDictionaryGetValue.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    cf.CFStringCreateWithCString.restype = ctypes.c_void_p
+    cf.CFStringCreateWithCString.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_uint32]
+    cf.CFStringGetCString.restype = ctypes.c_bool
+    cf.CFStringGetCString.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_long, ctypes.c_uint32]
+    cf.CFNumberGetValue.restype = ctypes.c_bool
+    cf.CFNumberGetValue.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p]
+    cf.CFRelease.argtypes = [ctypes.c_void_p]
+    cg.CGWindowListCopyWindowInfo.restype = ctypes.c_void_p
+    cg.CGWindowListCopyWindowInfo.argtypes = [ctypes.c_uint32, ctypes.c_uint32]
+    cg.CGMainDisplayID.restype = ctypes.c_uint32
+    cg.CGDisplayPixelsWide.restype = ctypes.c_size_t
+    cg.CGDisplayPixelsWide.argtypes = [ctypes.c_uint32]
+    cg.CGDisplayPixelsHigh.restype = ctypes.c_size_t
+    cg.CGDisplayPixelsHigh.argtypes = [ctypes.c_uint32]
+    return cf, cg
+
+
+try:                                   # a non-macOS/CI host must import cleanly, not explode
+    _CF, _CG = _load()
+except Exception:                      # noqa: BLE001
+    _CF = _CG = None
+
+
+def _cfstr(py: str):
+    return _CF.CFStringCreateWithCString(None, py.encode("utf-8"), kCFStringEncodingUTF8)
+
+
+def _to_str(ref) -> str:
+    if not ref:
+        return ""
+    buf = ctypes.create_string_buffer(1024)
+    if _CF.CFStringGetCString(ref, buf, 1024, kCFStringEncodingUTF8):
+        return buf.value.decode("utf-8", "replace")
+    return ""
+
+
+def _to_num(ref) -> float:
+    if not ref:
+        return 0.0
+    out = ctypes.c_double(0.0)
+    _CF.CFNumberGetValue(ref, kCFNumberDoubleType, ctypes.byref(out))
+    return float(out.value)
+
+
+def main_display_points() -> tuple:
+    """(width, height) of the MAIN display in POINTS (the current mode's logical size).
+
+    On this host: (1492, 817) — one display, "Screen Sharing Virtual Display", 2984x1634 backing.
+    Returns (0, 0) when CoreGraphics is unavailable; every caller treats that as "cannot judge".
+    """
+    if _CG is None:
+        return (0, 0)
+    try:
+        did = _CG.CGMainDisplayID()
+        return (int(_CG.CGDisplayPixelsWide(did)), int(_CG.CGDisplayPixelsHigh(did)))
+    except Exception:  # noqa: BLE001
+        return (0, 0)
+
+
+def cg_windows(pid=None, owner=None) -> list:
+    """On-screen windows as {pid, owner, layer, name, bounds:{X,Y,Width,Height}}.
+
+    Needs NO TCC grant for pid/layer/bounds. `name` is often "" without Screen Recording — that is
+    expected, and is exactly why nothing in this module keys on a window title.
+    """
+    if _CF is None or _CG is None:
+        return []
+    opt = kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements
+    arr = _CG.CGWindowListCopyWindowInfo(opt, 0)
+    if not arr:
+        return []
+    keys = [_cfstr(k) for k in ("kCGWindowOwnerPID", "kCGWindowOwnerName", "kCGWindowLayer",
+                                "kCGWindowName", "kCGWindowBounds", "X", "Y", "Width", "Height")]
+    k_pid, k_owner, k_layer, k_name, k_bounds, k_x, k_y, k_w, k_h = keys
+    out: list = []
+    try:
+        for i in range(_CF.CFArrayGetCount(arr)):
+            d = _CF.CFArrayGetValueAtIndex(arr, i)
+            wpid = int(_to_num(_CF.CFDictionaryGetValue(d, k_pid)))
+            wown = _to_str(_CF.CFDictionaryGetValue(d, k_owner))
+            if pid is not None and wpid != pid:
+                continue
+            if owner is not None and wown != owner:
+                continue
+            b = _CF.CFDictionaryGetValue(d, k_bounds)
+            bounds = {"X": _to_num(_CF.CFDictionaryGetValue(b, k_x)) if b else 0.0,
+                      "Y": _to_num(_CF.CFDictionaryGetValue(b, k_y)) if b else 0.0,
+                      "Width": _to_num(_CF.CFDictionaryGetValue(b, k_w)) if b else 0.0,
+                      "Height": _to_num(_CF.CFDictionaryGetValue(b, k_h)) if b else 0.0}
+            out.append({"pid": wpid, "owner": wown,
+                        "layer": int(_to_num(_CF.CFDictionaryGetValue(d, k_layer))),
+                        "name": _to_str(_CF.CFDictionaryGetValue(d, k_name)), "bounds": bounds})
+    finally:
+        for ref in [arr, *keys]:
+            try:
+                _CF.CFRelease(ref)
+            except Exception:  # noqa: BLE001
+                pass
+    return out
+
+
+def _content_windows(pid: int) -> list:
+    return [w for w in cg_windows(pid=pid) if w.get("layer", 0) == 0]
+
+
+def _descendants(pid: int) -> list:
+    seen, todo = [pid], [pid]
+    while todo:
+        cur = todo.pop()
+        try:
+            kids = subprocess.run(["pgrep", "-P", str(cur)], capture_output=True, text=True,
+                                  timeout=5).stdout.split()
+        except Exception:  # noqa: BLE001
+            kids = []
+        for k in kids:
+            if k.isdigit() and int(k) not in seen:
+                seen.append(int(k))
+                todo.append(int(k))
+    return seen
+
+
+def resolve_player_pid(popen_pid: int, exe: str = "WorldOSPlayer", timeout: float = 8.0) -> int:
+    """Defensive fallback: find `exe` among popen_pid's descendants.
+
+    With the current launch shape the Popen pid IS the Unity process (caffeinate is a SIBLING with
+    `-w <pid>`, not the parent), so this normally returns popen_pid unchanged. It stays for the case
+    where some future caller wraps the binary in something.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for pid in _descendants(popen_pid):
+            try:
+                comm = subprocess.run(["ps", "-p", str(pid), "-o", "comm="],
+                                      capture_output=True, text=True, timeout=5).stdout.strip()
+            except Exception:  # noqa: BLE001
+                continue
+            if comm.rsplit("/", 1)[-1] == exe:
+                return pid
+        time.sleep(0.5)
+    return popen_pid
+
+
+def wait_for_window(pid: int, timeout: float = 25.0) -> list:
+    """Poll until `pid` owns a real content window (layer 0, > 200x200 points). [] on timeout."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        wins = [w for w in _content_windows(pid)
+                if w["bounds"]["Width"] > 200 and w["bounds"]["Height"] > 200]
+        if wins:
+            return wins
+        time.sleep(0.5)
+    return []
+
+
+def fullscreen_verdict(pid: int, cover_frac=None):
+    """The offending window if `pid` covers >= cover_frac of the main display, else None."""
+    frac = FULLSCREEN_COVER_FRAC if cover_frac is None else cover_frac
+    dw, dh = main_display_points()
+    if dw <= 0 or dh <= 0:
+        return None
+    for w in _content_windows(pid):
+        b = w["bounds"]
+        if b["Width"] * b["Height"] >= frac * dw * dh:
+            return w
+    return None
+
+
+def offscreen_verdict(pid: int, min_w: int = MIN_ONSCREEN_W, min_h: int = MIN_ONSCREEN_H):
+    """The offending window if it does not keep >= min_w x min_h points ON the main display.
+
+    Offscreen is as disqualifying as fullscreen: a window with no on-screen surface hands
+    ScreenCapture a black or frozen backbuffer and /shot still returns 200, so walk_test reads
+    "the actor never moved" instead of "the harness is broken".
+    """
+    dw, dh = main_display_points()
+    if dw <= 0 or dh <= 0:
+        return None
+    for w in _content_windows(pid):
+        b = w["bounds"]
+        ix = max(0.0, min(b["X"] + b["Width"], float(dw)) - max(b["X"], 0.0))
+        iy = max(0.0, min(b["Y"] + b["Height"], float(dh)) - max(b["Y"], 0.0))
+        if ix < min_w or iy < min_h:
+            return w
+    return None
+
+
+def front_app_name():
+    """Name of the frontmost app, or None. Uses `System Events` process frontmost (no AX grant)."""
+    try:
+        p = subprocess.run(
+            ["/usr/bin/osascript", "-e",
+             'tell application "System Events" to get name of first application process '
+             'whose frontmost is true'],
+            capture_output=True, text=True, timeout=10)
+    except Exception:  # noqa: BLE001
+        return None
+    name = p.stdout.strip()
+    return name if p.returncode == 0 and name else None
+
+
+def restore_front(name) -> bool:
+    """Re-front `name` via Launch Services (`open -a`). No TCC, no AX, best-effort."""
+    if not name:
+        return False
+    try:
+        return subprocess.run(["/usr/bin/open", "-a", name],
+                              capture_output=True, text=True, timeout=10).returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+if __name__ == "__main__":   # tiny read-only probe: `python3 qa/lib_qa_window.py [pid]`
+    import json
+    import sys
+    _pid = int(sys.argv[1]) if len(sys.argv) > 1 else None
+    print(json.dumps({"display_points": main_display_points(),
+                      "windows": cg_windows(pid=_pid, owner=None if _pid else "WorldOSPlayer")},
+                     indent=2))

--- a/qa/lib_qa_window.py
+++ b/qa/lib_qa_window.py
@@ -28,7 +28,9 @@ from __future__ import annotations
 import ctypes
 import ctypes.util
 import os
+import re
 import subprocess
+import sys
 import time
 
 # fraction of the main display's area at or above which a window counts as a takeover
@@ -36,6 +38,10 @@ FULLSCREEN_COVER_FRAC = float(os.environ.get("WORLDOS_QA_MAX_COVER_FRAC", "0.85"
 # a window must keep at least this much of itself on the display, or ScreenCapture can hand back
 # black/stale frames with no HTTP error (runInBackground governs the update loop, not presentation)
 MIN_ONSCREEN_W, MIN_ONSCREEN_H = 220, 120
+# the player also owns SMALL layer-0 windows (measured 2026-09-02: four 1492x30 strips, off-screen).
+# They are Unity aux windows, not the game window; every verdict must ignore them or a healthy run
+# reads as OFFSCREEN.
+MIN_CONTENT_W, MIN_CONTENT_H = 200, 200
 
 kCGWindowListOptionOnScreenOnly = 1 << 0
 kCGWindowListExcludeDesktopElements = 1 << 4
@@ -66,6 +72,15 @@ def _load():
     cg.CGDisplayPixelsWide.argtypes = [ctypes.c_uint32]
     cg.CGDisplayPixelsHigh.restype = ctypes.c_size_t
     cg.CGDisplayPixelsHigh.argtypes = [ctypes.c_uint32]
+    # CGDisplayPixelsWide/High report the mode's POINT size on a HiDPI display; the BACKING pixel
+    # count (what Unity's -screen-width means) only comes from the display MODE.
+    cg.CGDisplayCopyDisplayMode.restype = ctypes.c_void_p
+    cg.CGDisplayCopyDisplayMode.argtypes = [ctypes.c_uint32]
+    cg.CGDisplayModeGetPixelWidth.restype = ctypes.c_size_t
+    cg.CGDisplayModeGetPixelWidth.argtypes = [ctypes.c_void_p]
+    cg.CGDisplayModeGetPixelHeight.restype = ctypes.c_size_t
+    cg.CGDisplayModeGetPixelHeight.argtypes = [ctypes.c_void_p]
+    cg.CGDisplayModeRelease.argtypes = [ctypes.c_void_p]
     return cf, cg
 
 
@@ -99,8 +114,10 @@ def _to_num(ref) -> float:
 def main_display_points() -> tuple:
     """(width, height) of the MAIN display in POINTS (the current mode's logical size).
 
-    On this host: (1492, 817) — one display, "Screen Sharing Virtual Display", 2984x1634 backing.
-    Returns (0, 0) when CoreGraphics is unavailable; every caller treats that as "cannot judge".
+    Measured 2026-09-02: (1512, 835) on the built-in panel and (1492, 817) while Screen Sharing's
+    virtual display is the main one — both 2x, so the BACKING size is 3024x1670 / 2984x1634.
+    CGWindowList bounds are POINTS too, so every window verdict in this module compares against
+    this. Returns (0, 0) when CoreGraphics is unavailable; every caller treats that as "cannot judge".
     """
     if _CG is None:
         return (0, 0)
@@ -109,6 +126,70 @@ def main_display_points() -> tuple:
         return (int(_CG.CGDisplayPixelsWide(did)), int(_CG.CGDisplayPixelsHigh(did)))
     except Exception:  # noqa: BLE001
         return (0, 0)
+
+
+def _scale_from_system_profiler() -> float:
+    """Backing scale from `system_profiler SPDisplaysDataType` — the fallback path only.
+
+    Returns 1.0 when it cannot tell. 1.0 is the SAFE unknown: every caller multiplies a POINT budget
+    by the scale to get a PIXEL budget, so under-estimating the scale can only make the rig's window
+    smaller, never larger.
+    """
+    try:
+        out = subprocess.run(["system_profiler", "SPDisplaysDataType"],
+                             capture_output=True, text=True, timeout=30).stdout or ""
+    except Exception:  # noqa: BLE001
+        return 1.0
+    native = looks = 0
+    for line in out.splitlines():
+        m = re.search(r"Resolution:\s*(\d+)\s*x\s*(\d+)", line)
+        if m and not native:
+            native = int(m.group(1))
+        m = re.search(r"UI Looks like:\s*(\d+)\s*x\s*(\d+)", line)
+        if m and not looks:
+            looks = int(m.group(1))
+    if native > 0 and looks > 0:
+        return round(native / looks, 4)
+    return 1.0
+
+
+def main_display_backing() -> tuple:
+    """(width, height) of the MAIN display in BACKING PIXELS.
+
+    Measured 2026-09-02: (3024, 1670) for a (1512, 835) point mode — scale 2.0. This is
+    the unit Unity's `-screen-width`/`-screen-height` speak (a resolution, i.e. backing pixels): the
+    2026-09-02 launch asked for 1280x700 and the window server reported a 640x382 POINT window. Any
+    fit clamp or coverage check that mixes the two is off by the scale factor.
+    """
+    if _CG is None:
+        return (0, 0)
+    try:
+        did = _CG.CGMainDisplayID()
+        mode = _CG.CGDisplayCopyDisplayMode(did)
+        if mode:
+            try:
+                pw = int(_CG.CGDisplayModeGetPixelWidth(mode))
+                ph = int(_CG.CGDisplayModeGetPixelHeight(mode))
+            finally:
+                _CG.CGDisplayModeRelease(mode)
+            if pw > 0 and ph > 0:
+                return (pw, ph)
+    except Exception:  # noqa: BLE001
+        pass
+    pw, ph = main_display_points()
+    if pw <= 0 or ph <= 0:
+        return (0, 0)
+    scale = _scale_from_system_profiler()
+    return (int(round(pw * scale)), int(round(ph * scale)))
+
+
+def backing_scale() -> float:
+    """BACKING PIXELS per POINT on the main display (2.0 here). 1.0 when it cannot be determined."""
+    pw, _ph = main_display_points()
+    bw, _bh = main_display_backing()
+    if pw > 0 and bw > 0:
+        return bw / float(pw)
+    return 1.0
 
 
 def cg_windows(pid=None, owner=None) -> list:
@@ -154,7 +235,16 @@ def cg_windows(pid=None, owner=None) -> list:
 
 
 def _content_windows(pid: int) -> list:
-    return [w for w in cg_windows(pid=pid) if w.get("layer", 0) == 0]
+    """Layer-0 windows big enough to BE the game window.
+
+    The size floor is load-bearing, not cosmetic: the player owns small layer-0 aux windows
+    (measured 2026-09-02: four 1492x30 strips, off-screen), and an unfiltered offscreen_verdict fires
+    on those every single healthy run. wait_for_window already filtered them; the verdicts must use
+    the SAME filter or the watchdog and the boot check disagree about what the window is.
+    """
+    return [w for w in cg_windows(pid=pid)
+            if w.get("layer", 0) == 0
+            and w["bounds"]["Width"] > MIN_CONTENT_W and w["bounds"]["Height"] > MIN_CONTENT_H]
 
 
 def _descendants(pid: int) -> list:
@@ -198,8 +288,7 @@ def wait_for_window(pid: int, timeout: float = 25.0) -> list:
     """Poll until `pid` owns a real content window (layer 0, > 200x200 points). [] on timeout."""
     deadline = time.time() + timeout
     while time.time() < deadline:
-        wins = [w for w in _content_windows(pid)
-                if w["bounds"]["Width"] > 200 and w["bounds"]["Height"] > 200]
+        wins = _content_windows(pid)
         if wins:
             return wins
         time.sleep(0.5)
@@ -238,29 +327,59 @@ def offscreen_verdict(pid: int, min_w: int = MIN_ONSCREEN_W, min_h: int = MIN_ON
     return None
 
 
-def front_app_name():
-    """Name of the frontmost app, or None. Uses `System Events` process frontmost (no AX grant)."""
+def front_app():
+    """{"name", "pid"} of the frontmost app, or None. `System Events` process info needs no AX grant.
+
+    The PID is what matters: it is the only identity that cannot be re-resolved to a DIFFERENT copy
+    of the app later (see restore_front).
+    """
     try:
         p = subprocess.run(
             ["/usr/bin/osascript", "-e",
-             'tell application "System Events" to get name of first application process '
-             'whose frontmost is true'],
+             'tell application "System Events" to tell (first application process whose '
+             'frontmost is true) to get {name, unix id}'],
             capture_output=True, text=True, timeout=10)
     except Exception:  # noqa: BLE001
         return None
-    name = p.stdout.strip()
-    return name if p.returncode == 0 and name else None
+    out = p.stdout.strip()
+    if p.returncode != 0 or not out:
+        return None
+    name, _, pid = out.rpartition(", ")
+    name = name.strip()
+    if not name or not pid.strip().isdigit():
+        return None
+    return {"name": name, "pid": int(pid.strip())}
 
 
-def restore_front(name) -> bool:
-    """Re-front `name` via Launch Services (`open -a`). No TCC, no AX, best-effort."""
-    if not name:
+def restore_front(info, *, player_exe: str = "WorldOSPlayer") -> bool:
+    """Re-front the app that was frontmost BEFORE the rig launched, BY PID.
+
+    NEVER `open -a <name>`: Launch Services resolves a NAME to an installed bundle, so if the owner's
+    game happened to be frontmost (or if nothing by that name is running any more) the "restore"
+    would LAUNCH a fresh WorldOSPlayer — the rig would create exactly the fullscreen owner instance
+    this whole module exists to prevent. Fronting a unix id can only touch a process that is already
+    running, and we refuse outright when that process is a player.
+    """
+    if not info or not info.get("pid"):
+        print("[window] no frontmost app was recorded — leaving focus where it is.", file=sys.stderr)
+        return False
+    if str(info.get("name") or "").startswith(player_exe):
+        print(f"[window] frontmost app at launch was {info['name']!r} (a player) — NOT restoring "
+              f"focus; re-fronting a player is the hijack this lane guards against.", file=sys.stderr)
         return False
     try:
-        return subprocess.run(["/usr/bin/open", "-a", name],
-                              capture_output=True, text=True, timeout=10).returncode == 0
+        p = subprocess.run(
+            ["/usr/bin/osascript", "-e",
+             f'tell application "System Events" to set frontmost of (first process whose unix id '
+             f'is {int(info["pid"])}) to true'],
+            capture_output=True, text=True, timeout=10)
     except Exception:  # noqa: BLE001
         return False
+    if p.returncode != 0:
+        print(f"[window] could not re-front pid {info['pid']} ({info.get('name')}): "
+              f"{p.stderr.strip()}", file=sys.stderr)
+        return False
+    return True
 
 
 if __name__ == "__main__":   # tiny read-only probe: `python3 qa/lib_qa_window.py [pid]`
@@ -268,5 +387,7 @@ if __name__ == "__main__":   # tiny read-only probe: `python3 qa/lib_qa_window.p
     import sys
     _pid = int(sys.argv[1]) if len(sys.argv) > 1 else None
     print(json.dumps({"display_points": main_display_points(),
+                      "display_backing": main_display_backing(),
+                      "backing_scale": backing_scale(),
                       "windows": cg_windows(pid=_pid, owner=None if _pid else "WorldOSPlayer")},
                      indent=2))

--- a/qa/qa_sandbox.py
+++ b/qa/qa_sandbox.py
@@ -29,21 +29,29 @@ QA RIG vs THE OWNER'S GAME (#1672, incident 2026-09-02) — read this before cha
   BOUNDS — not from the player's /health — that the window is neither fullscreen nor offscreen, and
   tears the run down within ~25s if it is.
 - Bundle id is SHARED with the owner's game (ProjectSettings.asset:171), so the rig NEVER writes
-  ~/Library/Preferences/com.worldos.WorldOSPlayer.plist. `down` snapshots/diffs/restores instead.
+  ~/Library/Preferences/com.worldos.WorldOSPlayer.plist itself — but UNITY does, on quit. `down`
+  snapshots the whole domain, diffs it, and restores ATTRIBUTION-SAFELY: a key is rewritten only if
+  it changed AND still holds the exact value this rig deterministically produces. Anything else
+  (including the cosmetic window-position keys) is reported and left alone — a blind restore would
+  silently revert the owner's own settings.
+- CFFIXED_USER_HOME=<rundir>/home gives the rig its OWN Application Support, so /shot frames land in
+  the run dir instead of racing the owner's instance over the shared shot directory. Measured
+  2026-09-02: it DOES redirect Application.persistentDataPath; it does NOT redirect PlayerPrefs
+  (~/Library/Preferences is still shared) — hence the restore logic above.
 - TELLING THEM APART TODAY: window geometry, `lsof -nP -iTCP:8972 -sTCP:LISTEN -t` (owner = 8971),
   and sandbox.json. The rig's window TITLE is still "WorldOSPlayer" — the #1672 badge needs the
   Phase 2 C# change (docs/qa/QA-RIG-WINDOW-BADGE.md) and an Editor rebuild.
 
 Caveats:
-- Two player instances share Application Support/com.worldos.WorldOSPlayer — /shot writes collide.
-  Don't run owner-instance probes and a sandbox sweep at the same moment. The owner-active guard
-  makes that unlikely; it is NOT an interlock.
+- The two instances no longer share a shot directory (CFFIXED_USER_HOME, above), but they DO share
+  the preferences domain and the GPU. The owner-active guard is a courtesy, NOT an interlock.
 - 16 GB host: ONE sandbox at a time; always teardown (the overnight-loop RAM discipline).
 
 Usage:
   qa/qa_sandbox.py up   --run scale1            # seed + engine + player; prints the endpoints
   qa/qa_sandbox.py status --run scale1
   qa/qa_sandbox.py down --run scale1            # kill own pids; state/logs kept for evidence
+  qa/qa_sandbox.py watchdog --run scale1        # ONE takeover check; kills + exits 3 if fullscreen
   qa/qa_sandbox.py orphans                      # rig leftovers on :8972 / stray player windows
   # or via the orchestrator:  qa/room_pipeline.py --room crypt --sandbox
 Custom seed (new rooms): --seed-cmd "uv run --directory servers/engine python qa/my_seed.py {state}"
@@ -53,6 +61,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import plistlib
 import re
 import shlex
 import signal
@@ -75,23 +84,28 @@ ENGINE_PORT, QA_PORT = 8866, 8972          # owner runs 8766/8971 — never coll
 
 # ── #1672 / incident 2026-09-02: WINDOWED, non-hijacking launch ────────────────────────────────────
 # Same env NAMES as the shell helper (qa/lib_native_player_boot.sh:83-85) so all three player lanes
-# are one knob. 700 (not the shell lane's 800) because this display is 1492x817 POINTS with ~792
-# usable after the menu bar — 800 does not fit — and 1280x700 (aspect 1.829) is >= the display's
-# 1.826, so the ortho crop (walk_test.world_to_window_px) shows at least as much world as the
-# fullscreen baseline and no sample cell that was in frame falls out.
+# are one knob. These are BACKING PIXELS (a Unity resolution), not points: 1280x700 rendered a
+# 640x382 POINT window on the measured 2x host, and /health reported 1280x700. The value is chosen
+# for the VISUAL stage, not for fit — 1280x700 is aspect 1.829, >= this display's 1.826, so the ortho
+# crop (walk_test.world_to_window_px) shows at least as much world as the fullscreen baseline and no
+# sample cell that was in frame falls out. WIN_MIN_* is the floor below which a grid cell shrinks
+# under the pixel-diff threshold.
 WIN_W, WIN_H = 1280, 700
 WIN_MIN_W, WIN_MIN_H = 640, 400
 CAFFEINATE_FLAGS = os.environ.get("WORLDOS_QA_CAFFEINATE_FLAGS", "-is").split()
 OWNER_ACTIVE_RC = 75                      # parity with PLAYER_QA_OWNER_ACTIVE_RC (shell lane)
+WATCHDOG_RC = 3                           # the rig had the display; killed and failed CLOSED
+# /health reports the player's RESOLUTION (backing pixels). At or above this fraction of the
+# display's backing-pixel area the rig is effectively taking the screen, whatever it was asked for.
+MAX_SCREEN_COVER_FRAC = float(os.environ.get("WORLDOS_QA_MAX_SCREEN_FRAC", "0.6"))
 PLIST_DOMAIN = "com.worldos.WorldOSPlayer"    # SHARED with the owner's game (same bundle id)
-SCREEN_KEYS = ("Screenmanager Fullscreen mode", "Screenmanager Fullscreen mode Default",
-               "Screenmanager Resolution Width", "Screenmanager Resolution Height",
-               "Screenmanager Resolution Width Default", "Screenmanager Resolution Height Default",
-               "Screenmanager Resolution Use Native", "Screenmanager Resolution Use Native Default",
-               "Screenmanager Window Position X", "Screenmanager Window Position Y",
-               "UnitySelectMonitor")
-# deliberately EXCLUDED (they churn every launch, so including them would make every run look like a
-# leak): unity.player_session_count, unity.player_sessionid, unity_connect.*
+# Keys that CHURN on every launch — excluded from the leak diff or every run looks like a leak.
+CHURN_KEYS = ("unity.player_session_count", "unity.player_sessionid")
+CHURN_PREFIXES = ("unity_connect.",)
+# Reported by the leak check, NEVER rewritten: the owner drags the window and Unity records it, so a
+# change here is as likely theirs as ours and it costs them nothing to keep.
+NEVER_RESTORE = ("Screenmanager Window Position X", "Screenmanager Window Position Y")
+_INT_RE = re.compile(r"-?\d+")
 
 
 # ── owner-active guard (Python port of qa/lib_native_player_boot.sh:51-71) ─────────────────────────
@@ -155,16 +169,24 @@ def _player_windowed_args(logfile) -> list:
     whatever the SHARED plist holds. -logFile puts THIS run's player log in the run dir instead of
     the shared, overwritten-every-launch default.
 
-    The fit clamp keeps the window inside the real desktop (menu bar + margin) while never letting
-    the aspect drop BELOW the display's: a narrower window would crop horizontal world out of the
-    ortho frame and cells that were in frame at fullscreen would project outside the capture.
+    UNITS (measured 2026-09-02, and the reason the first cut of this clamp was wrong): -screen-width
+    and -screen-height are a RESOLUTION — BACKING PIXELS — while LQW.main_display_points() and every
+    CGWindowList bound are POINTS. Asking for 1280x700 on this 2x display produced a 640x382 POINT
+    window and /health reported 1280x700. So the desktop budget is computed in points (menu bar +
+    margin, where the window actually has to fit) and converted to pixels with the display's backing
+    scale before clamping. Host values: 1512x835 points, 3024x1670 pixels, scale 2.
+
+    The fit clamp keeps the window inside the real desktop while never letting the aspect drop BELOW
+    the display's: a narrower window would crop horizontal world out of the ortho frame and cells
+    that were in frame at fullscreen would project outside the capture.
     """
     w, h = _win_size_from_env()
     dw, dh = LQW.main_display_points()
     if dw > 0 and dh > 0:
-        h = min(h, dh - 120)
-        w = max(w, round(h * dw / dh))
-        w = min(w, dw - 160)
+        scale = LQW.backing_scale() or 1.0
+        h = min(h, int((dh - 120) * scale))      # point budget -> pixel budget
+        w = max(w, round(h * dw / dh))           # aspect is scale-free
+        w = min(w, int((dw - 160) * scale))
     args = ["-screen-fullscreen", "0", "-screen-width", str(int(w)), "-screen-height", str(int(h))]
     if logfile:
         args += ["-logFile", str(logfile)]
@@ -172,50 +194,112 @@ def _player_windowed_args(logfile) -> list:
 
 
 # ── shared-plist leak check (#1672 item 3) ─────────────────────────────────────────────────────────
-def _plist_read(key: str):
-    try:
-        p = subprocess.run(["defaults", "read", PLIST_DOMAIN, key],
-                           capture_output=True, text=True, timeout=15)
-    except Exception:  # noqa: BLE001
-        return None
-    return p.stdout.strip() if p.returncode == 0 else None
+def _is_churn(key: str) -> bool:
+    return key in CHURN_KEYS or any(key.startswith(pre) for pre in CHURN_PREFIXES)
 
 
 def _plist_snapshot() -> dict:
-    return {k: _plist_read(k) for k in SCREEN_KEYS}
+    """The WHOLE shared domain as {key: str}, minus the churn keys. READ ONLY.
+
+    Whole-domain, not just the Screenmanager keys: the leak CHECK must be able to report any key the
+    rig moved, including one nobody has thought of yet. `defaults export` + plistlib is one read-only
+    process (`defaults read <domain> <key>` per key was 11 processes and still could not see an
+    unexpected key).
+    """
+    try:
+        p = subprocess.run(["defaults", "export", PLIST_DOMAIN, "-"],
+                           capture_output=True, timeout=15)
+    except Exception:  # noqa: BLE001
+        return {}
+    if p.returncode != 0 or not p.stdout:
+        return {}
+    try:
+        data = plistlib.loads(p.stdout)
+    except Exception:  # noqa: BLE001
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(k): str(v) for k, v in sorted(data.items()) if not _is_churn(str(k))}
 
 
 def _plist_diff(before: dict, after: dict) -> dict:
+    keys = sorted(set(before) | set(after))
     return {k: {"before": before.get(k), "after": after.get(k)}
-            for k in SCREEN_KEYS if before.get(k) != after.get(k)}
+            for k in keys if before.get(k) != after.get(k) and not _is_churn(k)}
 
 
-def _plist_restore(diff: dict, *, foreign_alive: bool) -> dict:
-    """Put the SHARED domain back the way we found it. Detect-only would ship the owner a regression.
+def _rig_written_values(win_w, win_h) -> dict:
+    """Exactly what a rig launch deterministically leaves in the SHARED domain.
+
+    Unity writes these on quit from the `-screen-*` args we passed: mode 3 = FullScreenMode.Windowed,
+    the requested resolution, native resolution off. Measured 2026-09-02 (1->3, 3024->1280,
+    1670->700, 1->0). Window Position X/Y also moved and are deliberately NOT here — see
+    NEVER_RESTORE.
+    """
+    try:
+        w, h = int(win_w), int(win_h)
+    except (TypeError, ValueError):
+        return {}
+    return {"Screenmanager Fullscreen mode": "3",
+            "Screenmanager Resolution Width": str(w),
+            "Screenmanager Resolution Height": str(h),
+            "Screenmanager Resolution Use Native": "0"}
+
+
+def _plist_restore(diff: dict, *, foreign_alive: bool, rig_values: dict) -> dict:
+    """Put back ONLY what this rig provably wrote. Restoring the rest would be its own regression.
+
+    ATTRIBUTION (the round-2 finding): the first cut rewrote every changed key from the snapshot. The
+    domain is SHARED, so any key the owner changed while the sweep ran — in their own game, in a
+    settings menu, by dragging the window — would be silently reverted by our teardown, and the rig
+    would be a a bug for the owner instead of a fix. A key is now restored only when BOTH hold:
+      (a) it changed since the up() snapshot, and
+      (b) it STILL holds the exact value this rig deterministically writes (rig_values).
+    Anything else is reported as skipped, with the reason, and left exactly as found. Values are
+    integer-validated before any `defaults write` — a non-integer is reported, never written.
 
     Ordering constraint: the caller must confirm OUR pids are dead first — a live instance writes on
     quit and cfprefsd caches the domain, so an early restore is silently clobbered. For the same
     reason we refuse to write while a FOREIGN player is alive.
     """
-    report = {"restored": {}, "note": ""}
+    report = {"restored": {}, "skipped": {}, "note": ""}
     if not diff:
         return report
     if os.environ.get("WORLDOS_QA_PLIST_RESTORE", "1") != "1":
         report["note"] = "WORLDOS_QA_PLIST_RESTORE=0 — detect only; the shared plist was NOT restored."
+        report["skipped"] = {k: "restore disabled (WORLDOS_QA_PLIST_RESTORE=0)" for k in diff}
         return report
     if foreign_alive:
         report["note"] = ("a foreign WorldOSPlayer is still running — NOT writing the shared domain "
                           "(cfprefsd would clobber the write when that instance quits). Re-run "
                           "`qa/qa_sandbox.py down --run <run>` once it has exited.")
+        report["skipped"] = {k: "a foreign WorldOSPlayer is alive" for k in diff}
         return report
-    for key, ba in diff.items():
-        old = ba.get("before")
+    for key, ba in sorted(diff.items()):
+        old, new = ba.get("before"), ba.get("after")
+        if key in NEVER_RESTORE:
+            report["skipped"][key] = ("cosmetic window position — owner-attributable, never "
+                                      "rewritten by the rig")
+            continue
+        want = rig_values.get(key)
+        if want is None:
+            report["skipped"][key] = "not a key this rig writes — the change is not ours to undo"
+            continue
+        if new != want:
+            report["skipped"][key] = (f"current value {new!r} is not the value this rig writes "
+                                      f"({want!r}) — someone else wrote it last")
+            continue
         if old is None:
             subprocess.run(["defaults", "delete", PLIST_DOMAIN, key],
                            capture_output=True, text=True)
-        else:
-            subprocess.run(["defaults", "write", PLIST_DOMAIN, key, "-int", str(old)],
-                           capture_output=True, text=True)
+            report["restored"][key] = None
+            continue
+        if not _INT_RE.fullmatch(str(old)):
+            report["skipped"][key] = (f"snapshot value {old!r} is not an integer — refusing to "
+                                      f"`defaults write -int` it")
+            continue
+        subprocess.run(["defaults", "write", PLIST_DOMAIN, key, "-int", str(old)],
+                       capture_output=True, text=True)
         report["restored"][key] = old
     return report
 
@@ -228,31 +312,61 @@ def _player_pids(exe: str = "WorldOSPlayer") -> set:
     return {int(t) for t in p.stdout.split() if t.strip().isdigit()}
 
 
-def _kill_group(pid: int, label: str = "") -> None:
-    """SIGTERM then SIGKILL the process GROUP. Never terminate() — see the caffeinate note in up()."""
+def _kill_group(pid: int, label: str = "", *, expect_pgid=None) -> str:
+    """SIGTERM then SIGKILL the process GROUP. Never terminate() — see the caffeinate note in up().
+
+    IDENTITY (the round-2 finding): a recorded pid is not an identity. Between `up` and `down` the
+    rig's player can exit and the OS can hand its number to something else — signalling a whole
+    process GROUP on a stale number is how a teardown takes out an unrelated tree. So the pgid
+    recorded at launch is re-verified against the live one and a mismatch NEVER signals.
+    Returns "" (signalled/already gone) or a short reason string.
+    """
+    try:
+        pgid = os.getpgid(pid)
+    except ProcessLookupError:
+        return ""
+    except PermissionError:
+        print(f"[sandbox] cannot read pgid of {label or 'pid'} {pid}", file=sys.stderr)
+        return "no permission to read the process group"
+    if expect_pgid is not None and pgid != int(expect_pgid):
+        print(f"[sandbox] REFUSING to signal {label or 'pid'} {pid}: its process group is {pgid}, "
+              f"we recorded {expect_pgid} — the pid was REUSED and is not ours.", file=sys.stderr)
+        return f"pid reused (pgid {pgid} != recorded {expect_pgid})"
     for sig in (signal.SIGTERM, signal.SIGKILL):
         try:
-            os.killpg(os.getpgid(pid), sig)
+            os.killpg(pgid, sig)
             time.sleep(1.5)
         except ProcessLookupError:
-            return
+            return ""
         except PermissionError:
             print(f"[sandbox] cannot signal {label or 'pid'} {pid}", file=sys.stderr)
-            return
+            return "no permission to signal the process group"
+    return ""
 
 
 def _assert_windowed(qa_port: int, w: int, h: int, *, timeout_s: float = 20.0,
-                     interval: float = 1.0) -> tuple:
-    """POLL /health until the player reports a rendered window size, then assert it is ours.
+                     interval: float = 1.0, on_poll=None) -> tuple:
+    """POLL /health until the player reports a rendered window size, then assert it is SAFE.
 
     Must POLL, never one-shot: CombatSurfaceClient caches _screenW/_screenH inside the QA-click
     block and after the `_busy` early-out (CombatSurfaceClient.cs:2320-2326), so they read 0 until a
     non-busy QA frame has run — while /debug already answers from the listener thread.
-    Accepts (w,h) and (2w,2h): macRetinaSupport=1 and this display is a 2x HiDPI mode.
+
+    SAFETY, NOT IDENTITY (the round-2 finding): the first cut demanded exactly (w,h) or (2w,2h) and
+    aborted otherwise. Unity is entitled to adjust a requested resolution (mode snap, DPI clamp,
+    minimum size), and a rig that came up at 1268x700 instead of 1280x700 is perfectly safe — failing
+    it teaches the next person to delete the check. What must hold is that the rig CANNOT have the
+    display: /health's resolution covers less than MAX_SCREEN_COVER_FRAC of the display's BACKING
+    PIXEL area (both are backing pixels — see _player_windowed_args), and the window server itself
+    agrees the window is not covering the display.
     """
     deadline = time.time() + timeout_s
     last = None
+    bw, bh = LQW.main_display_backing()
+    area = float(bw * bh)
     while time.time() < deadline:
+        if on_poll:
+            on_poll()
         try:
             req = urllib.request.Request(f"http://127.0.0.1:{qa_port}/health")
             with urllib.request.urlopen(req, timeout=3) as r:
@@ -262,17 +376,55 @@ def _assert_windowed(qa_port: int, w: int, h: int, *, timeout_s: float = 20.0,
             sw = sh = 0
         if sw > 0 and sh > 0:
             last = (sw, sh)
-            if last in ((w, h), (2 * w, 2 * h)):
-                return last
-            raise SystemExit(
-                f"[sandbox] player is NOT windowed at the requested size: /health reports {sw}x{sh}, "
-                f"expected {w}x{h} (or the 2x HiDPI {2*w}x{2*h}). The -screen-* args were ignored — "
-                f"do NOT run a sweep against this instance.")
+            if (sw, sh) != (w, h):
+                print(f"[sandbox] NOTE: Unity adjusted the requested {w}x{h} to {sw}x{sh} — "
+                      f"tolerated; only the coverage bound below is gating.", file=sys.stderr)
+            if area > 0:
+                frac = (sw * sh) / area
+                if frac >= MAX_SCREEN_COVER_FRAC:
+                    raise SystemExit(
+                        f"[sandbox] player is NOT windowed: /health reports {sw}x{sh}, which is "
+                        f"{frac:.0%} of the {bw}x{bh} backing-pixel display (limit "
+                        f"{MAX_SCREEN_COVER_FRAC:.0%}). The -screen-* args were ignored — do NOT run "
+                        f"a sweep against this instance.")
+            else:
+                print("[sandbox] WARN: display size unknown — /health coverage bound NOT applied.",
+                      file=sys.stderr)
+            if on_poll:
+                on_poll()      # window-server confirmation of what /health just self-reported
+            return last
         time.sleep(interval)
     raise SystemExit(
         f"[sandbox] /health never reported a rendered window size within {timeout_s:.0f}s "
         f"(last={last}) — the QA channel is up but no QA frame has run; treat the geometry as "
         f"UNVERIFIED and tear the run down.")
+
+
+# ── G. the takeover watchdog (permission-free CGWindowList read) ───────────────────────────────
+def _watchdog(pid: int, *, pgid=None, kill: bool = True) -> None:
+    """One read of the window server's own bounds. Fails CLOSED; returns None when the rig is safe.
+
+    Runs on EVERY readiness poll and from `qa/qa_sandbox.py watchdog` during a sweep, because one
+    check at boot only proves the first second: a mode change, a plist race or a stray
+    Screen.SetResolution can turn the rig fullscreen at any later moment, and THAT is the failure
+    that cost a reboot on 2026-09-02. A fullscreen verdict kills OUR player first and asks questions
+    afterwards — every extra second is the owner's Mac.
+    """
+    bad = LQW.fullscreen_verdict(pid)
+    if bad:
+        dsp = LQW.main_display_points()
+        killed = _kill_group(pid, "player", expect_pgid=pgid) if kill else "not killed (kill=False)"
+        print(f"[sandbox] WATCHDOG — the rig player (pid {pid}) is COVERING the main display {dsp}: "
+              f"window bounds {bad['bounds']}. {killed or 'Killed the rig player group.'} The "
+              f"-screen-fullscreen 0 arg was ignored or overridden; do not re-run until that is "
+              f"understood.", file=sys.stderr)
+        raise SystemExit(WATCHDOG_RC)
+    bad = LQW.offscreen_verdict(pid)
+    if bad:
+        raise SystemExit(f"[sandbox] ABORT — player window {bad['bounds']} is effectively OFFSCREEN "
+                         f"on display {LQW.main_display_points()}: an offscreen window returns "
+                         f"black/stale ScreenCapture frames with no HTTP error, which the visual "
+                         f"stage would read as 'the actor never moved'.")
 
 
 def _http_ok(url: str, post: bool = False, timeout: float = 3.0) -> bool:
@@ -285,9 +437,11 @@ def _http_ok(url: str, post: bool = False, timeout: float = 3.0) -> bool:
         return False
 
 
-def _wait(label: str, url: str, *, post: bool, timeout_s: float) -> bool:
+def _wait(label: str, url: str, *, post: bool, timeout_s: float, on_poll=None) -> bool:
     deadline = time.time() + timeout_s
     while time.time() < deadline:
+        if on_poll:
+            on_poll()      # the watchdog: it fails CLOSED, it never returns a verdict to ignore
         if _http_ok(url, post=post):
             return True
         time.sleep(2)
@@ -410,10 +564,18 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
 
     # 0a) #1672: never launch a QA player over an owner who is actively using the Mac.
     owner_active_guard()
-    plist_before = _plist_snapshot()      # SHARED domain — snapshot now, diff + restore in down()
-    front_before = LQW.front_app_name()   # so the run can hand focus back (Launch Services, no AX)
 
-    # 0) PREFLIGHT the .app before anything is created or spawned. Both of these used to run after the
+    # 0b) PREFLIGHT the window geometry HERE, before anything is created or spawned — that is what
+    #     the step-0 comment below promises. It used to be computed inside step 3, so a bad
+    #     WORLDOS_PLAYER_WIN_W/H raised only after the seed had run and the engine was already up.
+    win_args = _player_windowed_args(rd / "unity_player.log")
+    win_w = int(win_args[win_args.index("-screen-width") + 1])
+    win_h = int(win_args[win_args.index("-screen-height") + 1])
+
+    plist_before = _plist_snapshot()      # SHARED domain — snapshot now, diff + restore in down()
+    front_before = LQW.front_app()        # {"name","pid"}: focus is handed back BY PID, not by name
+
+    # 0c) PREFLIGHT the .app, still before anything is created or spawned. Both of these used to run after the
     #    engine was already up, so a rejected app still seeded state and left an engine behind that no
     #    run metadata could clean up (terminate() is non-blocking and `down` needs sandbox.json).
     pbin = app / "Contents" / "MacOS" / "WorldOSPlayer"
@@ -451,24 +613,33 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
          str(REPO / "viewer" / "server.py"), campaign, str(engine_port)],
         cwd=REPO, env=env, stdout=eng_log, stderr=subprocess.STDOUT,
         start_new_session=True)
+    eng_pgid = os.getpgid(engine.pid)
     if not _wait("engine", f"http://127.0.0.1:{engine_port}/combat-surface", post=False, timeout_s=90):
         # killpg, NOT terminate(): engine.pid is the `uv` WRAPPER — SIGTERM to it leaves the real
         # viewer/server.py holding the port, and `down` has no sandbox.json to clean up with yet.
-        _kill_group(engine.pid, "engine")
+        _kill_group(engine.pid, "engine", expect_pgid=eng_pgid)
         raise SystemExit(f"[sandbox] engine never came up — see {rd/'engine.log'}")
 
     # 3) a SECOND player instance — direct binary exec (open -n drops env), own QA port.
     #    ⚠ never `osascript quit app` here (kills the OWNER's instance too) — pid-scoped only.
     #    (binary presence + contamination were preflighted at step 0, before anything was spawned.)
+    home = rd / "home"
+    home.mkdir(parents=True, exist_ok=True)
     penv = dict(os.environ,
                 WORLDOS_ENGINE_BASE_URL=f"http://127.0.0.1:{engine_port}",
                 WORLDOS_CAMPAIGN_ID=campaign,
                 WORLDOS_QA_INPUT="1",
-                WORLDOS_QA_INPUT_PORT=str(qa_port))
+                WORLDOS_QA_INPUT_PORT=str(qa_port),
+                # PER-RUN HOME. Measured 2026-09-02: CFFIXED_USER_HOME DOES redirect
+                # Application.persistentDataPath, so this run's wos_shot_<n>.png land in
+                # <rundir>/home/Library/Application Support/com.worldos.WorldOSPlayer and can no
+                # longer collide with the owner instance's shots in the shared directory. No
+                # consumer needs to change: walk_test._capture_shot copies the ABSOLUTE path /shot
+                # returns, and the two lanes built on it (adventure_walk, player_cert) call that
+                # same helper. It does NOT redirect PlayerPrefs — ~/Library/Preferences stays
+                # shared, which is why down() still leak-checks and restores that domain.
+                CFFIXED_USER_HOME=str(home))
     ply_log = open(rd / "player.log", "w")  # noqa: SIM115
-    win_args = _player_windowed_args(rd / "unity_player.log")
-    win_w = int(win_args[win_args.index("-screen-width") + 1])
-    win_h = int(win_args[win_args.index("-screen-height") + 1])
     argv = [str(pbin), *win_args]
     print(f"[sandbox] player argv: {' '.join(argv)}")
     # The player is its OWN Popen — NOT a caffeinate child. caffeinate does not forward SIGTERM, so
@@ -479,58 +650,57 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
     # -i (idle) + -s (system sleep) still keep App-Nap -> throttled-render -> delayed /shot away.
     player = subprocess.Popen(argv, env=penv, stdout=ply_log, stderr=subprocess.STDOUT,
                               start_new_session=True)
+    player_pgid = os.getpgid(player.pid)
     caff = subprocess.Popen(["/usr/bin/caffeinate", *CAFFEINATE_FLAGS, "-w", str(player.pid)],
                             stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT,
                             start_new_session=False)
 
     meta = {"run": run, "campaign": campaign, "state": str(state), "status": "booting",
             "engine": f"http://127.0.0.1:{engine_port}", "qa": f"http://127.0.0.1:{qa_port}",
-            "win": [win_w, win_h], "argv": argv, "screen": None,
+            "win": [win_w, win_h], "argv": argv, "screen": None, "home": str(home),
             "plist_before": plist_before, "front_before": front_before,
             "pids": {"engine": engine.pid, "player": player.pid},
-            "pgids": {"engine": os.getpgid(engine.pid), "player": os.getpgid(player.pid)},
+            "pgids": {"engine": eng_pgid, "player": player_pgid},
             "caffeinate_pid": caff.pid}
     # ANTI-ORPHAN FENCE: write the metadata BEFORE the readiness wait. Previously it was written
     # after, so a boot timeout raised with nothing on disk and `down` had no pids to kill.
     _meta_path(run).write_text(json.dumps(meta, indent=2) + "\n")
 
-    # WATCHDOG (permission-free, window-server bounds — not the player's self-report): bound a
-    # flags-ignored regression to ~25s instead of a machine lockup.
-    wins = LQW.wait_for_window(player.pid, timeout=25)
-    if not wins:
-        print("[sandbox] WARN: CGWindowList shows no content window for the player yet — "
-              "geometry unverified at this point (the /health assertion below still gates).",
-              file=sys.stderr)
-    else:
-        dsp = LQW.main_display_points()
-        bad = LQW.fullscreen_verdict(player.pid)
-        if bad:
-            down(run)
-            raise SystemExit(f"[sandbox] ABORT — player came up FULLSCREEN {bad['bounds']} on the "
-                             f"main display {dsp}. Torn down. The -screen-fullscreen 0 arg was "
-                             f"ignored; do not re-run until that is understood.")
-        bad = LQW.offscreen_verdict(player.pid)
-        if bad:
-            down(run)
-            raise SystemExit(f"[sandbox] ABORT — player window {bad['bounds']} is effectively "
-                             f"OFFSCREEN on display {dsp}. Torn down: an offscreen window returns "
-                             f"black/stale ScreenCapture frames with no HTTP error, which the "
-                             f"visual stage would read as 'the actor never moved'.")
+    def _guard() -> None:
+        """The takeover watchdog, run on EVERY readiness poll (see _watchdog)."""
+        _watchdog(player.pid, pgid=player_pgid)
 
-    if not _wait("player QA channel", f"http://127.0.0.1:{qa_port}/debug", post=True, timeout_s=120):
-        down(run)      # safe now: sandbox.json exists, so this kills both process GROUPS
-        raise SystemExit(f"[sandbox] player QA channel never came up — see {rd/'player.log'}")
-
+    # ABORT UNWIND: everything past the Popen runs inside this. `except BaseException` is deliberate
+    # — a Ctrl-C (KeyboardInterrupt) or a SystemExit from any check below used to leave a live
+    # player and engine behind with only a sandbox.json to prove it, which on 2026-09-02 is exactly
+    # the state that ended in a reboot. Whatever goes wrong, the run comes down.
     try:
-        meta["screen"] = list(_assert_windowed(qa_port, win_w, win_h))
-    except SystemExit:
-        down(run)       # a mis-sized/unverifiable player must not survive the failed assertion
+        # window-server bounds, not the player's self-report: bound a flags-ignored regression to
+        # ~25s instead of a machine lockup.
+        if not LQW.wait_for_window(player.pid, timeout=25):
+            print("[sandbox] WARN: CGWindowList shows no content window for the player yet — "
+                  "geometry unverified at this point (the /health assertion below still gates).",
+                  file=sys.stderr)
+        _guard()
+        if not _wait("player QA channel", f"http://127.0.0.1:{qa_port}/debug", post=True,
+                     timeout_s=120, on_poll=_guard):
+            raise SystemExit(f"[sandbox] player QA channel never came up — see {rd/'player.log'}")
+        meta["screen"] = list(_assert_windowed(qa_port, win_w, win_h, on_poll=_guard))
+        meta["status"] = "up"
+        _meta_path(run).write_text(json.dumps(meta, indent=2) + "\n")
+    except BaseException:
+        try:
+            down(run)  # safe: sandbox.json exists, so this kills both process GROUPS
+        except BaseException as exc:   # noqa: BLE001 — a teardown error must not MASK the abort
+            print(f"[sandbox] teardown after abort FAILED: {exc}", file=sys.stderr)
         raise
-    meta["status"] = "up"
-    _meta_path(run).write_text(json.dumps(meta, indent=2) + "\n")
-    LQW.restore_front(front_before)     # hand focus back; never re-activate the player
+    finally:
+        # In a finally, not on the success path only: a run that aborts has just as much stolen the
+        # owner's focus as one that succeeds.
+        LQW.restore_front(front_before)
     print(f"[sandbox] UP — engine {meta['engine']}  qa {meta['qa']}  (pids {meta['pids']})  "
-          f"window {win_w}x{win_h} (screen {meta['screen'][0]}x{meta['screen'][1]})")
+          f"window {win_w}x{win_h} (screen {meta['screen'][0]}x{meta['screen'][1]})  "
+          f"home {home}")
     return meta
 
 
@@ -554,9 +724,15 @@ def down(run: str) -> int:
         return 0
     meta = json.loads(mp.read_text())
     pids = {n: int(p) for n, p in meta.get("pids", {}).items()}
+    pgids = meta.get("pgids") or {}
     leaks: list = []
     for name, pid in pids.items():
-        _kill_group(pid, name)            # own session group only (start_new_session)
+        # IDENTITY FIRST: a recorded pid can have been recycled by the OS since `up`, and killpg on a
+        # stale number takes out an unrelated process TREE. _kill_group refuses on a pgid mismatch.
+        refused = _kill_group(pid, name, expect_pgid=pgids.get(name))
+        if refused:
+            leaks.append(f"NOT SIGNALLED: {name} pid {pid} — {refused}")
+            continue
         deadline = time.time() + 5.0
         while time.time() < deadline and _pid_alive(pid):
             time.sleep(0.5)
@@ -574,17 +750,26 @@ def down(run: str) -> int:
     after = _plist_snapshot()
     diff = _plist_diff(before, after)
     foreign = _player_pids() - set(pids.values())
-    report = _plist_restore(diff, foreign_alive=bool(foreign))
+    win = meta.get("win") or []
+    rig_values = _rig_written_values(*win[:2]) if len(win) >= 2 else {}
+    report = _plist_restore(diff, foreign_alive=bool(foreign), rig_values=rig_values)
     report.update({"domain": PLIST_DOMAIN, "before": before, "after": after, "changed": diff,
-                   "foreign_player_pids": sorted(foreign)})
+                   "rig_values": rig_values, "foreign_player_pids": sorted(foreign)})
     (_rundir(run) / "prefs_leak.json").write_text(json.dumps(report, indent=2) + "\n")
     if diff:
-        print(f"[sandbox] shared plist CHANGED by this run: {sorted(diff)} "
-              f"(restored={sorted(report['restored'])}) — see {_rundir(run)/'prefs_leak.json'}")
+        print(f"[sandbox] shared plist CHANGED by this run: {sorted(diff)}")
+        for key, old in sorted(report["restored"].items()):
+            print(f"[sandbox]   RESTORED   {key!r} -> {old!r}")
+        for key, why in sorted(report["skipped"].items()):
+            print(f"[sandbox]   LEFT AS-IS {key!r}: {why}")
+        unrestored = sorted(set(diff) - set(report["restored"]))
+        if unrestored:
+            print(f"[sandbox] LEAK CHECK: {len(unrestored)} changed key(s) NOT restored "
+                  f"{unrestored} — see {_rundir(run)/'prefs_leak.json'}")
         if report["note"]:
             print(f"[sandbox] {report['note']}", file=sys.stderr)
     else:
-        print("[sandbox] shared plist clean — no Screenmanager/UnitySelectMonitor key changed.")
+        print("[sandbox] shared plist clean — no non-churn key changed.")
 
     # ORPHAN SCAN, two sensors. The QA port is the rig's EXACT identity (owner = 8971); every other
     # WorldOSPlayer pid is the OWNER's game — report it, never signal it.
@@ -593,6 +778,9 @@ def down(run: str) -> int:
     for line in stray["lines"]:
         print(line)
 
+    # the teardown ledger travels WITH the run metadata, not only in prefs_leak.json
+    meta["stopped"] = {"plist": report, "orphans": stray["lines"], "leaks": leaks}
+    mp.write_text(json.dumps(meta, indent=2) + "\n")
     mp.rename(mp.with_suffix(".json.stopped"))
     print(f"[sandbox] DOWN — state/logs kept at {_rundir(run)} for evidence")
     return 1 if leaks else 0
@@ -642,13 +830,16 @@ def status(run: str) -> dict:
     meta["engine_ok"] = _http_ok(meta["engine"] + "/combat-surface")
     meta["qa_ok"] = _http_ok(meta["qa"] + "/debug", post=True)
     meta["up"] = meta["engine_ok"] and meta["qa_ok"]
+    pid = int((meta.get("pids") or {}).get("player") or 0)
+    bad = LQW.fullscreen_verdict(pid) if pid else None      # read-only; `watchdog` is the one that acts
+    meta["takeover"] = bad["bounds"] if bad else None
     return meta
 
 
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("cmd", choices=["up", "down", "status", "orphans"])
+    ap.add_argument("cmd", choices=["up", "down", "status", "watchdog", "orphans"])
     ap.add_argument("--run", default="default")
     ap.add_argument("--campaign", default=DEFAULT_CAMPAIGN)
     ap.add_argument("--engine-port", type=int, default=ENGINE_PORT)
@@ -665,6 +856,25 @@ def main(argv=None) -> int:
            qa_port=args.qa_port, seed_cmd=args.seed_cmd, app=Path(args.app))
     elif args.cmd == "down":
         return down(args.run)
+    elif args.cmd == "watchdog":
+        # Run this periodically for the duration of a sweep: the boot checks only prove the first
+        # second, and this is a permission-free CGWindowList read that costs nothing.
+        mp = _meta_path(args.run)
+        if not mp.exists():
+            print(f"[sandbox] no sandbox.json for '{args.run}' — nothing to watch")
+            return 0
+        meta = json.loads(mp.read_text())
+        pid = int((meta.get("pids") or {}).get("player") or 0)
+        if not pid:
+            print(f"[sandbox] no player pid recorded for '{args.run}'", file=sys.stderr)
+            return 0
+        try:
+            _watchdog(pid, pgid=(meta.get("pgids") or {}).get("player"))
+        except SystemExit:
+            down(args.run)      # the player is already dead; this reclaims the engine + the plist
+            raise
+        print(f"[sandbox] watchdog OK — player {pid} is windowed and on-screen.")
+        return 0
     elif args.cmd == "orphans":
         rep = _orphan_report(qa_url=f"http://127.0.0.1:{args.qa_port}")
         for line in rep["lines"]:

--- a/qa/qa_sandbox.py
+++ b/qa/qa_sandbox.py
@@ -17,15 +17,34 @@ differences: (1) NO `osascript quit app "WorldOSPlayer"` — that kills EVERY in
 owner's; teardown signals only the PIDs this module started. (2) The engine runs through
 `uv run --directory servers/engine` so it gets the real venv (the plist pattern).
 
+QA RIG vs THE OWNER'S GAME (#1672, incident 2026-09-02) — read this before changing the launch:
+- The rig is launched WINDOWED and never fullscreen: `-screen-fullscreen 0 -screen-width W
+  -screen-height H` (Unity standalone args, honored before the app's own window setup). This lane
+  was the ONLY player launch site that skipped the #1456 windowed contract in
+  qa/lib_native_player_boot.sh:81-88, so it inherited the SHARED plist's "Screenmanager Fullscreen
+  mode"=1 + "Resolution Use Native"=1 and took over the developer's only display.
+- An owner-active guard (ioreg HIDIdleTime, FORCE_PLAYER_QA=1 override, exit 75) refuses to launch
+  while someone is using the Mac.
+- A permission-free CGWindowList watchdog (qa/lib_qa_window.py) proves from the window server's own
+  BOUNDS — not from the player's /health — that the window is neither fullscreen nor offscreen, and
+  tears the run down within ~25s if it is.
+- Bundle id is SHARED with the owner's game (ProjectSettings.asset:171), so the rig NEVER writes
+  ~/Library/Preferences/com.worldos.WorldOSPlayer.plist. `down` snapshots/diffs/restores instead.
+- TELLING THEM APART TODAY: window geometry, `lsof -nP -iTCP:8972 -sTCP:LISTEN -t` (owner = 8971),
+  and sandbox.json. The rig's window TITLE is still "WorldOSPlayer" — the #1672 badge needs the
+  Phase 2 C# change (docs/qa/QA-RIG-WINDOW-BADGE.md) and an Editor rebuild.
+
 Caveats:
 - Two player instances share Application Support/com.worldos.WorldOSPlayer — /shot writes collide.
-  Don't run owner-instance probes and a sandbox sweep at the same moment.
+  Don't run owner-instance probes and a sandbox sweep at the same moment. The owner-active guard
+  makes that unlikely; it is NOT an interlock.
 - 16 GB host: ONE sandbox at a time; always teardown (the overnight-loop RAM discipline).
 
 Usage:
   qa/qa_sandbox.py up   --run scale1            # seed + engine + player; prints the endpoints
   qa/qa_sandbox.py status --run scale1
   qa/qa_sandbox.py down --run scale1            # kill own pids; state/logs kept for evidence
+  qa/qa_sandbox.py orphans                      # rig leftovers on :8972 / stray player windows
   # or via the orchestrator:  qa/room_pipeline.py --room crypt --sandbox
 Custom seed (new rooms): --seed-cmd "uv run --directory servers/engine python qa/my_seed.py {state}"
 """
@@ -43,6 +62,9 @@ import time
 import urllib.request
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import lib_qa_window as LQW  # noqa: E402  (read-only CGWindowList sensors; see its module docstring)
+
 HERE = Path(__file__).resolve().parent
 REPO = HERE.parent
 ROOT = Path(os.environ.get("WORLDOS_QA_SANDBOX_ROOT", "/tmp/worldos-qa-sandbox"))
@@ -50,6 +72,207 @@ DEFAULT_APP = Path(os.environ.get("WORLDOS_PLAYER_APP",
                                   str(Path.home() / "Applications" / "WorldOSPlayer.app")))
 DEFAULT_CAMPAIGN = "registered_world_v1"   # what qa/seed_gfx_registered_world.py seeds
 ENGINE_PORT, QA_PORT = 8866, 8972          # owner runs 8766/8971 — never collide
+
+# ── #1672 / incident 2026-09-02: WINDOWED, non-hijacking launch ────────────────────────────────────
+# Same env NAMES as the shell helper (qa/lib_native_player_boot.sh:83-85) so all three player lanes
+# are one knob. 700 (not the shell lane's 800) because this display is 1492x817 POINTS with ~792
+# usable after the menu bar — 800 does not fit — and 1280x700 (aspect 1.829) is >= the display's
+# 1.826, so the ortho crop (walk_test.world_to_window_px) shows at least as much world as the
+# fullscreen baseline and no sample cell that was in frame falls out.
+WIN_W, WIN_H = 1280, 700
+WIN_MIN_W, WIN_MIN_H = 640, 400
+CAFFEINATE_FLAGS = os.environ.get("WORLDOS_QA_CAFFEINATE_FLAGS", "-is").split()
+OWNER_ACTIVE_RC = 75                      # parity with PLAYER_QA_OWNER_ACTIVE_RC (shell lane)
+PLIST_DOMAIN = "com.worldos.WorldOSPlayer"    # SHARED with the owner's game (same bundle id)
+SCREEN_KEYS = ("Screenmanager Fullscreen mode", "Screenmanager Fullscreen mode Default",
+               "Screenmanager Resolution Width", "Screenmanager Resolution Height",
+               "Screenmanager Resolution Width Default", "Screenmanager Resolution Height Default",
+               "Screenmanager Resolution Use Native", "Screenmanager Resolution Use Native Default",
+               "Screenmanager Window Position X", "Screenmanager Window Position Y",
+               "UnitySelectMonitor")
+# deliberately EXCLUDED (they churn every launch, so including them would make every run look like a
+# leak): unity.player_session_count, unity.player_sessionid, unity_connect.*
+
+
+# ── owner-active guard (Python port of qa/lib_native_player_boot.sh:51-71) ─────────────────────────
+def owner_active_guard() -> None:
+    """Refuse to launch while the owner is using the Mac. SystemExit(75) when they are.
+
+    HIDIdleTime is nanoseconds since the last HID event. A missing/unreadable value is treated as
+    idle (proceed) — headless-box parity with the shell lane, which must not block on a box with no
+    console user.
+    """
+    if os.environ.get("FORCE_PLAYER_QA", "0") == "1":
+        print("[guard] FORCE_PLAYER_QA=1 — bypassing owner-active guard.", file=sys.stderr)
+        return
+    try:
+        threshold = int(os.environ.get("WORLDOS_PLAYER_IDLE_THRESHOLD") or 120)
+    except ValueError:
+        threshold = 120
+    try:
+        out = subprocess.run(["ioreg", "-c", "IOHIDSystem"],
+                             capture_output=True, text=True, timeout=20).stdout or ""
+    except Exception:  # noqa: BLE001
+        out = ""
+    idle_ns = None
+    for line in out.splitlines():
+        if "HIDIdleTime" in line:
+            tok = line.split()[-1].strip()
+            if tok.isdigit():
+                idle_ns = int(tok)
+            break
+    if idle_ns is None:
+        print("[guard] WARN: could not read HIDIdleTime — proceeding (assume idle).", file=sys.stderr)
+        return
+    idle_s = idle_ns // 1_000_000_000
+    if idle_s < threshold:
+        print(f"SANDBOX-DEFERRED (owner active): last input {idle_s}s ago (< {threshold}s). "
+              f"Set FORCE_PLAYER_QA=1 to override.", file=sys.stderr)
+        raise SystemExit(OWNER_ACTIVE_RC)
+    print(f"[guard] owner idle {idle_s}s (>= {threshold}s) — OK to launch the sandbox player.",
+          file=sys.stderr)
+
+
+def _win_size_from_env() -> tuple:
+    raw_w = str(os.environ.get("WORLDOS_PLAYER_WIN_W") or WIN_W)
+    raw_h = str(os.environ.get("WORLDOS_PLAYER_WIN_H") or WIN_H)
+    if not (raw_w.isdigit() and raw_h.isdigit()):
+        raise SystemExit(f"[sandbox] WORLDOS_PLAYER_WIN_W/H must be integers "
+                         f"(got {raw_w!r}/{raw_h!r})")
+    w, h = int(raw_w), int(raw_h)
+    if w < WIN_MIN_W or h < WIN_MIN_H:
+        raise SystemExit(f"[sandbox] window {w}x{h} is below the {WIN_MIN_W}x{WIN_MIN_H} floor — a "
+                         f"tiny window shrinks a grid cell below the pixel-diff threshold and the "
+                         f"visual stage goes false-RED.")
+    return w, h
+
+
+def _player_windowed_args(logfile) -> list:
+    """Unity standalone args that force a WINDOWED player at a display-fitted size.
+
+    -screen-fullscreen/-screen-width/-screen-height are Unity's own built-in standalone args, honored
+    before the app's own window setup — no C# change and no plist write needed, and they win over
+    whatever the SHARED plist holds. -logFile puts THIS run's player log in the run dir instead of
+    the shared, overwritten-every-launch default.
+
+    The fit clamp keeps the window inside the real desktop (menu bar + margin) while never letting
+    the aspect drop BELOW the display's: a narrower window would crop horizontal world out of the
+    ortho frame and cells that were in frame at fullscreen would project outside the capture.
+    """
+    w, h = _win_size_from_env()
+    dw, dh = LQW.main_display_points()
+    if dw > 0 and dh > 0:
+        h = min(h, dh - 120)
+        w = max(w, round(h * dw / dh))
+        w = min(w, dw - 160)
+    args = ["-screen-fullscreen", "0", "-screen-width", str(int(w)), "-screen-height", str(int(h))]
+    if logfile:
+        args += ["-logFile", str(logfile)]
+    return args
+
+
+# ── shared-plist leak check (#1672 item 3) ─────────────────────────────────────────────────────────
+def _plist_read(key: str):
+    try:
+        p = subprocess.run(["defaults", "read", PLIST_DOMAIN, key],
+                           capture_output=True, text=True, timeout=15)
+    except Exception:  # noqa: BLE001
+        return None
+    return p.stdout.strip() if p.returncode == 0 else None
+
+
+def _plist_snapshot() -> dict:
+    return {k: _plist_read(k) for k in SCREEN_KEYS}
+
+
+def _plist_diff(before: dict, after: dict) -> dict:
+    return {k: {"before": before.get(k), "after": after.get(k)}
+            for k in SCREEN_KEYS if before.get(k) != after.get(k)}
+
+
+def _plist_restore(diff: dict, *, foreign_alive: bool) -> dict:
+    """Put the SHARED domain back the way we found it. Detect-only would ship the owner a regression.
+
+    Ordering constraint: the caller must confirm OUR pids are dead first — a live instance writes on
+    quit and cfprefsd caches the domain, so an early restore is silently clobbered. For the same
+    reason we refuse to write while a FOREIGN player is alive.
+    """
+    report = {"restored": {}, "note": ""}
+    if not diff:
+        return report
+    if os.environ.get("WORLDOS_QA_PLIST_RESTORE", "1") != "1":
+        report["note"] = "WORLDOS_QA_PLIST_RESTORE=0 — detect only; the shared plist was NOT restored."
+        return report
+    if foreign_alive:
+        report["note"] = ("a foreign WorldOSPlayer is still running — NOT writing the shared domain "
+                          "(cfprefsd would clobber the write when that instance quits). Re-run "
+                          "`qa/qa_sandbox.py down --run <run>` once it has exited.")
+        return report
+    for key, ba in diff.items():
+        old = ba.get("before")
+        if old is None:
+            subprocess.run(["defaults", "delete", PLIST_DOMAIN, key],
+                           capture_output=True, text=True)
+        else:
+            subprocess.run(["defaults", "write", PLIST_DOMAIN, key, "-int", str(old)],
+                           capture_output=True, text=True)
+        report["restored"][key] = old
+    return report
+
+
+def _player_pids(exe: str = "WorldOSPlayer") -> set:
+    try:
+        p = subprocess.run(["pgrep", "-x", exe], capture_output=True, text=True, timeout=15)
+    except Exception:  # noqa: BLE001
+        return set()
+    return {int(t) for t in p.stdout.split() if t.strip().isdigit()}
+
+
+def _kill_group(pid: int, label: str = "") -> None:
+    """SIGTERM then SIGKILL the process GROUP. Never terminate() — see the caffeinate note in up()."""
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(os.getpgid(pid), sig)
+            time.sleep(1.5)
+        except ProcessLookupError:
+            return
+        except PermissionError:
+            print(f"[sandbox] cannot signal {label or 'pid'} {pid}", file=sys.stderr)
+            return
+
+
+def _assert_windowed(qa_port: int, w: int, h: int, *, timeout_s: float = 20.0,
+                     interval: float = 1.0) -> tuple:
+    """POLL /health until the player reports a rendered window size, then assert it is ours.
+
+    Must POLL, never one-shot: CombatSurfaceClient caches _screenW/_screenH inside the QA-click
+    block and after the `_busy` early-out (CombatSurfaceClient.cs:2320-2326), so they read 0 until a
+    non-busy QA frame has run — while /debug already answers from the listener thread.
+    Accepts (w,h) and (2w,2h): macRetinaSupport=1 and this display is a 2x HiDPI mode.
+    """
+    deadline = time.time() + timeout_s
+    last = None
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(f"http://127.0.0.1:{qa_port}/health")
+            with urllib.request.urlopen(req, timeout=3) as r:
+                d = json.loads(r.read().decode("utf-8"))
+            sw, sh = int(d.get("screenW") or 0), int(d.get("screenH") or 0)
+        except Exception:  # noqa: BLE001
+            sw = sh = 0
+        if sw > 0 and sh > 0:
+            last = (sw, sh)
+            if last in ((w, h), (2 * w, 2 * h)):
+                return last
+            raise SystemExit(
+                f"[sandbox] player is NOT windowed at the requested size: /health reports {sw}x{sh}, "
+                f"expected {w}x{h} (or the 2x HiDPI {2*w}x{2*h}). The -screen-* args were ignored — "
+                f"do NOT run a sweep against this instance.")
+        time.sleep(interval)
+    raise SystemExit(
+        f"[sandbox] /health never reported a rendered window size within {timeout_s:.0f}s "
+        f"(last={last}) — the QA channel is up but no QA frame has run; treat the geometry as "
+        f"UNVERIFIED and tear the run down.")
 
 
 def _http_ok(url: str, post: bool = False, timeout: float = 3.0) -> bool:
@@ -185,6 +408,11 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
     if _meta_path(run).exists():
         raise SystemExit(f"[sandbox] run '{run}' already provisioned — `down` it first ({rd})")
 
+    # 0a) #1672: never launch a QA player over an owner who is actively using the Mac.
+    owner_active_guard()
+    plist_before = _plist_snapshot()      # SHARED domain — snapshot now, diff + restore in down()
+    front_before = LQW.front_app_name()   # so the run can hand focus back (Launch Services, no AX)
+
     # 0) PREFLIGHT the .app before anything is created or spawned. Both of these used to run after the
     #    engine was already up, so a rejected app still seeded state and left an engine behind that no
     #    run metadata could clean up (terminate() is non-blocking and `down` needs sandbox.json).
@@ -224,7 +452,9 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
         cwd=REPO, env=env, stdout=eng_log, stderr=subprocess.STDOUT,
         start_new_session=True)
     if not _wait("engine", f"http://127.0.0.1:{engine_port}/combat-surface", post=False, timeout_s=90):
-        engine.terminate()
+        # killpg, NOT terminate(): engine.pid is the `uv` WRAPPER — SIGTERM to it leaves the real
+        # viewer/server.py holding the port, and `down` has no sandbox.json to clean up with yet.
+        _kill_group(engine.pid, "engine")
         raise SystemExit(f"[sandbox] engine never came up — see {rd/'engine.log'}")
 
     # 3) a SECOND player instance — direct binary exec (open -n drops env), own QA port.
@@ -236,42 +466,172 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
                 WORLDOS_QA_INPUT="1",
                 WORLDOS_QA_INPUT_PORT=str(qa_port))
     ply_log = open(rd / "player.log", "w")  # noqa: SIM115
-    # caffeinate -disu: a background/occluded sandbox player can App-Nap -> throttled rendering ->
-    # delayed /shot frames and glide stalls mid-sweep (sidecar review). caffeinate exits with the child.
-    player = subprocess.Popen(["/usr/bin/caffeinate", "-disu", str(pbin)], env=penv, stdout=ply_log,
-                              stderr=subprocess.STDOUT, start_new_session=True)
+    win_args = _player_windowed_args(rd / "unity_player.log")
+    win_w = int(win_args[win_args.index("-screen-width") + 1])
+    win_h = int(win_args[win_args.index("-screen-height") + 1])
+    argv = [str(pbin), *win_args]
+    print(f"[sandbox] player argv: {' '.join(argv)}")
+    # The player is its OWN Popen — NOT a caffeinate child. caffeinate does not forward SIGTERM, so
+    # the old `caffeinate -disu <player>` shape meant terminate() killed only caffeinate and the
+    # Unity child reparented to launchd and SURVIVED — a fullscreen orphan nothing could clean up.
+    # caffeinate is now a SIBLING watcher (`-w <pid>`, exits with the player) in the SAME process
+    # group, and -d/-u are gone: -u ASSERTS USER ACTIVITY (wakes and holds the owner's display).
+    # -i (idle) + -s (system sleep) still keep App-Nap -> throttled-render -> delayed /shot away.
+    player = subprocess.Popen(argv, env=penv, stdout=ply_log, stderr=subprocess.STDOUT,
+                              start_new_session=True)
+    caff = subprocess.Popen(["/usr/bin/caffeinate", *CAFFEINATE_FLAGS, "-w", str(player.pid)],
+                            stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT,
+                            start_new_session=False)
+
+    meta = {"run": run, "campaign": campaign, "state": str(state), "status": "booting",
+            "engine": f"http://127.0.0.1:{engine_port}", "qa": f"http://127.0.0.1:{qa_port}",
+            "win": [win_w, win_h], "argv": argv, "screen": None,
+            "plist_before": plist_before, "front_before": front_before,
+            "pids": {"engine": engine.pid, "player": player.pid},
+            "pgids": {"engine": os.getpgid(engine.pid), "player": os.getpgid(player.pid)},
+            "caffeinate_pid": caff.pid}
+    # ANTI-ORPHAN FENCE: write the metadata BEFORE the readiness wait. Previously it was written
+    # after, so a boot timeout raised with nothing on disk and `down` had no pids to kill.
+    _meta_path(run).write_text(json.dumps(meta, indent=2) + "\n")
+
+    # WATCHDOG (permission-free, window-server bounds — not the player's self-report): bound a
+    # flags-ignored regression to ~25s instead of a machine lockup.
+    wins = LQW.wait_for_window(player.pid, timeout=25)
+    if not wins:
+        print("[sandbox] WARN: CGWindowList shows no content window for the player yet — "
+              "geometry unverified at this point (the /health assertion below still gates).",
+              file=sys.stderr)
+    else:
+        dsp = LQW.main_display_points()
+        bad = LQW.fullscreen_verdict(player.pid)
+        if bad:
+            down(run)
+            raise SystemExit(f"[sandbox] ABORT — player came up FULLSCREEN {bad['bounds']} on the "
+                             f"main display {dsp}. Torn down. The -screen-fullscreen 0 arg was "
+                             f"ignored; do not re-run until that is understood.")
+        bad = LQW.offscreen_verdict(player.pid)
+        if bad:
+            down(run)
+            raise SystemExit(f"[sandbox] ABORT — player window {bad['bounds']} is effectively "
+                             f"OFFSCREEN on display {dsp}. Torn down: an offscreen window returns "
+                             f"black/stale ScreenCapture frames with no HTTP error, which the "
+                             f"visual stage would read as 'the actor never moved'.")
+
     if not _wait("player QA channel", f"http://127.0.0.1:{qa_port}/debug", post=True, timeout_s=120):
-        player.terminate()
-        engine.terminate()
+        down(run)      # safe now: sandbox.json exists, so this kills both process GROUPS
         raise SystemExit(f"[sandbox] player QA channel never came up — see {rd/'player.log'}")
 
-    meta = {"run": run, "campaign": campaign, "state": str(state),
-            "engine": f"http://127.0.0.1:{engine_port}", "qa": f"http://127.0.0.1:{qa_port}",
-            "pids": {"engine": engine.pid, "player": player.pid}}
+    try:
+        meta["screen"] = list(_assert_windowed(qa_port, win_w, win_h))
+    except SystemExit:
+        down(run)       # a mis-sized/unverifiable player must not survive the failed assertion
+        raise
+    meta["status"] = "up"
     _meta_path(run).write_text(json.dumps(meta, indent=2) + "\n")
-    print(f"[sandbox] UP — engine {meta['engine']}  qa {meta['qa']}  (pids {meta['pids']})")
+    LQW.restore_front(front_before)     # hand focus back; never re-activate the player
+    print(f"[sandbox] UP — engine {meta['engine']}  qa {meta['qa']}  (pids {meta['pids']})  "
+          f"window {win_w}x{win_h} (screen {meta['screen'][0]}x{meta['screen'][1]})")
     return meta
 
 
-def down(run: str) -> None:
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def down(run: str) -> int:
+    """Kill ONLY this run's process groups, verify they died, then leak-check + restore the SHARED
+    plist. Returns 0 clean, non-zero if anything leaked. NEVER `osascript quit app "WorldOSPlayer"`
+    — that kills EVERY instance, including the owner's live game."""
     mp = _meta_path(run)
     if not mp.exists():
         print(f"[sandbox] no sandbox.json for '{run}' — nothing to stop")
-        return
+        return 0
     meta = json.loads(mp.read_text())
-    for name, pid in meta.get("pids", {}).items():
-        for sig in (signal.SIGTERM, signal.SIGKILL):
-            try:
-                os.killpg(os.getpgid(pid), sig)   # own session group only (start_new_session)
-                time.sleep(1.5)
-            except ProcessLookupError:
-                break
-            except PermissionError:
-                print(f"[sandbox] cannot signal {name} pid {pid}")
-                break
-        print(f"[sandbox] stopped {name} (pid {pid})")
+    pids = {n: int(p) for n, p in meta.get("pids", {}).items()}
+    leaks: list = []
+    for name, pid in pids.items():
+        _kill_group(pid, name)            # own session group only (start_new_session)
+        deadline = time.time() + 5.0
+        while time.time() < deadline and _pid_alive(pid):
+            time.sleep(0.5)
+        if _pid_alive(pid):
+            leaks.append(f"LEAK: {name} pid {pid} SURVIVED SIGKILL")
+            print(f"[sandbox] LEAK: {name} pid {pid} SURVIVED SIGKILL", file=sys.stderr)
+        else:
+            print(f"[sandbox] stopped {name} (pid {pid})")
+
+    # LEAK CHECK (#1672 item 3) — ORDER MATTERS: only diff after OUR pids are confirmed dead. A live
+    # instance writes the domain on quit and cfprefsd caches it, so an earlier diff reads the wrong
+    # state and an earlier restore is silently clobbered.
+    time.sleep(2.0)
+    before = meta.get("plist_before") or {}
+    after = _plist_snapshot()
+    diff = _plist_diff(before, after)
+    foreign = _player_pids() - set(pids.values())
+    report = _plist_restore(diff, foreign_alive=bool(foreign))
+    report.update({"domain": PLIST_DOMAIN, "before": before, "after": after, "changed": diff,
+                   "foreign_player_pids": sorted(foreign)})
+    (_rundir(run) / "prefs_leak.json").write_text(json.dumps(report, indent=2) + "\n")
+    if diff:
+        print(f"[sandbox] shared plist CHANGED by this run: {sorted(diff)} "
+              f"(restored={sorted(report['restored'])}) — see {_rundir(run)/'prefs_leak.json'}")
+        if report["note"]:
+            print(f"[sandbox] {report['note']}", file=sys.stderr)
+    else:
+        print("[sandbox] shared plist clean — no Screenmanager/UnitySelectMonitor key changed.")
+
+    # ORPHAN SCAN, two sensors. The QA port is the rig's EXACT identity (owner = 8971); every other
+    # WorldOSPlayer pid is the OWNER's game — report it, never signal it.
+    stray = _orphan_report(qa_url=meta.get("qa"), our_pids=set(pids.values()))
+    leaks += stray["leaks"]
+    for line in stray["lines"]:
+        print(line)
+
     mp.rename(mp.with_suffix(".json.stopped"))
     print(f"[sandbox] DOWN — state/logs kept at {_rundir(run)} for evidence")
+    return 1 if leaks else 0
+
+
+def _listeners(port: int) -> set:
+    try:
+        p = subprocess.run(["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
+                           capture_output=True, text=True, timeout=15)
+    except Exception:  # noqa: BLE001
+        return set()
+    return {int(t) for t in p.stdout.split() if t.strip().isdigit()}
+
+
+def _orphan_report(*, qa_url=None, our_pids: set = frozenset()) -> dict:
+    port = QA_PORT
+    if qa_url:
+        try:
+            port = int(str(qa_url).rsplit(":", 1)[-1].strip("/"))
+        except ValueError:
+            port = QA_PORT
+    lines, leaks = [], []
+    held = _listeners(port)
+    if held:
+        leaks.append(f"LEAK: QA port {port} still LISTENing (pids {sorted(held)})")
+        lines.append(f"[sandbox] LEAK: QA port {port} still held by pids {sorted(held)} — that port "
+                     f"is the rig's identity (owner = 8971), so those are ours to kill.")
+    else:
+        lines.append(f"[sandbox] QA port {port} free.")
+    ours, theirs = [], []
+    for w in LQW.cg_windows(owner="WorldOSPlayer"):
+        (ours if w["pid"] in our_pids else theirs).append(w["pid"])
+    if ours:
+        leaks.append(f"LEAK: sandbox player window still on screen (pids {sorted(set(ours))})")
+        lines.append(f"[sandbox] LEAK: sandbox player windows still on screen: {sorted(set(ours))}")
+    if theirs:
+        lines.append(f"[sandbox] NOTE: {len(set(theirs))} other WorldOSPlayer window(s) "
+                     f"(pids {sorted(set(theirs))}) — that is the OWNER's game. NOT touched.")
+    return {"lines": lines, "leaks": leaks, "port": port, "port_pids": sorted(held)}
 
 
 def status(run: str) -> dict:
@@ -288,7 +648,7 @@ def status(run: str) -> dict:
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("cmd", choices=["up", "down", "status"])
+    ap.add_argument("cmd", choices=["up", "down", "status", "orphans"])
     ap.add_argument("--run", default="default")
     ap.add_argument("--campaign", default=DEFAULT_CAMPAIGN)
     ap.add_argument("--engine-port", type=int, default=ENGINE_PORT)
@@ -304,7 +664,12 @@ def main(argv=None) -> int:
         up(args.run, campaign=args.campaign, engine_port=args.engine_port,
            qa_port=args.qa_port, seed_cmd=args.seed_cmd, app=Path(args.app))
     elif args.cmd == "down":
-        down(args.run)
+        return down(args.run)
+    elif args.cmd == "orphans":
+        rep = _orphan_report(qa_url=f"http://127.0.0.1:{args.qa_port}")
+        for line in rep["lines"]:
+            print(line)
+        return 1 if rep["leaks"] else 0
     else:
         print(json.dumps(status(args.run), indent=2))
     return 0

--- a/qa/test_native_palette.py
+++ b/qa/test_native_palette.py
@@ -428,6 +428,23 @@ class NoHijackLaunchTests(unittest.TestCase):
     def test_player_smoke_is_no_hijack(self):
         self._assert_runner_no_hijack(SMOKE_RUNNER.read_text(encoding="utf-8"))
 
+    def test_qa_sandbox_lane_is_no_hijack(self):
+        """#1672 / incident 2026-09-02: qa/qa_sandbox.py was the ONLY player launch site that skipped
+        the #1456 contract above, so it inherited the SHARED plist's fullscreen+native-resolution
+        state and took over the developer's only display. It is a Python lane, not a shell runner, so
+        it re-implements the same two fences plus a plist leak check — fenced by the same test class
+        as the two shell lanes so the three cannot drift apart again."""
+        src = (ROOT / "qa" / "qa_sandbox.py").read_text(encoding="utf-8")
+        self.assertIn("-screen-fullscreen", src, "sandbox launch must force -screen-fullscreen 0")
+        self.assertIn("-screen-width", src)
+        self.assertIn("-logFile", src)
+        self.assertIn("HIDIdleTime", src, "guard must read console-user idle from ioreg HIDIdleTime")
+        self.assertIn("FORCE_PLAYER_QA", src, "guard must honor a FORCE_PLAYER_QA=1 override")
+        self.assertIn("SANDBOX-DEFERRED (owner active)", src)
+        self.assertIn("os.killpg", src, "teardown is process-GROUP scoped, never terminate()")
+        self.assertIn("_plist_snapshot", src, "the SHARED bundle id needs a plist leak check")
+        self.assertNotIn("activate_current_space_context", src)
+
 
 class PlayerSmokeTests(unittest.TestCase):
     """qa/player_smoke.sh (#1443) — the deterministic, headless-of-agents post-build check."""

--- a/qa/test_qa_sandbox_window.py
+++ b/qa/test_qa_sandbox_window.py
@@ -494,8 +494,9 @@ def test_wait_runs_the_watchdog_every_poll(monkeypatch):
     polls: list = []
     monkeypatch.setattr(qa_sandbox, "_http_ok", lambda *a, **k: bool(polls) and len(polls) >= 2)
     monkeypatch.setattr(qa_sandbox.time, "sleep", lambda *_: None)
-    assert qa_sandbox._wait("x", "http://x", post=True, timeout_s=5,
-                            on_poll=lambda: polls.append(1)) is True
+    waited = qa_sandbox._wait("x", "http://x", post=True, timeout_s=5,
+                              on_poll=lambda: polls.append(1))
+    assert waited is True
     assert len(polls) >= 2
 
 

--- a/qa/test_qa_sandbox_window.py
+++ b/qa/test_qa_sandbox_window.py
@@ -5,9 +5,16 @@ The incident: `qa/qa_sandbox.py up` launched the second player instance with NO 
 so it inherited the SHARED plist's "Screenmanager Fullscreen mode"=1 + "Resolution Use Native"=1,
 came up fullscreen on the developer's only display during a gate run, and the Mac had to be rebooted.
 
+Round 2 (two adversarial reviews + a live launch on 2026-09-02) added the properties the first cut
+got wrong, and they are the load-bearing half of this file: the teardown restores the SHARED plist
+only for values THIS rig provably wrote, focus is handed back by PID (never `open -a`, which would
+LAUNCH the owner's player), the geometry assertion tests a coverage bound instead of an exact size,
+`-screen-width` is treated as BACKING PIXELS, the takeover watchdog runs on every poll, and a
+recorded pid is re-verified against its recorded pgid before anything is signalled.
+
 NOTHING here launches a player, opens a port, or touches the real
 ~/Library/Preferences/com.worldos.WorldOSPlayer.plist — every `defaults` / `ioreg` / `lsof` /
-CoreGraphics call is monkeypatched.
+osascript / CoreGraphics call is monkeypatched.
 
 Run: uv run --directory servers/engine python -m pytest qa/test_qa_sandbox_window.py -q -p no:xdist
 """
@@ -15,6 +22,7 @@ from __future__ import annotations
 
 import ast
 import json
+import plistlib
 import sys
 import types
 from pathlib import Path
@@ -30,9 +38,20 @@ SANDBOX_SRC = (HERE / "qa_sandbox.py").read_text(encoding="utf-8")
 WINDOW_SRC = (HERE / "lib_qa_window.py").read_text(encoding="utf-8")
 CSC = HERE.parent / "extensions" / "renderers" / "unity" / "scripts" / "CombatSurfaceClient.cs"
 
+# The measured host, 2026-09-02: a 2x display. POINTS is what CGWindowList speaks; BACKING PIXELS is
+# what Unity's -screen-width/-screen-height and /health speak.
+HOST_POINTS = (1512, 835)
+HOST_BACKING = (3024, 1670)
+
 
 def _proc(stdout="", rc=0):
     return types.SimpleNamespace(stdout=stdout, stderr="", returncode=rc)
+
+
+def _display(monkeypatch, points=HOST_POINTS, backing=HOST_BACKING):
+    monkeypatch.setattr(LQW, "main_display_points", lambda: points)
+    monkeypatch.setattr(LQW, "main_display_backing", lambda: backing)
+    monkeypatch.setattr(LQW, "backing_scale", lambda: (backing[0] / points[0]) if points[0] else 1.0)
 
 
 def _string_literals(path: Path) -> list:
@@ -61,10 +80,10 @@ def _clean_env(monkeypatch):
         monkeypatch.delenv(k, raising=False)
 
 
-# ── launch args ───────────────────────────────────────────────────────────────────────────────────
-def test_player_windowed_args_defaults(monkeypatch):
+# ── launch args: -screen-* are BACKING PIXELS, the desktop budget is POINTS ────────────────────────
+def test_player_windowed_args_defaults_on_a_1x_display(monkeypatch):
     """The exact Unity arg contract, in order: fullscreen OFF, then a fitted size, then the log."""
-    monkeypatch.setattr(LQW, "main_display_points", lambda: (1492, 817))
+    _display(monkeypatch, points=(1492, 817), backing=(1492, 817))
     args = qa_sandbox._player_windowed_args("/x.log")
     assert args == ["-screen-fullscreen", "0", "-screen-width", "1280",
                     "-screen-height", "697", "-logFile", "/x.log"]
@@ -72,30 +91,56 @@ def test_player_windowed_args_defaults(monkeypatch):
     assert args[args.index("-screen-fullscreen") + 1] == "0"
 
 
-def test_win_env_override_and_fit_clamp(monkeypatch):
-    """An oversized request is clamped INTO the desktop, and never below the display's aspect."""
-    monkeypatch.setattr(LQW, "main_display_points", lambda: (1492, 817))
-    monkeypatch.setenv("WORLDOS_PLAYER_WIN_W", "1600")
-    monkeypatch.setenv("WORLDOS_PLAYER_WIN_H", "1000")
+def test_player_windowed_args_on_the_measured_2x_host(monkeypatch):
+    """The live 2026-09-02 launch: 1280x700 asked for, 1280x700 reported by /health, 640x382 points
+    on screen. The default must survive the clamp untouched on the real host."""
+    _display(monkeypatch)
+    args = qa_sandbox._player_windowed_args(None)
+    assert args == ["-screen-fullscreen", "0", "-screen-width", "1280", "-screen-height", "700"]
+
+
+def test_fit_clamp_budget_is_in_backing_pixels_not_points(monkeypatch):
+    """UNITS (round-2 finding): the clamp compares a PIXEL request against a POINT desktop. On a 2x
+    display the usable budget is (835-120)*2 = 1430 pixels tall; clamping to 715 would halve the
+    window for no reason, and on a hypothetical 0.5x it would double it."""
+    _display(monkeypatch)
+    monkeypatch.setenv("WORLDOS_PLAYER_WIN_W", "4000")
+    monkeypatch.setenv("WORLDOS_PLAYER_WIN_H", "3000")
     args = qa_sandbox._player_windowed_args(None)
     w = int(args[args.index("-screen-width") + 1])
     h = int(args[args.index("-screen-height") + 1])
-    assert h == 697, "height must fit under the menu bar (817 - 120)"
-    assert w <= 1332, "width must stay inside the desktop (1492 - 160)"
+    assert h == (835 - 120) * 2, "height budget is a POINT budget converted to pixels"
+    assert w == (1512 - 160) * 2, "width budget likewise"
     # a NARROWER aspect than the display crops horizontal world out of the ortho frame, so a cell
     # that was in frame at the fullscreen baseline would project outside the capture.
-    assert w / h >= 1492 / 817
-    assert "-logFile" not in args
+    assert w / h >= HOST_POINTS[0] / HOST_POINTS[1]
+
+
+def test_fit_clamp_is_inert_when_the_display_cannot_be_measured(monkeypatch):
+    _display(monkeypatch, points=(0, 0), backing=(0, 0))
+    args = qa_sandbox._player_windowed_args(None)
+    assert args[args.index("-screen-width") + 1] == str(qa_sandbox.WIN_W)
+    assert args[args.index("-screen-height") + 1] == str(qa_sandbox.WIN_H)
 
 
 @pytest.mark.parametrize("w,h", [("notanint", "700"), ("1280", "7e2"), ("320", "700"),
                                  ("1280", "200")])
 def test_win_env_rejects_garbage_and_tiny(monkeypatch, w, h):
-    monkeypatch.setattr(LQW, "main_display_points", lambda: (1492, 817))
+    _display(monkeypatch)
     monkeypatch.setenv("WORLDOS_PLAYER_WIN_W", w)
     monkeypatch.setenv("WORLDOS_PLAYER_WIN_H", h)
     with pytest.raises(SystemExit):
         qa_sandbox._player_windowed_args(None)
+
+
+def test_geometry_is_preflighted_before_anything_is_spawned():
+    """The step-0 comment promises the preflight runs 'before anything is created or spawned'. It
+    used to be computed inside step 3, so a bad WORLDOS_PLAYER_WIN_W/H raised only after the seed had
+    run and the engine was already up."""
+    i_win = SANDBOX_SRC.index("win_args = _player_windowed_args")
+    assert i_win < SANDBOX_SRC.index("seed = subprocess.run")
+    assert i_win < SANDBOX_SRC.index("engine = subprocess.Popen")
+    assert i_win < SANDBOX_SRC.index("player = subprocess.Popen")
 
 
 # ── owner-active guard ────────────────────────────────────────────────────────────────────────────
@@ -142,61 +187,150 @@ def test_owner_active_guard_prints_the_documented_line(monkeypatch, capsys):
     assert "SANDBOX-DEFERRED (owner active)" in capsys.readouterr().err
 
 
-# ── shared-plist leak check ───────────────────────────────────────────────────────────────────────
-def _fake_defaults(monkeypatch, values: dict, log: list):
+# ── shared-plist leak check + ATTRIBUTION-SAFE restore ────────────────────────────────────────────
+def _fake_defaults(monkeypatch, domain: dict, log: list):
+    """`defaults export <domain> -` returns the whole domain as an XML plist on stdout (bytes)."""
     def fake_run(cmd, *a, **kw):
         log.append(list(cmd))
-        if cmd[:2] == ["defaults", "read"]:
-            key = cmd[3]
-            return _proc(stdout=values[key], rc=0) if key in values else _proc(rc=1)
+        if cmd[:2] == ["defaults", "export"]:
+            return types.SimpleNamespace(stdout=plistlib.dumps(domain), stderr=b"", returncode=0)
         return _proc(rc=0)
 
     monkeypatch.setattr(qa_sandbox.subprocess, "run", fake_run)
 
 
-def test_plist_snapshot_and_diff(monkeypatch):
+def _writes(log):
+    return [c for c in log if c[:2] in (["defaults", "write"], ["defaults", "delete"])]
+
+
+def test_plist_snapshot_is_whole_domain_minus_churn(monkeypatch):
     log: list = []
-    vals = {"Screenmanager Fullscreen mode": "1", "Screenmanager Resolution Width": "3024"}
-    _fake_defaults(monkeypatch, vals, log)
-    before = qa_sandbox._plist_snapshot()
-    assert before["Screenmanager Fullscreen mode"] == "1"
-    assert before["UnitySelectMonitor"] is None, "an absent key reads None, not ''"
+    _fake_defaults(monkeypatch, {"Screenmanager Fullscreen mode": 1,
+                                 "Screenmanager Resolution Width": 3024,
+                                 "unity.player_session_count": 41,
+                                 "unity.player_sessionid": 12345,
+                                 "unity_connect.access_token": "x",
+                                 "SomeOwnerSetting": 7}, log)
+    snap = qa_sandbox._plist_snapshot()
+    assert snap["Screenmanager Fullscreen mode"] == "1"
+    assert snap["SomeOwnerSetting"] == "7", "the leak check is whole-domain, not a fixed key list"
+    assert not {"unity.player_session_count", "unity.player_sessionid",
+                "unity_connect.access_token"} & set(snap)
+    assert _writes(log) == [], "the snapshot is READ-ONLY"
 
-    after = dict(before, **{"Screenmanager Fullscreen mode": "3",
-                            "unity.player_session_count": "42",
-                            "unity_connect.access_token": "x"})
+
+def test_plist_diff_reports_added_removed_and_changed():
+    before = {"a": "1", "gone": "2"}
+    after = {"a": "3", "new": "9", "unity.player_session_count": "42"}
     diff = qa_sandbox._plist_diff(before, after)
-    assert set(diff) == {"Screenmanager Fullscreen mode"}
-    assert diff["Screenmanager Fullscreen mode"] == {"before": "1", "after": "3"}
-    # churn keys must never be reported, or every run looks like a leak
-    assert not {"unity.player_session_count", "unity.player_sessionid"} & set(diff)
+    assert diff["a"] == {"before": "1", "after": "3"}
+    assert diff["gone"] == {"before": "2", "after": None}
+    assert diff["new"] == {"before": None, "after": "9"}
+    assert "unity.player_session_count" not in diff, "churn keys must never look like a leak"
 
 
-def test_plist_restore_gating(monkeypatch):
+def _rig_diff():
+    """The five keys the live 2026-09-02 run actually moved, as a down()-shaped diff."""
+    return {"Screenmanager Fullscreen mode": {"before": "1", "after": "3"},
+            "Screenmanager Resolution Width": {"before": "3024", "after": "1280"},
+            "Screenmanager Resolution Height": {"before": "1670", "after": "700"},
+            "Screenmanager Resolution Use Native": {"before": "1", "after": "0"},
+            "Screenmanager Window Position Y": {"before": "0", "after": "60"}}
+
+
+def test_restore_writes_only_keys_that_still_hold_the_rig_value(monkeypatch):
     log: list = []
     _fake_defaults(monkeypatch, {}, log)
-    diff = {"Screenmanager Fullscreen mode": {"before": "1", "after": "3"},
-            "Screenmanager Window Position X": {"before": None, "after": "900"}}
+    rep = qa_sandbox._plist_restore(_rig_diff(), foreign_alive=False,
+                                    rig_values=qa_sandbox._rig_written_values(1280, 700))
+    assert sorted(rep["restored"]) == ["Screenmanager Fullscreen mode",
+                                       "Screenmanager Resolution Height",
+                                       "Screenmanager Resolution Use Native",
+                                       "Screenmanager Resolution Width"]
+    assert _writes(log) == [
+        ["defaults", "write", qa_sandbox.PLIST_DOMAIN, "Screenmanager Fullscreen mode", "-int", "1"],
+        ["defaults", "write", qa_sandbox.PLIST_DOMAIN, "Screenmanager Resolution Height", "-int", "1670"],
+        ["defaults", "write", qa_sandbox.PLIST_DOMAIN, "Screenmanager Resolution Use Native", "-int", "1"],
+        ["defaults", "write", qa_sandbox.PLIST_DOMAIN, "Screenmanager Resolution Width", "-int", "3024"],
+    ]
 
-    rep = qa_sandbox._plist_restore(diff, foreign_alive=False)
-    writes = [c for c in log if c[:2] == ["defaults", "write"]]
-    deletes = [c for c in log if c[:2] == ["defaults", "delete"]]
-    assert writes == [["defaults", "write", qa_sandbox.PLIST_DOMAIN,
-                       "Screenmanager Fullscreen mode", "-int", "1"]]
-    assert deletes == [["defaults", "delete", qa_sandbox.PLIST_DOMAIN,
-                        "Screenmanager Window Position X"]]
-    assert set(rep["restored"]) == set(diff)
 
-    log.clear()
-    rep = qa_sandbox._plist_restore(diff, foreign_alive=True)
-    assert [c for c in log if c[:2] in (["defaults", "write"], ["defaults", "delete"])] == []
+def test_restore_never_touches_the_window_position_keys(monkeypatch):
+    log: list = []
+    _fake_defaults(monkeypatch, {}, log)
+    rep = qa_sandbox._plist_restore(_rig_diff(), foreign_alive=False,
+                                    rig_values=qa_sandbox._rig_written_values(1280, 700))
+    for key in qa_sandbox.NEVER_RESTORE:
+        assert key not in rep["restored"]
+    assert "cosmetic" in rep["skipped"]["Screenmanager Window Position Y"]
+    assert not [c for c in _writes(log) if "Position" in c[3]]
+
+
+def test_restore_skips_a_key_the_owner_wrote_last(monkeypatch):
+    """ATTRIBUTION (the round-2 finding): the owner changed their own resolution while the sweep ran.
+    The value is no longer the one this rig writes, so reverting it would be OUR regression."""
+    log: list = []
+    _fake_defaults(monkeypatch, {}, log)
+    diff = {"Screenmanager Resolution Width": {"before": "3024", "after": "1920"},
+            "SomeOwnerSetting": {"before": "7", "after": "9"}}
+    rep = qa_sandbox._plist_restore(diff, foreign_alive=False,
+                                    rig_values=qa_sandbox._rig_written_values(1280, 700))
+    assert rep["restored"] == {}
+    assert "not the value this rig writes" in rep["skipped"]["Screenmanager Resolution Width"]
+    assert "not a key this rig writes" in rep["skipped"]["SomeOwnerSetting"]
+    assert _writes(log) == []
+
+
+def test_restore_refuses_a_non_integer_snapshot_value(monkeypatch):
+    log: list = []
+    _fake_defaults(monkeypatch, {}, log)
+    diff = {"Screenmanager Fullscreen mode": {"before": "windowed", "after": "3"}}
+    rep = qa_sandbox._plist_restore(diff, foreign_alive=False,
+                                    rig_values=qa_sandbox._rig_written_values(1280, 700))
+    assert rep["restored"] == {} and _writes(log) == []
+    assert "not an integer" in rep["skipped"]["Screenmanager Fullscreen mode"]
+
+
+def test_restore_deletes_a_key_that_did_not_exist_before(monkeypatch):
+    log: list = []
+    _fake_defaults(monkeypatch, {}, log)
+    diff = {"Screenmanager Resolution Use Native": {"before": None, "after": "0"}}
+    rep = qa_sandbox._plist_restore(diff, foreign_alive=False,
+                                    rig_values=qa_sandbox._rig_written_values(1280, 700))
+    assert rep["restored"] == {"Screenmanager Resolution Use Native": None}
+    assert _writes(log) == [["defaults", "delete", qa_sandbox.PLIST_DOMAIN,
+                             "Screenmanager Resolution Use Native"]]
+
+
+def test_restore_gating_foreign_player_and_opt_out(monkeypatch):
+    log: list = []
+    _fake_defaults(monkeypatch, {}, log)
+    rig = qa_sandbox._rig_written_values(1280, 700)
+
+    rep = qa_sandbox._plist_restore(_rig_diff(), foreign_alive=True, rig_values=rig)
+    assert _writes(log) == []
     assert rep["restored"] == {} and rep["note"], "a live foreign player must block the write"
+    assert rep["skipped"], "and every changed key must be reported as skipped, with a reason"
 
     log.clear()
     monkeypatch.setenv("WORLDOS_QA_PLIST_RESTORE", "0")
-    rep = qa_sandbox._plist_restore(diff, foreign_alive=False)
-    assert [c for c in log if c[:2] in (["defaults", "write"], ["defaults", "delete"])] == []
+    rep = qa_sandbox._plist_restore(_rig_diff(), foreign_alive=False, rig_values=rig)
+    assert _writes(log) == []
     assert rep["restored"] == {} and "detect only" in rep["note"]
+
+
+# ── teardown identity: a recorded pid is not an identity ──────────────────────────────────────────
+def test_kill_group_refuses_a_reused_pid(monkeypatch):
+    killed: list = []
+    monkeypatch.setattr(qa_sandbox.os, "getpgid", lambda pid: 4242)
+    monkeypatch.setattr(qa_sandbox.os, "killpg", lambda pgid, sig: killed.append((pgid, sig)))
+    monkeypatch.setattr(qa_sandbox.time, "sleep", lambda *_: None)
+
+    why = qa_sandbox._kill_group(999, "player", expect_pgid=1111)
+    assert "reused" in why and killed == [], "a pgid mismatch must NEVER signal a group"
+
+    assert qa_sandbox._kill_group(999, "player", expect_pgid=4242) == ""
+    assert [sig for _pg, sig in killed] == [qa_sandbox.signal.SIGTERM, qa_sandbox.signal.SIGKILL]
 
 
 # ── launch SHAPE (source-level fences) ────────────────────────────────────────────────────────────
@@ -232,7 +366,66 @@ def test_no_osascript_quit_and_no_ax():
         assert "set size of" not in src
 
 
-# ── achieved-geometry assertion ───────────────────────────────────────────────────────────────────
+def test_boot_unwinds_on_any_abort_including_ctrl_c():
+    """KeyboardInterrupt/SystemExit are BaseExceptions: an `except Exception` here leaves a live
+    player and engine behind with only a sandbox.json to prove it."""
+    tail = SANDBOX_SRC.split("player = subprocess.Popen(argv", 1)[1]
+    assert "except BaseException:" in tail
+    body = tail.split("except BaseException:", 1)[1]
+    assert "down(run)" in body.split("raise", 1)[0]
+    assert "finally:" in tail and "LQW.restore_front(front_before)" in tail.split("finally:", 1)[1]
+
+
+def test_per_run_home_isolates_the_shot_directory():
+    """CFFIXED_USER_HOME=<rundir>/home: /shot frames land in the run dir instead of racing the owner
+    instance in the shared Application Support. Consumers copy the ABSOLUTE path /shot returns, so
+    none of them may hardcode the shared location."""
+    assert 'CFFIXED_USER_HOME=str(home)' in SANDBOX_SRC
+    assert 'home = rd / "home"' in SANDBOX_SRC and "home.mkdir(" in SANDBOX_SRC
+    for lane in ("walk_test.py", "adventure_walk.py", "player_cert.py"):
+        src = (HERE / lane).read_text(encoding="utf-8")
+        assert "Application Support" not in src, f"{lane} must not hardcode the shot directory"
+
+
+# ── focus restore: by PID, never `open -a` ────────────────────────────────────────────────────────
+def test_restore_front_never_uses_launch_services():
+    """`open -a WorldOSPlayer` resolves a NAME to an installed bundle: if the owner's game was
+    frontmost (or had since quit), the 'restore' would LAUNCH a fresh fullscreen player — the exact
+    hijack this lane exists to prevent."""
+    lits = _string_literals(HERE / "lib_qa_window.py")
+    assert "/usr/bin/open" not in lits and "open" not in lits
+    assert "-a" not in lits
+
+
+def test_restore_front_fronts_by_unix_id(monkeypatch):
+    seen: list = []
+    monkeypatch.setattr(LQW.subprocess, "run",
+                        lambda cmd, *a, **k: (seen.append(cmd), _proc(rc=0))[1])
+    assert LQW.restore_front({"name": "Terminal", "pid": 4321}) is True
+    script = seen[0][-1]
+    assert seen[0][0] == "/usr/bin/osascript"
+    assert "unix id is 4321" in script and "set frontmost" in script
+
+
+def test_restore_front_skips_a_player_or_a_missing_record(monkeypatch, capsys):
+    seen: list = []
+    monkeypatch.setattr(LQW.subprocess, "run",
+                        lambda cmd, *a, **k: (seen.append(cmd), _proc(rc=0))[1])
+    assert LQW.restore_front(None) is False
+    assert LQW.restore_front({"name": "WorldOSPlayer", "pid": 55}) is False
+    assert seen == [], "neither case may run anything"
+    err = capsys.readouterr().err
+    assert "no frontmost app was recorded" in err and "a player" in err
+
+
+def test_front_app_parses_name_and_pid(monkeypatch):
+    monkeypatch.setattr(LQW.subprocess, "run", lambda *a, **k: _proc(stdout="Terminal, 4321\n"))
+    assert LQW.front_app() == {"name": "Terminal", "pid": 4321}
+    monkeypatch.setattr(LQW.subprocess, "run", lambda *a, **k: _proc(stdout="", rc=1))
+    assert LQW.front_app() is None
+
+
+# ── achieved-geometry assertion: a SAFETY bound, not an exact size ────────────────────────────────
 class _Resp:
     def __init__(self, payload):
         self._p = json.dumps(payload).encode()
@@ -257,33 +450,87 @@ def _fake_health(monkeypatch, sequence):
     monkeypatch.setattr(qa_sandbox.time, "sleep", lambda *_: None)
 
 
-def test_health_assertion_polls_and_accepts_1x_2x(monkeypatch):
+def test_health_assertion_polls_until_a_frame_has_run(monkeypatch):
     """/health must be POLLED: CombatSurfaceClient.cs:2320-2326 caches _screenW/_screenH only on a
     non-_busy QA frame, so it reads 0 while /debug already answers."""
+    _display(monkeypatch)
     zero = {"screenW": 0, "screenH": 0}
-    _fake_health(monkeypatch, [zero, zero, {"screenW": 1280, "screenH": 697}])
-    assert qa_sandbox._assert_windowed(8972, 1280, 697, timeout_s=5, interval=0) == (1280, 697)
-
-    _fake_health(monkeypatch, [{"screenW": 2560, "screenH": 1394}])
-    assert qa_sandbox._assert_windowed(8972, 1280, 697, timeout_s=5, interval=0) == (2560, 1394)
-
-    _fake_health(monkeypatch, [{"screenW": 2984, "screenH": 1634}])   # the incident geometry
-    with pytest.raises(SystemExit) as ei:
-        qa_sandbox._assert_windowed(8972, 1280, 697, timeout_s=5, interval=0)
-    assert "windowed" in str(ei.value)
+    _fake_health(monkeypatch, [zero, zero, {"screenW": 1280, "screenH": 700}])
+    assert qa_sandbox._assert_windowed(8972, 1280, 700, timeout_s=5, interval=0) == (1280, 700)
 
     _fake_health(monkeypatch, [])                                     # permanently 0
     with pytest.raises(SystemExit) as ei:
-        qa_sandbox._assert_windowed(8972, 1280, 697, timeout_s=0.2, interval=0)
+        qa_sandbox._assert_windowed(8972, 1280, 700, timeout_s=0.2, interval=0)
     assert "never reported" in str(ei.value)
 
 
-# ── window-server verdicts (pure; no CoreGraphics call) ───────────────────────────────────────────
-def _win(x, y, w, h, pid=999):
-    return {"pid": pid, "owner": "WorldOSPlayer", "layer": 0, "name": "",
+def test_health_assertion_tolerates_a_unity_adjusted_size(monkeypatch):
+    """Unity may snap a requested resolution. 1268x700 instead of 1280x700 is SAFE, and failing it
+    only teaches the next person to delete the check."""
+    _display(monkeypatch)
+    _fake_health(monkeypatch, [{"screenW": 1268, "screenH": 700}])
+    assert qa_sandbox._assert_windowed(8972, 1280, 700, timeout_s=5, interval=0) == (1268, 700)
+
+
+def test_health_assertion_fails_on_the_incident_geometry(monkeypatch):
+    _display(monkeypatch)
+    _fake_health(monkeypatch, [{"screenW": 3024, "screenH": 1670}])   # the incident: the whole screen
+    with pytest.raises(SystemExit) as ei:
+        qa_sandbox._assert_windowed(8972, 1280, 700, timeout_s=5, interval=0)
+    assert "NOT windowed" in str(ei.value)
+
+
+def test_health_assertion_runs_the_watchdog_every_poll(monkeypatch):
+    _display(monkeypatch)
+    polls: list = []
+    zero = {"screenW": 0, "screenH": 0}
+    _fake_health(monkeypatch, [zero, zero, {"screenW": 1280, "screenH": 700}])
+    qa_sandbox._assert_windowed(8972, 1280, 700, timeout_s=5, interval=0,
+                                on_poll=lambda: polls.append(1))
+    assert len(polls) >= 3, "the window server is re-read on every poll, not once at the end"
+
+
+def test_wait_runs_the_watchdog_every_poll(monkeypatch):
+    polls: list = []
+    monkeypatch.setattr(qa_sandbox, "_http_ok", lambda *a, **k: bool(polls) and len(polls) >= 2)
+    monkeypatch.setattr(qa_sandbox.time, "sleep", lambda *_: None)
+    assert qa_sandbox._wait("x", "http://x", post=True, timeout_s=5,
+                            on_poll=lambda: polls.append(1)) is True
+    assert len(polls) >= 2
+
+
+# ── the takeover watchdog ─────────────────────────────────────────────────────────────────────────
+def _win(x, y, w, h, pid=999, layer=0):
+    return {"pid": pid, "owner": "WorldOSPlayer", "layer": layer, "name": "",
             "bounds": {"X": float(x), "Y": float(y), "Width": float(w), "Height": float(h)}}
 
 
+def test_watchdog_kills_the_rig_player_and_exits_3(monkeypatch, capsys):
+    _display(monkeypatch, points=(1492, 817), backing=(2984, 1634))
+    monkeypatch.setattr(LQW, "cg_windows", lambda pid=None, owner=None: [_win(0, 0, 1492, 817)])
+    killed: list = []
+    monkeypatch.setattr(qa_sandbox, "_kill_group",
+                        lambda pid, label="", expect_pgid=None: killed.append((pid, expect_pgid)) or "")
+    with pytest.raises(SystemExit) as ei:
+        qa_sandbox._watchdog(999, pgid=777)
+    assert ei.value.code == qa_sandbox.WATCHDOG_RC == 3
+    assert killed == [(999, 777)], "the rig's OWN player group, identity-checked, killed first"
+    assert "WATCHDOG" in capsys.readouterr().err
+
+
+def test_watchdog_passes_a_windowed_player_and_fails_an_offscreen_one(monkeypatch):
+    _display(monkeypatch, points=(1492, 817), backing=(2984, 1634))
+    monkeypatch.setattr(qa_sandbox, "_kill_group", lambda *a, **k: "")
+    monkeypatch.setattr(LQW, "cg_windows", lambda pid=None, owner=None: [_win(100, 60, 640, 382)])
+    assert qa_sandbox._watchdog(999, pgid=777) is None
+
+    monkeypatch.setattr(LQW, "cg_windows", lambda pid=None, owner=None: [_win(1480, 800, 640, 382)])
+    with pytest.raises(SystemExit) as ei:
+        qa_sandbox._watchdog(999, pgid=777)
+    assert "OFFSCREEN" in str(ei.value)
+
+
+# ── window-server verdicts (pure; no CoreGraphics call) ───────────────────────────────────────────
 def test_fullscreen_and_offscreen_verdicts(monkeypatch):
     monkeypatch.setattr(LQW, "main_display_points", lambda: (1492, 817))
 
@@ -299,12 +546,61 @@ def test_fullscreen_and_offscreen_verdicts(monkeypatch):
     assert LQW.offscreen_verdict(999) is not None
 
 
+def test_verdicts_ignore_the_players_small_aux_windows(monkeypatch):
+    """Measured 2026-09-02: the player also owns four 1492x30 layer-0 strips, off-screen. Unfiltered
+    they make offscreen_verdict fire on every healthy run — wait_for_window already filtered them, so
+    the verdicts must use the SAME filter or the boot check and the watchdog disagree."""
+    monkeypatch.setattr(LQW, "main_display_points", lambda: (1512, 835))
+    monkeypatch.setattr(LQW, "cg_windows", lambda pid=None, owner=None: [
+        _win(0, 30, 640, 382), _win(0, -1000, 1492, 30), _win(0, -1000, 1492, 30)])
+    assert LQW.offscreen_verdict(999) is None
+    assert LQW.fullscreen_verdict(999) is None
+    assert len(LQW.wait_for_window(999, timeout=0.1)) == 1
+
+
 def test_verdicts_are_inert_without_coregraphics(monkeypatch):
     """A host with no CoreGraphics must not manufacture a verdict out of (0, 0)."""
     monkeypatch.setattr(LQW, "main_display_points", lambda: (0, 0))
     monkeypatch.setattr(LQW, "cg_windows", lambda pid=None, owner=None: [_win(0, 0, 4000, 4000)])
     assert LQW.fullscreen_verdict(999) is None
     assert LQW.offscreen_verdict(999) is None
+
+
+# ── down(): the teardown ledger ───────────────────────────────────────────────────────────────────
+def test_down_reports_every_restore_and_skip_in_the_stopped_metadata(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(qa_sandbox, "ROOT", tmp_path)
+    rd = tmp_path / "r1"
+    rd.mkdir()
+    (rd / "sandbox.json").write_text(json.dumps({
+        "run": "r1", "win": [1280, 700], "qa": "http://127.0.0.1:8972",
+        "pids": {"engine": 101, "player": 102}, "pgids": {"engine": 101, "player": 102},
+        "plist_before": {"Screenmanager Fullscreen mode": "1",
+                         "Screenmanager Window Position Y": "0",
+                         "SomeOwnerSetting": "7"}}))
+    monkeypatch.setattr(qa_sandbox, "_kill_group",
+                        lambda pid, label="", expect_pgid=None:
+                        "pid reused (pgid 9 != recorded 101)" if pid == 101 else "")
+    monkeypatch.setattr(qa_sandbox, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(qa_sandbox, "_player_pids", lambda exe="WorldOSPlayer": set())
+    monkeypatch.setattr(qa_sandbox, "_orphan_report",
+                        lambda **k: {"lines": ["[sandbox] QA port 8972 free."], "leaks": [],
+                                     "port": 8972, "port_pids": []})
+    monkeypatch.setattr(qa_sandbox.time, "sleep", lambda *_: None)
+    log: list = []
+    _fake_defaults(monkeypatch, {"Screenmanager Fullscreen mode": 3,     # ours: restore
+                                 "Screenmanager Window Position Y": 60,  # cosmetic: leave
+                                 "SomeOwnerSetting": 9}, log)            # theirs: leave
+
+    rc = qa_sandbox.down("r1")
+    assert rc == 1, "a refused (pid-reused) kill is a leak, not a clean teardown"
+    stopped = json.loads((rd / "sandbox.json.stopped").read_text())["stopped"]
+    assert stopped["plist"]["restored"] == {"Screenmanager Fullscreen mode": "1"}
+    assert set(stopped["plist"]["skipped"]) == {"Screenmanager Window Position Y", "SomeOwnerSetting"}
+    assert any("pid reused" in leak for leak in stopped["leaks"])
+    assert _writes(log) == [["defaults", "write", qa_sandbox.PLIST_DOMAIN,
+                             "Screenmanager Fullscreen mode", "-int", "1"]]
+    out = capsys.readouterr().out
+    assert "RESTORED" in out and "LEFT AS-IS" in out and "NOT restored" in out
 
 
 # ── Phase 2 (C# badge) — RED until the Editor rebuild lands ───────────────────────────────────────

--- a/qa/test_qa_sandbox_window.py
+++ b/qa/test_qa_sandbox_window.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Units for the WINDOWED, non-hijacking sandbox player launch (#1672, incident 2026-09-02).
+
+The incident: `qa/qa_sandbox.py up` launched the second player instance with NO Unity window args,
+so it inherited the SHARED plist's "Screenmanager Fullscreen mode"=1 + "Resolution Use Native"=1,
+came up fullscreen on the developer's only display during a gate run, and the Mac had to be rebooted.
+
+NOTHING here launches a player, opens a port, or touches the real
+~/Library/Preferences/com.worldos.WorldOSPlayer.plist — every `defaults` / `ioreg` / `lsof` /
+CoreGraphics call is monkeypatched.
+
+Run: uv run --directory servers/engine python -m pytest qa/test_qa_sandbox_window.py -q -p no:xdist
+"""
+from __future__ import annotations
+
+import ast
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import lib_qa_window as LQW  # noqa: E402
+import qa_sandbox  # noqa: E402
+
+SANDBOX_SRC = (HERE / "qa_sandbox.py").read_text(encoding="utf-8")
+WINDOW_SRC = (HERE / "lib_qa_window.py").read_text(encoding="utf-8")
+CSC = HERE.parent / "extensions" / "renderers" / "unity" / "scripts" / "CombatSurfaceClient.cs"
+
+
+def _proc(stdout="", rc=0):
+    return types.SimpleNamespace(stdout=stdout, stderr="", returncode=rc)
+
+
+def _string_literals(path: Path) -> list:
+    """Every string literal in a module EXCEPT docstrings — i.e. strings the code actually uses.
+
+    Comment/docstring prose in these modules deliberately mentions the forbidden commands ("NEVER
+    osascript quit app ..."), so a raw substring scan would fail on the very warning that documents
+    the rule. This scans what would actually be executed.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    docs = set()
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) \
+                and body and isinstance(body[0], ast.Expr) \
+                and isinstance(body[0].value, ast.Constant) and isinstance(body[0].value.value, str):
+            docs.add(id(body[0].value))
+    return [n.value for n in ast.walk(tree)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str) and id(n) not in docs]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for k in ("WORLDOS_PLAYER_WIN_W", "WORLDOS_PLAYER_WIN_H", "WORLDOS_PLAYER_IDLE_THRESHOLD",
+              "FORCE_PLAYER_QA", "WORLDOS_QA_PLIST_RESTORE"):
+        monkeypatch.delenv(k, raising=False)
+
+
+# ── launch args ───────────────────────────────────────────────────────────────────────────────────
+def test_player_windowed_args_defaults(monkeypatch):
+    """The exact Unity arg contract, in order: fullscreen OFF, then a fitted size, then the log."""
+    monkeypatch.setattr(LQW, "main_display_points", lambda: (1492, 817))
+    args = qa_sandbox._player_windowed_args("/x.log")
+    assert args == ["-screen-fullscreen", "0", "-screen-width", "1280",
+                    "-screen-height", "697", "-logFile", "/x.log"]
+    # the flag is worthless if its value drifts away from it
+    assert args[args.index("-screen-fullscreen") + 1] == "0"
+
+
+def test_win_env_override_and_fit_clamp(monkeypatch):
+    """An oversized request is clamped INTO the desktop, and never below the display's aspect."""
+    monkeypatch.setattr(LQW, "main_display_points", lambda: (1492, 817))
+    monkeypatch.setenv("WORLDOS_PLAYER_WIN_W", "1600")
+    monkeypatch.setenv("WORLDOS_PLAYER_WIN_H", "1000")
+    args = qa_sandbox._player_windowed_args(None)
+    w = int(args[args.index("-screen-width") + 1])
+    h = int(args[args.index("-screen-height") + 1])
+    assert h == 697, "height must fit under the menu bar (817 - 120)"
+    assert w <= 1332, "width must stay inside the desktop (1492 - 160)"
+    # a NARROWER aspect than the display crops horizontal world out of the ortho frame, so a cell
+    # that was in frame at the fullscreen baseline would project outside the capture.
+    assert w / h >= 1492 / 817
+    assert "-logFile" not in args
+
+
+@pytest.mark.parametrize("w,h", [("notanint", "700"), ("1280", "7e2"), ("320", "700"),
+                                 ("1280", "200")])
+def test_win_env_rejects_garbage_and_tiny(monkeypatch, w, h):
+    monkeypatch.setattr(LQW, "main_display_points", lambda: (1492, 817))
+    monkeypatch.setenv("WORLDOS_PLAYER_WIN_W", w)
+    monkeypatch.setenv("WORLDOS_PLAYER_WIN_H", h)
+    with pytest.raises(SystemExit):
+        qa_sandbox._player_windowed_args(None)
+
+
+# ── owner-active guard ────────────────────────────────────────────────────────────────────────────
+def _ioreg(idle_ns) -> str:
+    return ('+-o IOHIDSystem  <class IOHIDSystem>\n'
+            '    | {\n'
+            f'    |   "HIDIdleTime" = {idle_ns}\n'
+            '    | }\n')
+
+
+def test_owner_active_guard(monkeypatch):
+    calls = {}
+
+    def fake_run(cmd, *a, **kw):
+        calls["cmd"] = cmd
+        return _proc(stdout=calls["out"])
+
+    monkeypatch.setattr(qa_sandbox.subprocess, "run", fake_run)
+
+    calls["out"] = _ioreg(int(30e9))                    # owner touched the Mac 30s ago
+    with pytest.raises(SystemExit) as ei:
+        qa_sandbox.owner_active_guard()
+    assert ei.value.code == 75
+
+    calls["out"] = _ioreg(int(300e9))                   # idle 300s -> proceed
+    assert qa_sandbox.owner_active_guard() is None
+    assert calls["cmd"][:3] == ["ioreg", "-c", "IOHIDSystem"]
+
+    calls["out"] = _ioreg(0)                            # active, but explicitly forced
+    monkeypatch.setenv("FORCE_PLAYER_QA", "1")
+    assert qa_sandbox.owner_active_guard() is None
+    monkeypatch.delenv("FORCE_PLAYER_QA")
+
+    calls["out"] = '    |   "HIDIdleTime" = <garbage>\n'   # unreadable -> assume idle (headless box)
+    assert qa_sandbox.owner_active_guard() is None
+    calls["out"] = ""
+    assert qa_sandbox.owner_active_guard() is None
+
+
+def test_owner_active_guard_prints_the_documented_line(monkeypatch, capsys):
+    monkeypatch.setattr(qa_sandbox.subprocess, "run", lambda *a, **k: _proc(stdout=_ioreg(int(5e9))))
+    with pytest.raises(SystemExit):
+        qa_sandbox.owner_active_guard()
+    assert "SANDBOX-DEFERRED (owner active)" in capsys.readouterr().err
+
+
+# ── shared-plist leak check ───────────────────────────────────────────────────────────────────────
+def _fake_defaults(monkeypatch, values: dict, log: list):
+    def fake_run(cmd, *a, **kw):
+        log.append(list(cmd))
+        if cmd[:2] == ["defaults", "read"]:
+            key = cmd[3]
+            return _proc(stdout=values[key], rc=0) if key in values else _proc(rc=1)
+        return _proc(rc=0)
+
+    monkeypatch.setattr(qa_sandbox.subprocess, "run", fake_run)
+
+
+def test_plist_snapshot_and_diff(monkeypatch):
+    log: list = []
+    vals = {"Screenmanager Fullscreen mode": "1", "Screenmanager Resolution Width": "3024"}
+    _fake_defaults(monkeypatch, vals, log)
+    before = qa_sandbox._plist_snapshot()
+    assert before["Screenmanager Fullscreen mode"] == "1"
+    assert before["UnitySelectMonitor"] is None, "an absent key reads None, not ''"
+
+    after = dict(before, **{"Screenmanager Fullscreen mode": "3",
+                            "unity.player_session_count": "42",
+                            "unity_connect.access_token": "x"})
+    diff = qa_sandbox._plist_diff(before, after)
+    assert set(diff) == {"Screenmanager Fullscreen mode"}
+    assert diff["Screenmanager Fullscreen mode"] == {"before": "1", "after": "3"}
+    # churn keys must never be reported, or every run looks like a leak
+    assert not {"unity.player_session_count", "unity.player_sessionid"} & set(diff)
+
+
+def test_plist_restore_gating(monkeypatch):
+    log: list = []
+    _fake_defaults(monkeypatch, {}, log)
+    diff = {"Screenmanager Fullscreen mode": {"before": "1", "after": "3"},
+            "Screenmanager Window Position X": {"before": None, "after": "900"}}
+
+    rep = qa_sandbox._plist_restore(diff, foreign_alive=False)
+    writes = [c for c in log if c[:2] == ["defaults", "write"]]
+    deletes = [c for c in log if c[:2] == ["defaults", "delete"]]
+    assert writes == [["defaults", "write", qa_sandbox.PLIST_DOMAIN,
+                       "Screenmanager Fullscreen mode", "-int", "1"]]
+    assert deletes == [["defaults", "delete", qa_sandbox.PLIST_DOMAIN,
+                        "Screenmanager Window Position X"]]
+    assert set(rep["restored"]) == set(diff)
+
+    log.clear()
+    rep = qa_sandbox._plist_restore(diff, foreign_alive=True)
+    assert [c for c in log if c[:2] in (["defaults", "write"], ["defaults", "delete"])] == []
+    assert rep["restored"] == {} and rep["note"], "a live foreign player must block the write"
+
+    log.clear()
+    monkeypatch.setenv("WORLDOS_QA_PLIST_RESTORE", "0")
+    rep = qa_sandbox._plist_restore(diff, foreign_alive=False)
+    assert [c for c in log if c[:2] in (["defaults", "write"], ["defaults", "delete"])] == []
+    assert rep["restored"] == {} and "detect only" in rep["note"]
+
+
+# ── launch SHAPE (source-level fences) ────────────────────────────────────────────────────────────
+def test_meta_written_before_readiness_wait():
+    """The anti-orphan fence: a failed boot must always leave a killable recorded pid on disk."""
+    assert SANDBOX_SRC.index("_meta_path(run).write_text") < SANDBOX_SRC.index('"player QA channel"')
+
+
+def test_launch_shape_is_not_caffeinate_parented():
+    """caffeinate does NOT forward SIGTERM: a caffeinate-PARENTED player survives terminate() and
+    reparents to launchd — that is how the incident stranded a fullscreen orphan. The player must be
+    its own Popen, with caffeinate a sibling watcher (`-w <pid>`)."""
+    assert "argv = [str(pbin), *win_args]" in SANDBOX_SRC
+    assert "subprocess.Popen(argv, env=penv" in SANDBOX_SRC
+    assert '"-w", str(player.pid)' in SANDBOX_SRC
+    # -u ASSERTS USER ACTIVITY (wakes and holds the owner's display) and -d keeps it awake. Scan the
+    # code's own string literals, not the prose that documents why the old flags are gone.
+    lits = _string_literals(HERE / "qa_sandbox.py")
+    assert "-disu" not in lits
+    assert qa_sandbox.CAFFEINATE_FLAGS == ["-is"]
+    assert "player.terminate()" not in SANDBOX_SRC
+    assert "engine.terminate()" not in SANDBOX_SRC
+    assert "os.killpg" in SANDBOX_SRC
+
+
+def test_no_osascript_quit_and_no_ax():
+    """`quit app "WorldOSPlayer"` kills EVERY instance including the owner's. And AX geometry is off
+    the critical path: it is nondeterministic on this host and resizableWindow=0 blocks resize."""
+    for path in (HERE / "qa_sandbox.py", HERE / "lib_qa_window.py"):
+        assert not [s for s in _string_literals(path) if "quit app" in s], path
+    for src in (SANDBOX_SRC, WINDOW_SRC):
+        assert "set position of" not in src
+        assert "set size of" not in src
+
+
+# ── achieved-geometry assertion ───────────────────────────────────────────────────────────────────
+class _Resp:
+    def __init__(self, payload):
+        self._p = json.dumps(payload).encode()
+
+    def read(self):
+        return self._p
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _fake_health(monkeypatch, sequence):
+    seq = list(sequence)
+
+    def fake_urlopen(req, timeout=None):
+        return _Resp(seq.pop(0) if seq else {"screenW": 0, "screenH": 0})
+
+    monkeypatch.setattr(qa_sandbox.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(qa_sandbox.time, "sleep", lambda *_: None)
+
+
+def test_health_assertion_polls_and_accepts_1x_2x(monkeypatch):
+    """/health must be POLLED: CombatSurfaceClient.cs:2320-2326 caches _screenW/_screenH only on a
+    non-_busy QA frame, so it reads 0 while /debug already answers."""
+    zero = {"screenW": 0, "screenH": 0}
+    _fake_health(monkeypatch, [zero, zero, {"screenW": 1280, "screenH": 697}])
+    assert qa_sandbox._assert_windowed(8972, 1280, 697, timeout_s=5, interval=0) == (1280, 697)
+
+    _fake_health(monkeypatch, [{"screenW": 2560, "screenH": 1394}])
+    assert qa_sandbox._assert_windowed(8972, 1280, 697, timeout_s=5, interval=0) == (2560, 1394)
+
+    _fake_health(monkeypatch, [{"screenW": 2984, "screenH": 1634}])   # the incident geometry
+    with pytest.raises(SystemExit) as ei:
+        qa_sandbox._assert_windowed(8972, 1280, 697, timeout_s=5, interval=0)
+    assert "windowed" in str(ei.value)
+
+    _fake_health(monkeypatch, [])                                     # permanently 0
+    with pytest.raises(SystemExit) as ei:
+        qa_sandbox._assert_windowed(8972, 1280, 697, timeout_s=0.2, interval=0)
+    assert "never reported" in str(ei.value)
+
+
+# ── window-server verdicts (pure; no CoreGraphics call) ───────────────────────────────────────────
+def _win(x, y, w, h, pid=999):
+    return {"pid": pid, "owner": "WorldOSPlayer", "layer": 0, "name": "",
+            "bounds": {"X": float(x), "Y": float(y), "Width": float(w), "Height": float(h)}}
+
+
+def test_fullscreen_and_offscreen_verdicts(monkeypatch):
+    monkeypatch.setattr(LQW, "main_display_points", lambda: (1492, 817))
+
+    monkeypatch.setattr(LQW, "cg_windows", lambda pid=None, owner=None: [_win(0, 0, 1492, 817)])
+    assert LQW.fullscreen_verdict(999) is not None
+
+    monkeypatch.setattr(LQW, "cg_windows", lambda pid=None, owner=None: [_win(100, 60, 1280, 697)])
+    assert LQW.fullscreen_verdict(999) is None
+    assert LQW.offscreen_verdict(999) is None
+
+    # dragged/parked off the bottom-right: only 12x17 points remain on the display
+    monkeypatch.setattr(LQW, "cg_windows", lambda pid=None, owner=None: [_win(1480, 800, 1280, 697)])
+    assert LQW.offscreen_verdict(999) is not None
+
+
+def test_verdicts_are_inert_without_coregraphics(monkeypatch):
+    """A host with no CoreGraphics must not manufacture a verdict out of (0, 0)."""
+    monkeypatch.setattr(LQW, "main_display_points", lambda: (0, 0))
+    monkeypatch.setattr(LQW, "cg_windows", lambda pid=None, owner=None: [_win(0, 0, 4000, 4000)])
+    assert LQW.fullscreen_verdict(999) is None
+    assert LQW.offscreen_verdict(999) is None
+
+
+# ── Phase 2 (C# badge) — RED until the Editor rebuild lands ───────────────────────────────────────
+@pytest.mark.xfail(reason="#1672 item 4: needs the CombatSurfaceClient.cs change + an Editor "
+                          "rebuild (docs/qa/QA-RIG-WINDOW-BADGE.md). Flip this when it lands.",
+                   strict=False)
+def test_csharp_qa_window_policy():
+    src = CSC.read_text(encoding="utf-8")
+    for sym in ("ApplyQaWindowPolicy", "FullScreenMode.Windowed", "DrawQaBadge",
+                "QaRestoreScreenPrefs"):
+        assert sym in src, sym
+    # OnGUI's advisory early-out would otherwise hide the badge whenever no advisory is up
+    assert src.index("DrawQaBadge();") < src.index("if (string.IsNullOrEmpty(_advMsg)) return;")
+    body = src.split("void DrawQaBadge()", 1)[1].split("\n    }", 1)[0]
+    for banned in ("Time.", "frameCount", "DateTime"):
+        assert banned not in body, ("an ANIMATED badge is a large stable-position diff blob that "
+                                    "can win the nearest-neighbour race at walk_test.py:236-254")

--- a/qa/test_walk_test.py
+++ b/qa/test_walk_test.py
@@ -471,3 +471,106 @@ def test_select_visual_cells_never_samples_mask_covered_cells():
     assert (1, 1) in picked                                          # far cell always in
     assert (7, 7) in picked                                          # chebyshev-2: measurable top-up
     assert len(picked) == 2                                          # honestly smaller than n=3
+
+
+# --- #1672 windowed sandbox player: the pixel-diff constants must scale with the frame ------------
+# The visual stage was tuned at the fullscreen 2984x1634 baseline. Windowing the QA player to
+# 1280x697 shrinks a grid cell from ~126px to ~54px, and the HARD-CODED 60px cluster-merge radius
+# (walk_test.diff_blobs) becomes ~1.1 CELLS: a short hop's departure and arrival blobs FUSE into one
+# centroid midway between them, the measured distance reads about half the true hop, and a correct
+# build goes FALSE RED. These are the units for that.
+
+def _squares(*xs, y=10, size=12, w=400, h=200):
+    """Two frames differing only by `size`-square blocks at the given x offsets."""
+    import numpy as np
+    a = np.zeros((h, w, 3), dtype=int)
+    b = a.copy()
+    for x in xs:
+        b[y:y + size, x:x + size] = 255
+    return a, b
+
+
+def test_diff_blobs_merge_px_separates_close_blobs():
+    a, b = _squares(10, 60)          # centres 50px apart == ~1 cell at the windowed 1280x697
+    fused = W.diff_blobs(a, b, min_area_px=50, merge_px=60)
+    split = W.diff_blobs(a, b, min_area_px=50, merge_px=24)
+    assert len(fused) == 1, "today's fixed 60px radius fuses a 1-cell hop into a single blob"
+    assert len(split) == 2, "the frame-derived radius keeps departure and arrival apart"
+
+
+def test_diff_blobs_default_merge_px_is_60():
+    """The default is unchanged, so every existing caller/golden is provably unaffected."""
+    import inspect
+    assert inspect.signature(W.diff_blobs).parameters["merge_px"].default == 60
+
+
+def test_visual_diff_params_scale_with_window():
+    big = W.visual_diff_params(13, 2984, 1634)     # the fullscreen baseline
+    small = W.visual_diff_params(13, 1280, 697)    # the windowed sandbox rig
+    assert big["merge_px"] == 57 and big["min_area_px"] == 250
+    assert small["merge_px"] == 24 and small["min_area_px"] == 60   # min_area floors at 60
+    for p in (big, small):
+        assert abs(p["merge_px"] / p["cell_px"] - 0.45) < 0.02
+
+
+# --- #1672: the three ways the visual stage could silently invent a verdict, now NAMED errors -----
+# A windowed player made all three reachable: a 2x HiDPI backbuffer (projection off by 2x), a
+# minimized/occluded window (ScreenCapture hands back a black frame and /shot still returns 200), and
+# a window whose aspect crops sample cells out of the ortho frame. Each used to surface as a
+# mysterious per-cell RED; each must now fail LOUD and never report a pass.
+
+def _png(tmp_path, name, size, fill):
+    from PIL import Image
+    p = tmp_path / name
+    Image.new("RGB", size, fill).save(p)
+    return str(p)
+
+
+def _stub_visual(monkeypatch, shot_path, *, w=1280, h=697):
+    monkeypatch.setattr(W, "_get", lambda url: {"screenW": w, "screenH": h, "ok": True})
+    monkeypatch.setattr(W, "_capture_shot", lambda qa, out, label, timeout=6.0: shot_path)
+    monkeypatch.setattr(W, "_token_cell", lambda surf: (6, 6))
+    monkeypatch.setattr(W, "_drive_and_check",
+                        lambda qa, eng, c, r, s, t, expect_move=True: (True, (c, r), {}))
+    monkeypatch.setattr(W.time, "sleep", lambda *_: None)
+
+
+_MASK13 = {"cols": 13, "rows": 13, "walkable": []}
+
+
+def _run_visual(tmp_path, cells):
+    return W._visual_registration("http://qa", "http://eng", _MASK13, 13.0, cells,
+                                  tmp_path / "out", 0.2, 5.0)
+
+
+def test_visual_guard_rejects_uncalibratable_capture(monkeypatch, tmp_path):
+    _stub_visual(monkeypatch, _png(tmp_path, "odd.png", (1000, 500), (40, 40, 40)))
+    res = _run_visual(tmp_path, [(6, 7)])
+    assert "neither 1x nor 2x" in res["error"] and res["pass"] == 0
+
+
+def test_visual_guard_rejects_black_capture(monkeypatch, tmp_path):
+    _stub_visual(monkeypatch, _png(tmp_path, "black.png", (1280, 697), (0, 0, 0)))
+    res = _run_visual(tmp_path, [(6, 7)])
+    assert "capture is BLACK" in res["error"] and res["pass"] == 0
+
+
+def test_visual_guard_rejects_out_of_frame_cells(monkeypatch, tmp_path):
+    _stub_visual(monkeypatch, _png(tmp_path, "grey.png", (1280, 697), (40, 44, 48)))
+    res = _run_visual(tmp_path, [(6, 7), (60, 6)])
+    assert "project OUTSIDE" in res["error"] and "[60, 6]" in res["error"]
+
+
+def test_visual_guards_pass_a_normal_frame(monkeypatch, tmp_path):
+    _stub_visual(monkeypatch, _png(tmp_path, "ok.png", (1280, 697), (40, 44, 48)))
+    res = _run_visual(tmp_path, [(6, 7)])
+    assert "error" not in res
+    assert res["capture_scale"] == 1.0
+    assert res["diff_params"] == {"cell_px": 53.6, "merge_px": 24, "min_area_px": 60}
+
+
+def test_visual_guard_accepts_2x_hidpi_capture(monkeypatch, tmp_path):
+    _stub_visual(monkeypatch, _png(tmp_path, "hidpi.png", (2560, 1394), (40, 44, 48)))
+    res = _run_visual(tmp_path, [(6, 7)])
+    assert "error" not in res and res["capture_scale"] == 2.0
+    assert res["diff_params"]["merge_px"] == 48        # scales with the backing buffer, not /health

--- a/qa/walk_test.py
+++ b/qa/walk_test.py
@@ -209,7 +209,31 @@ def orphan_cells(mask: dict, start: tuple) -> list:
     return sorted(set(mask["walkable"]) - bfs_reachable(mask, start))
 
 
-def diff_blobs(img_a, img_b, *, min_area_px: int = 250, thresh: int = 60) -> list:
+def _frame_mean(img) -> float:
+    """Mean RGB level of a captured frame — the black-frame detector for the visual stage."""
+    import numpy as np  # noqa: PLC0415
+
+    return float(np.asarray(img.convert("RGB"), dtype=float).mean())
+
+
+def visual_diff_params(ortho: float, w: int, h: int) -> dict:
+    """Scale the pixel-diff clustering constants to the LIVE window (#1672 windowed sandbox).
+
+    The 60px cluster-merge radius and the 250px min-area were tuned at the fullscreen 2984x1634
+    baseline, where one grid cell is ~126px — 60px is 0.48 cell, comfortably smaller than a hop. At
+    the windowed 1280x697 the same fixed 60px is ~1.1 CELLS: the departure and arrival blobs of a
+    short hop MERGE into one centroid midway between them, so a 3-cell hop measures ~half its true
+    distance and a correct build reads FALSE RED. Both constants are therefore derived from the
+    frame, not hard-coded.
+    """
+    cpx = cell_px(ortho, h)
+    return {"cell_px": round(cpx, 1),
+            "merge_px": max(16, round(0.45 * cpx)),
+            "min_area_px": max(60, round(250 * (w * h) / (2984 * 1634)))}
+
+
+def diff_blobs(img_a, img_b, *, min_area_px: int = 250, thresh: int = 60,
+               merge_px: int = 60) -> list:
     """Cluster the pixel differences between two frames — the moved actor shows up as the two largest
     blobs (departure + arrival). Returns clusters as dicts {cx, cy, bottom: (x,y), area}, area-sorted.
     Pure (arrays in, dicts out) so it is unit-testable with synthetic frames. Animated fire/glow
@@ -225,7 +249,7 @@ def diff_blobs(img_a, img_b, *, min_area_px: int = 250, thresh: int = 60) -> lis
     clusters: list = []
     for x, y in zip(xs.tolist(), ys.tolist()):
         for c in clusters:
-            if abs(x - c["sx"] / c["n"]) < 60 and abs(y - c["sy"] / c["n"]) < 60:
+            if abs(x - c["sx"] / c["n"]) < merge_px and abs(y - c["sy"] / c["n"]) < merge_px:
                 c["sx"] += x; c["sy"] += y; c["n"] += 1
                 if y > c["maxy"]:
                     c["maxy"], c["bxs"] = y, [x]
@@ -601,18 +625,55 @@ def _visual_registration(qa: str, engine: str, mask: dict, ortho: float, cells: 
     except Exception as e:  # noqa: BLE001
         return {"pass": 0, "fail": 0, "cases": [], "window": None, "error": f"health: {e}"}
     res["window"] = [w, h]
-    tol = 1.25 * cell_px(ortho, h)
     cols, rows = mask["cols"], mask["rows"]
 
-    def _proj(cell):
+    def _proj_win(cell):
         wx = (cell[0] - (cols - 1) / 2.0) * 2.0
         wz = ((rows - 1) / 2.0 - cell[1]) * 2.0
         return world_to_window_px(wx, 0.6, wz, ortho, w, h)   # 0.6 up = lower-torso/feet band
 
+    # --- #1672 capture preflight: three ways this stage can silently invent a verdict, each now a
+    # --- NAMED harness error instead of a mysterious per-cell RED. Windowing the sandbox player made
+    # --- all three reachable: a 2x HiDPI backbuffer, a minimized/occluded window, and a window whose
+    # --- aspect crops sample cells out of frame.
+    calib = _capture_shot(qa, out, "vis_calib")
+    if not calib:
+        return {**res, "error": "calibration capture FAILED — /shot returned no usable frame"}
+    with Image.open(calib) as _im:
+        iw, ih = _im.size
+        arr_mean = _frame_mean(_im)
+    if (iw, ih) == (w, h):
+        scale = 1.0
+    elif (iw, ih) == (2 * w, 2 * h):
+        scale = 2.0                        # macRetinaSupport=1 — capture is the backing buffer
+    else:
+        return {**res, "error": f"capture geometry {iw}x{ih} is neither 1x nor 2x the reported "
+                                f"window {w}x{h} — the projection math cannot be calibrated"}
+    res["capture_scale"] = scale
+    if arr_mean < 8:
+        return {**res, "error": "capture is BLACK — the QA window is minimized/offscreen/occluded; "
+                                "ScreenCapture returned no presented frame (mean luminance "
+                                f"{arr_mean:.2f} < 8). Fix the window, do not trust this run."}
+
+    def _proj(cell):
+        px, py = _proj_win(cell)
+        return (px * scale, py * scale)
+
+    outside = [list(c) for c in cells
+               if not (0 <= _proj(c)[0] < iw and 0 <= _proj(c)[1] < ih)]
+    if outside:
+        return {**res, "error": f"cells project OUTSIDE the {iw}x{ih} capture: {outside} — the "
+                                f"window aspect ({w}/{h}) crops them out of the ortho frame; widen "
+                                f"the window (WORLDOS_PLAYER_WIN_W) or reduce the sample set"}
+
+    tol = 1.25 * cell_px(ortho, ih)
+    res["diff_params"] = visual_diff_params(ortho, iw, ih)
+    merge_px, min_area_px = res["diff_params"]["merge_px"], res["diff_params"]["min_area_px"]
+
     # brazier/hearth flame VFX flicker sits ON the fire cell — mask any diff blob within ~1.5 cells of
     # a fire-anchor screen position so it cannot win the nearest-neighbour race against the actor.
     fire_px = [_proj(fc) for fc in fire_cells]
-    fire_radius = 1.5 * cell_px(ortho, h)
+    fire_radius = 1.5 * cell_px(ortho, ih)
     res["fire_cells"] = [list(fc) for fc in sorted(fire_cells)]
 
     prev = _token_cell(_get(f"{engine}/combat-surface"))
@@ -638,13 +699,15 @@ def _visual_registration(qa: str, engine: str, mask: dict, ortho: float, cells: 
         shot_new = _capture_shot(qa, out, f"vis_{i}_c{cell[0]}r{cell[1]}")
         case = {"cell": list(cell), "moved": ok_move, "dist_px": None, "tol_px": round(tol, 1), "ok": False}
         if ok_move and shot_prev and shot_new:
-            raw = diff_blobs(Image.open(shot_prev).convert("RGB"), Image.open(shot_new).convert("RGB"))
+            raw = diff_blobs(Image.open(shot_prev).convert("RGB"), Image.open(shot_new).convert("RGB"),
+                             min_area_px=min_area_px, merge_px=merge_px)
             blobs = mask_fire_blobs(raw, fire_px, fire_radius)   # drop brazier-flicker blobs first
             d_new = nearest_blob_distance(blobs, _proj(cell))    # inf when all blobs were fire-masked
             d_prev = nearest_blob_distance(blobs, _proj(prev)) if prev else 0.0
             case["dist_px"] = round(d_new, 1)
             case["dist_prev_px"] = round(d_prev, 1)
             case["n_blobs"] = len(blobs)
+            case["blob_area_max"] = max((b["area"] for b in blobs), default=0)
             case["n_blobs_masked"] = len(raw) - len(blobs)
             case["ok"] = d_new <= tol
         res["cases"].append(case)


### PR DESCRIPTION
Refresh charter #1702. On 2026-09-02 a sandbox gate run launched the built player with bare `caffeinate -disu`, Unity's default fullscreen took the only display, and the Mac rebooted. This makes every `qa/qa_sandbox.py` launch windowed and unobtrusive, and makes the owner's shared PlayerPrefs safe.

**Launch contract (current build, no rebuild):** `WorldOSPlayer -screen-fullscreen 0 -screen-width 1280 -screen-height 700 -logFile <run>/unity_player.log` + env `CFFIXED_USER_HOME=<run>/home` (per-run `persistentDataPath`: `/shot` files no longer share the owner's directory) + a sibling `caffeinate -is -w <pid>`; owner-active guard (defers when the console user typed < 120 s ago; `FORCE_PLAYER_QA=1` overrides); preflight size validation before the engine spawns; a CGWindowList watchdog on every readiness poll and a `watchdog` subcommand; pgid-verified, pid-scoped teardown; focus restored by PID (never `open -a`).
**Leak rule:** Unity still writes the Screenmanager keys into the owner's real plist. `down()` restores ONLY keys that changed AND currently hold this rig's own values (mode 3 / 1280 / 700 / use-native 0), validated as integers; window-position keys are never rewritten; churn keys ignored; everything reported in `prefs_leak.json`.

**Live verification (orchestrator, this build):** engine-less probe and a full `up rig1`: content window 640×382 pt at (0,30), `AXFullScreen=false` (System Events), frontmost app unchanged (ChatGPT) after launch, `/health` 1280×700, `/debug` plateLocMatch true / 73 occluders, `/shot` → 1280×700 PNG under `<run>/home/…`; `down rig1` restored `Fullscreen mode=1, 3024×1670, Use Native=1` (owner plist == pre-run snapshot minus churn), left Position Y, 0 leftover processes, ports free. Evidence: `session-notes/2026-09-02/worldos-refresh/artifacts/rig/`.
**Adversarial review folded:** attribution-blind restore (fixed), `open -a` hazard (removed), no unwind on abort (fixed), size check after engine spawn (moved to preflight), points-vs-pixels units (fixed), too-strict size assert (safety property), one-shot watchdog (per poll + subcommand), unverified kill identity (pgid check).
**Tests:** 151 passed, 1 skipped, 1 xfailed (Phase 2 C# badge, needs an Editor rebuild); `fast_gate` 257. Phase 2 (client-side QA badge/title + windowed default when `WORLDOS_QA_INPUT=1`) is specified in `docs/qa/QA-RIG-WINDOW-BADGE.md` for the next Editor window.

Claim class: `rig` — proves the launch contract and leak rule on this host/build; does NOT prove any §9 gate (the re-gates run on it now).