### PR TITLE
arc-duo eval: measured budget 15 → 20 beats (predeclared ruler change) + model ids recorded

### DIFF
--- a/docs/roadmap/PRODUCT-ROADMAP.md
+++ b/docs/roadmap/PRODUCT-ROADMAP.md
@@ -284,7 +284,7 @@ v1.0.7–v1.0.8) and is retitled **"The Table (story/world systems)"**.
   4-objective arc; reward staged; full static stack at seed. Every room class is already
   walk-green certified — composition, zero new geometry.
 - **A-T — The text-arc eval** *(parallel with A-G)*: `qa/run_adventure.sh` (duo-derivative,
-  arc-directed persona, ~15-beat budget, completion short-circuit) + `qa/quest_progress.py`
+  arc-directed persona, **20-beat budget** (raised from 15 on 2026-09-02 — a control run with the July DM model completed at beat 19 while 15 was knife-edge; the bar is unchanged: N≥3, completion ≥ 0.67, behavioral GREEN; DM and player model ids are pinned and recorded per row), completion short-circuit) + `qa/quest_progress.py`
   (per-beat get_quests polling → quest_trace.json: reached_giver / quest_accepted /
   entered_dungeon / boss_dead / reward_received / quest_completed) + `qa/adventure_eval.py`
   (N runs via the run_parallel pattern → completion_rate · beats/wall-time · stuck (dead beats +

--- a/qa/SCORECARD.md
+++ b/qa/SCORECARD.md
@@ -208,3 +208,11 @@ The `action_economy_engaged` / `combat_not_left_active` WARNs are end-state snap
 DM-model swap (~65%) vs structural beat budget (~25%); discriminating control run `adv_ctl_o48` (DM pinned to `claude-opus-4-8`, all
 else equal) in flight. Instrument gaps filed on #1709: `adventure_eval` must ERROR on run prefixes that resolve to no files; the
 behavioral checker reads only the last combat snapshot; `quest_completed` is stamped on a FAILED quest.
+
+### 2026-09-02 — RULER CHANGE (predeclared before the re-measurement): arc-duo measured budget 15 → 20 beats
+Evidence: `adv_ctl_o48` (DM pinned to `claude-opus-4-8`, 15 beats) removed the invented fights but still ended at `boss_dead@15` with
+42 resolved attacks; `adv_ctl_o48_b20` (same DM, 20 beats) COMPLETED at beat 19 (`boss_dead@15`, `reward_received@19`), behavioral GREEN.
+July's 3/3 landed at beats 13-15 with one beat of slack. Decision: the measured G2 eval runs at 20 beats from now; the bar is unchanged
+(N≥3, completion ≥ 0.67, behavioral GREEN); every row records the DM and player model ids (`opus`/`sonnet` aliases drift — Opus 5 today).
+The N=3 re-run at 20 beats in the shipping configuration (default `opus` alias) is the next G2 measurement; runs before this note
+(`adv_reboot*`) stay recorded at 15 beats.


### PR DESCRIPTION
Refresh charter #1702. Two control runs today (DM pinned to `claude-opus-4-8`): at 15 beats the arc ends at `boss_dead@15` (42 resolved attacks); at 20 beats it completes at beat 19. July's 3/3 landed at 13-15 with one beat of slack, so 15 was knife-edge against today's combat pacing. This predeclares the ruler change BEFORE the N=3 re-measurement now running in the shipping configuration: budget 20 beats; bar unchanged (N≥3, completion ≥ 0.67, behavioral GREEN); DM/player model ids recorded per row (the `opus`/`sonnet` aliases drift). Docs only. Claim class: `ruler-change-record`.