### PR TITLE
certifications: sha-pin kit crypt + kit tavern on build 07a997e9

### DIFF
--- a/qa/certifications/crypt.json
+++ b/qa/certifications/crypt.json
@@ -1,0 +1,72 @@
+{
+  "room": "crypt",
+  "verdicts": {
+    "walk": "GREEN",
+    "player_cert_live": "GREEN"
+  },
+  "manifest_entry": {
+    "plate": "plates/crypt_kit_v1_registered.png",
+    "cameraPin": {
+      "ortho": 11.7851,
+      "pitch": 30,
+      "yaw": 45
+    },
+    "boxes": "boxes/crypt_kit_v1_boxes.json",
+    "effects": [
+      {
+        "type": "fire_medium",
+        "cell": [
+          5,
+          1
+        ],
+        "scale": 0.8,
+        "y": 1.2
+      },
+      {
+        "type": "fire_medium",
+        "cell": [
+          14,
+          4
+        ],
+        "scale": 0.8,
+        "y": 1.2
+      },
+      {
+        "type": "fire_medium",
+        "cell": [
+          6,
+          5
+        ],
+        "scale": 0.8,
+        "y": 1.2
+      },
+      {
+        "type": "fire_medium",
+        "cell": [
+          10,
+          5
+        ],
+        "scale": 0.8,
+        "y": 1.2
+      }
+    ],
+    "_effects_comment": "Animated fire over the four painted brazier fires (geometry brazier cells; bowls sit ~1.2u up the stem). Tune scale/y at the sandbox eyeball if the flame floats or washes the paint.",
+    "_provenance": "KIT-CRYPT v1 (2026-07-23, #83/#84 nav-truth spike): 3D-FIRST CERTIFIED CHAIN \u2014 geometry crypt_v36 -> build_room_kit scene (footprint SEG GATE 100.00%, 0/192 disagreements, qa/evidence/kit-crypt/) -> kit 3D depth -> flux depth-CN base seed 12346 (recall 0.9752, asset_qM9R3tuRH4sceUrVjCoLdPRk) -> Gemini 3.0 Pro edit (model_google-gemini-pro-image-editing, critique-targeted detail prompt, job_Lmhssjh7iWnHsUKY1dhnHB4m) -> phase-corr ALIGNED dx=0,dy=0 vs base (qa/styled_align_check.py) -> geometric void composite (seg-frame mask). Blind panel 7 vs control 8 (delta -1.0, in-band; wf_89967920). Collision truth UNCHANGED: crypt_v36 geometry + walkmask are byte-identical; the OCCLUDER SIDECAR IS swapped to kit-derived bounds (see SIDECAR note below). The sidecar feeds VISUAL occluder proxies only (CombatSurfaceClient.RebuildOccluders destroys each proxy's Collider); engine walkability/collision reads the server scene_grid walkmask, never boxes. NOTE: model_google-gemini-pro-image-editing pending model-registry allowlist (owner sign-off). SIDECAR 2026-07-23: kit-derived boxes (ExportBoxes, 73 per-mass true bounds: parapets 0.55u, pillars/tomb/buttresses at real heights) replacing the authored crypt_v36 volumes -- silhouette bands now hug the paint."
+  },
+  "artifacts": {
+    "plate_sha256": "f88d357bad499a91edebda5e2558da8433db0df14ca40acb9b0b6cfe16448785",
+    "boxes_sha256": "1acf730b703a3afe2dad639b9ec1797dc223102b41d8d33b8a42304939cdf1b9",
+    "geometry_sha256": "d119d0514bf18ec18f40730921f22b3902ec1f92d3362bec7b48831176b6b6c1"
+  },
+  "walk_report": "qa/evidence/walk-crypt-kit-20260902/crypt/walk_report.json",
+  "provenance": {
+    "certified_on": "2026-09-02",
+    "player_build_sha256_prefix": "07a997e9",
+    "unity_repo_head": "b016a7db",
+    "worldos_main": "0c9e305c",
+    "sandbox": "qa_sandbox windowed (registered_world_v1, 8866/8972)",
+    "walk_test": "exhaustive --visual 4",
+    "packaged_pins": "GREEN (qa/packaged_pins.py)",
+    "player_cert": "qa/evidence/player_cert-20260902/ (spawn_coherence_open, silhouette_behind_occluder, silhouette_absent_when_visible GREEN; cast_renders_full_figure ERROR = no foe in fixture, harness)"
+  }
+}

--- a/qa/certifications/tavern.json
+++ b/qa/certifications/tavern.json
@@ -1,0 +1,31 @@
+{
+  "room": "tavern",
+  "verdicts": {
+    "walk": "GREEN"
+  },
+  "manifest_entry": {
+    "plate": "plates/tavern_kit_v2_registered.png",
+    "cameraPin": {
+      "ortho": 10.5224,
+      "pitch": 30,
+      "yaw": 45
+    },
+    "boxes": "boxes/tavern_kit_v1_boxes.json",
+    "_provenance": "KIT-TAVERN v1 (2026-07-23, #83 replication proof): SAME certified chain as KIT-CRYPT v1 \u2014 geometry tavern_v2 -> kit scene (seg gate 100.00% FIRST TRY, 0/154) -> kit 3D depth -> flux base seed 12345 (recall 0.9737+, asset_G5UBNVwMchoG84wPSFiBEsAZ) -> Gemini 3.0 Pro edit c2 w/ FURNITURE-IDENTITY grounding (job_UTwT9WJkbvZpuveXDoMso8Eh) -> phase-corr ALIGNED dx=0 -> seg-mask void composite. Blind panel 7 vs control 8 (delta -1.0 in-band; c1 without furniture grounding was 6/-2.0 \u2014 the grounding clause is load-bearing). Collision truth UNCHANGED: tavern_v2 geometry + walkmask are byte-identical; the OCCLUDER SIDECAR IS swapped to kit-derived bounds (ExportBoxes; parapets 0.55u, true table footprints -- see SIDECAR note below). The sidecar feeds VISUAL occluder proxies only (CombatSurfaceClient.RebuildOccluders destroys each proxy's Collider); engine walkability/collision reads the server scene_grid walkmask, never boxes. SIDECAR 2026-07-23: kit-derived boxes (ExportBoxes per-mass true bounds; cutaway parapets 0.55u, tables 1.4u true footprints) replacing the authored tavern_v2 chunky volumes \u2014 felt-truth fix for the owner-caught silhouette-everywhere class. V2 2026-07-23: per-object gate (qa/object_align_check.py) caught the c2 edit DELETING table#51 at (10,-4) (0.69 cells; global phase-corr blind to it) -- surgical fix: gemini-pro reference-conditioned re-add (job_ia3dLBuaA4pLup5ynEzb7zB6, seed 12345) -> feathered diff-mask composite (7.3% of frame, rest byte-certified v1) -> global identity dx=0 + PER-OBJECT-ALIGNED 12/12 (table#51 0.13 cells)."
+  },
+  "artifacts": {
+    "plate_sha256": "e48dd8cbf7b3ef5e397ac005446d30a323a552f87187d39f73e2500101d3653c",
+    "boxes_sha256": "29f57a0af86a888907ec583237bcf97adb273717980c69f41f5c9715f8020b12",
+    "geometry_sha256": "9f532086996d215845db99025b0ed1cfca0b4e3e1746e6d05a25dcd54b987d1b"
+  },
+  "walk_report": "qa/evidence/walk-tavern-kit-20260902/tavern/walk_report.json",
+  "provenance": {
+    "certified_on": "2026-09-02",
+    "player_build_sha256_prefix": "07a997e9",
+    "unity_repo_head": "b016a7db",
+    "worldos_main": "0c9e305c",
+    "sandbox": "qa_sandbox windowed (registered_world_v1, 8866/8972)",
+    "walk_test": "exhaustive --visual 4",
+    "packaged_pins": "GREEN (qa/packaged_pins.py)"
+  }
+}

--- a/qa/evidence/player_cert-20260902/player_cert_report.json
+++ b/qa/evidence/player_cert-20260902/player_cert_report.json
@@ -1,0 +1,191 @@
+{
+  "schema_version": 1,
+  "suite": "player_cert",
+  "repo_sha": "03acb17b",
+  "manifest_sha256": "0f51fb7ff20b7df588d677ea6e9f7833f7d04864d22454ddd4cc09963c6d0376",
+  "ts": "2026-09-02T07:41:10.774914+00:00",
+  "engine_url": "http://127.0.0.1:8866",
+  "qa_url": "http://127.0.0.1:8972",
+  "campaign": "registered_world_v1",
+  "app_path": "/Users/m1/worldos-unity/BuildOutput/WorldOSPlayer.app",
+  "live": true,
+  "player_build": null,
+  "assertions": [
+    {
+      "id": "spawn_coherence_open",
+      "scope": "engine_state",
+      "needs": [
+        "engine"
+      ],
+      "doc": "Primitive B \u2014 party spawn + arrival cells are prop-clear, BFS-reachable, and (where a coherence report exists) on cells the player sees as open, never `covered` (#1584/#1647).",
+      "verdict": "GREEN",
+      "detail": {
+        "n_tokens": 1,
+        "n_bad": 0
+      },
+      "record": {
+        "tokens": [
+          {
+            "name": "Aldric",
+            "team": "ally",
+            "cell": [
+              6,
+              1
+            ],
+            "prop_clear": true,
+            "reachable": true,
+            "coherence": "open",
+            "coherence_ok": true,
+            "ok": true
+          }
+        ],
+        "anchor": [
+          6,
+          1
+        ],
+        "verdict": "GREEN",
+        "harness_errors": [],
+        "detail": {
+          "n_tokens": 1,
+          "n_bad": 0
+        },
+        "room": "crypt",
+        "coherence_report": true
+      }
+    },
+    {
+      "id": "silhouette_behind_occluder",
+      "scope": "live_party",
+      "needs": [
+        "engine",
+        "player"
+      ],
+      "doc": "Primitive A \u2014 the party actor placed BEHIND a tall occluder still renders its walk-behind silhouette (#1572 per-submesh clone; WORLDOS_SILHOUETTE=0 turns this RED).",
+      "verdict": "GREEN",
+      "detail": "occluder=? h=5.4 behind=[13, 3] head_density=0.2817 min=0.045 head_px=[766, 120]",
+      "record": {
+        "harness_errors": [],
+        "moved": true,
+        "no_occluder": false,
+        "no_behind_cell": false,
+        "room": "crypt",
+        "window": [
+          1280,
+          700
+        ],
+        "cell_source": "calibrated",
+        "occluder": {
+          "name": "?",
+          "kind": "wallright",
+          "height": 5.4,
+          "center": [
+            15.0,
+            0.0,
+            5.0
+          ],
+          "size": [
+            1.4,
+            5.4,
+            2.0
+          ],
+          "cell": [
+            15,
+            3
+          ]
+        },
+        "behind_cell": [
+          13,
+          3
+        ],
+        "start_cell": [
+          6,
+          1
+        ],
+        "head_px": [
+          766,
+          120
+        ],
+        "head_radius_px": 33,
+        "min_density": 0.045,
+        "landed": [
+          13,
+          3
+        ],
+        "frames": {
+          "baseline": "/Users/m1/Codex/session-notes/2026-09-02/worldos-refresh/artifacts/player_cert/shot_sil_baseline.png",
+          "behind": "/Users/m1/Codex/session-notes/2026-09-02/worldos-refresh/artifacts/player_cert/shot_sil_behind.png"
+        },
+        "head_density": 0.2817,
+        "frames_identical": false
+      }
+    },
+    {
+      "id": "silhouette_absent_when_visible",
+      "scope": "live_party",
+      "needs": [
+        "engine",
+        "player"
+      ],
+      "doc": "Primitive A COUNTER-assert \u2014 the party actor on its UNOCCLUDED cell shows NO walk-behind silhouette tint (#1677 ghost-in-the-open: the ZTest-Greater clone tinting the actor against its OWN body depth). A ghost-cyan overlay in the open turns this RED \u2014 the occluder-scoping stencil fix keeps it GREEN.",
+      "verdict": "GREEN",
+      "detail": "open_cell=[6, 1] tint_share=0.0 head_tint_share=0.0 max=0.03 head_px=[388, 225]",
+      "record": {
+        "harness_errors": [],
+        "captured": true,
+        "max_tint_share": 0.03,
+        "room": "crypt",
+        "start_cell": [
+          6,
+          1
+        ],
+        "window": [
+          1280,
+          700
+        ],
+        "head_px": [
+          388,
+          225
+        ],
+        "region": [
+          308,
+          202,
+          468,
+          339
+        ],
+        "frames": {
+          "open": "/Users/m1/Codex/session-notes/2026-09-02/worldos-refresh/artifacts/player_cert/shot_sil_open.png"
+        },
+        "tint_share": 0.0,
+        "head_tint_share": 0.0
+      }
+    },
+    {
+      "id": "cast_renders_full_figure",
+      "scope": "live_party",
+      "needs": [
+        "engine",
+        "player"
+      ],
+      "doc": "Primitive C (#1666) \u2014 every FOE token renders a full BODY figure, not a fragment. A fragment-rendered token (body renderers never initialized; only an accessory mesh drew \u2014 the g5 crypt first-spawn residual) whose projected-figure body extent falls below the floor turns this RED; the bundle/skinning pre-warm + the render-coverage rebind guard keep it GREEN.",
+      "verdict": "ERROR",
+      "detail": null,
+      "record": {
+        "harness_errors": [
+          "no foe token on the surface to measure"
+        ],
+        "captured": false,
+        "min_extent": 0.35,
+        "foes": [],
+        "room": "crypt"
+      }
+    }
+  ],
+  "harness_errors": [
+    "cast_renders_full_figure: no foe token on the surface to measure"
+  ],
+  "verdict": "ERROR",
+  "endpoints": {
+    "engine_up": true,
+    "player_up": true
+  }
+}

--- a/qa/evidence/walk-crypt-kit-20260902/crypt/walk_report.json
+++ b/qa/evidence/walk-crypt-kit-20260902/crypt/walk_report.json
@@ -1,0 +1,2380 @@
+{
+  "schema_version": 1,
+  "repo_sha": "2d4f645c",
+  "manifest_sha256": "0f51fb7ff20b7df588d677ea6e9f7833f7d04864d22454ddd4cc09963c6d0376",
+  "ts": "2026-09-02T07:23:58.888144+00:00",
+  "engine_url": "http://127.0.0.1:8866",
+  "qa_url": "http://127.0.0.1:8972",
+  "room": "crypt",
+  "ortho": 11.7851,
+  "sceneId": "camp_townslice01:registered_world_v1_crypt",
+  "grid": {
+    "cols": 16,
+    "rows": 12
+  },
+  "camera": {
+    "dbg": {
+      "ok": true,
+      "enq": 0,
+      "deq": 0,
+      "acted": 0,
+      "surf": 7,
+      "busy": false,
+      "last": "none",
+      "camOrtho": 11.7851,
+      "camRx": 30,
+      "camRy": 45,
+      "camRz": 0,
+      "camPx": -48.9898,
+      "camPy": 40,
+      "camPz": -48.9898,
+      "originVX": 0.5,
+      "originVY": 0.5,
+      "occCount": 73,
+      "plateLocMatch": true,
+      "actorVX": 0.43745,
+      "actorVY": 0.4189
+    },
+    "fails": [],
+    "ok": true,
+    "pose_mismatch": false
+  },
+  "orphans": [],
+  "path": {
+    "pass": 113,
+    "fail": 0,
+    "violations": []
+  },
+  "reachable": {
+    "pass": 113,
+    "fail": 0,
+    "cases": [
+      {
+        "cell": [
+          1,
+          1
+        ],
+        "landed": [
+          1,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          2
+        ],
+        "landed": [
+          1,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          3
+        ],
+        "landed": [
+          1,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          4
+        ],
+        "landed": [
+          1,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          5
+        ],
+        "landed": [
+          1,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          6
+        ],
+        "landed": [
+          1,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          7
+        ],
+        "landed": [
+          1,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          8
+        ],
+        "landed": [
+          1,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          9
+        ],
+        "landed": [
+          1,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          10
+        ],
+        "landed": [
+          1,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          2
+        ],
+        "landed": [
+          2,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          3
+        ],
+        "landed": [
+          2,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          4
+        ],
+        "landed": [
+          2,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          5
+        ],
+        "landed": [
+          2,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          6
+        ],
+        "landed": [
+          2,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          7
+        ],
+        "landed": [
+          2,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          8
+        ],
+        "landed": [
+          2,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          2
+        ],
+        "landed": [
+          3,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          3
+        ],
+        "landed": [
+          3,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          4
+        ],
+        "landed": [
+          3,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          5
+        ],
+        "landed": [
+          3,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          6
+        ],
+        "landed": [
+          3,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          7
+        ],
+        "landed": [
+          3,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          8
+        ],
+        "landed": [
+          3,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          9
+        ],
+        "landed": [
+          3,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          1
+        ],
+        "landed": [
+          4,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          2
+        ],
+        "landed": [
+          4,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          5
+        ],
+        "landed": [
+          4,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          6
+        ],
+        "landed": [
+          4,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          7
+        ],
+        "landed": [
+          4,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          10
+        ],
+        "landed": [
+          4,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          2
+        ],
+        "landed": [
+          5,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          3
+        ],
+        "landed": [
+          5,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          4
+        ],
+        "landed": [
+          5,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          5
+        ],
+        "landed": [
+          5,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          6
+        ],
+        "landed": [
+          5,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          7
+        ],
+        "landed": [
+          5,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          8
+        ],
+        "landed": [
+          5,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          9
+        ],
+        "landed": [
+          5,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          10
+        ],
+        "landed": [
+          5,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          1
+        ],
+        "landed": [
+          6,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          2
+        ],
+        "landed": [
+          6,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          3
+        ],
+        "landed": [
+          6,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          4
+        ],
+        "landed": [
+          6,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          6
+        ],
+        "landed": [
+          6,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          7
+        ],
+        "landed": [
+          6,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          8
+        ],
+        "landed": [
+          6,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          9
+        ],
+        "landed": [
+          6,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          10
+        ],
+        "landed": [
+          6,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          1
+        ],
+        "landed": [
+          7,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          2
+        ],
+        "landed": [
+          7,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          3
+        ],
+        "landed": [
+          7,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          4
+        ],
+        "landed": [
+          7,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          7
+        ],
+        "landed": [
+          7,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          8
+        ],
+        "landed": [
+          7,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          9
+        ],
+        "landed": [
+          7,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          10
+        ],
+        "landed": [
+          7,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          1
+        ],
+        "landed": [
+          8,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          2
+        ],
+        "landed": [
+          8,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          3
+        ],
+        "landed": [
+          8,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          4
+        ],
+        "landed": [
+          8,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          7
+        ],
+        "landed": [
+          8,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          8
+        ],
+        "landed": [
+          8,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          9
+        ],
+        "landed": [
+          8,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          10
+        ],
+        "landed": [
+          8,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          2
+        ],
+        "landed": [
+          9,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          3
+        ],
+        "landed": [
+          9,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          4
+        ],
+        "landed": [
+          9,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          7
+        ],
+        "landed": [
+          9,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          8
+        ],
+        "landed": [
+          9,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          9
+        ],
+        "landed": [
+          9,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          10
+        ],
+        "landed": [
+          9,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          1
+        ],
+        "landed": [
+          10,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          2
+        ],
+        "landed": [
+          10,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          3
+        ],
+        "landed": [
+          10,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          4
+        ],
+        "landed": [
+          10,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          6
+        ],
+        "landed": [
+          10,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          8
+        ],
+        "landed": [
+          10,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          9
+        ],
+        "landed": [
+          10,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          10
+        ],
+        "landed": [
+          10,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          2
+        ],
+        "landed": [
+          11,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          3
+        ],
+        "landed": [
+          11,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          4
+        ],
+        "landed": [
+          11,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          5
+        ],
+        "landed": [
+          11,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          6
+        ],
+        "landed": [
+          11,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          7
+        ],
+        "landed": [
+          11,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          8
+        ],
+        "landed": [
+          11,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          9
+        ],
+        "landed": [
+          11,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          10
+        ],
+        "landed": [
+          11,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          2
+        ],
+        "landed": [
+          12,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          5
+        ],
+        "landed": [
+          12,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          6
+        ],
+        "landed": [
+          12,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          7
+        ],
+        "landed": [
+          12,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          10
+        ],
+        "landed": [
+          12,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          1
+        ],
+        "landed": [
+          13,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          2
+        ],
+        "landed": [
+          13,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          3
+        ],
+        "landed": [
+          13,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          4
+        ],
+        "landed": [
+          13,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          5
+        ],
+        "landed": [
+          13,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          6
+        ],
+        "landed": [
+          13,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          7
+        ],
+        "landed": [
+          13,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          8
+        ],
+        "landed": [
+          13,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          9
+        ],
+        "landed": [
+          13,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          10
+        ],
+        "landed": [
+          13,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          14,
+          1
+        ],
+        "landed": [
+          14,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          14,
+          2
+        ],
+        "landed": [
+          14,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          14,
+          3
+        ],
+        "landed": [
+          14,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          14,
+          5
+        ],
+        "landed": [
+          14,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          14,
+          6
+        ],
+        "landed": [
+          14,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          14,
+          7
+        ],
+        "landed": [
+          14,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          14,
+          8
+        ],
+        "landed": [
+          14,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          14,
+          9
+        ],
+        "landed": [
+          14,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          14,
+          10
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      }
+    ]
+  },
+  "impassable": {
+    "pass": 77,
+    "fail": 0,
+    "cases": [
+      {
+        "cell": [
+          0,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          1
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          2
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          3
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          4
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          5
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          6
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          7
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          8
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          9
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          10
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          1
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          9
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          10
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          1
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          10
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          3
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          4
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          8
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          9
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          1
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          5
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          5
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          6
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          5
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          6
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          1
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          5
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          6
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          5
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          7
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          1
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          1
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          3
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          4
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          8
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          9
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          14,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          14,
+          4
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          14,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          15,
+          0
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          15,
+          1
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          15,
+          2
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          15,
+          3
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          15,
+          4
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          15,
+          6
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          15,
+          7
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          15,
+          8
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          15,
+          9
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          15,
+          10
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          15,
+          11
+        ],
+        "landed": [
+          14,
+          10
+        ],
+        "ok": true
+      }
+    ]
+  },
+  "doors": {
+    "pass": 2,
+    "fail": 0,
+    "cases": [
+      {
+        "cell": [
+          7,
+          0
+        ],
+        "to": "tavern",
+        "ok": true,
+        "detail": {
+          "crossed_to": "tavern",
+          "target": "tavern",
+          "pose": {
+            "dest": {
+              "ortho": 10.5224,
+              "dbg": {
+                "ok": true,
+                "enq": 191,
+                "deq": 191,
+                "acted": 191,
+                "surf": 475,
+                "busy": false,
+                "last": "cell(7,0) rest=True foe=(-1,-1)'' imp=n occ=n",
+                "camOrtho": 10.5224,
+                "camRx": 30,
+                "camRy": 45,
+                "camRz": 0,
+                "camPx": -48.9898,
+                "camPy": 40,
+                "camPz": -48.9898,
+                "originVX": 0.5,
+                "originVY": 0.5,
+                "occCount": 56,
+                "plateLocMatch": true,
+                "actorVX": 0.3391,
+                "actorVY": 0.61939
+              }
+            },
+            "home": {
+              "ortho": 11.7851,
+              "dbg": {
+                "ok": true,
+                "enq": 192,
+                "deq": 192,
+                "acted": 192,
+                "surf": 476,
+                "busy": false,
+                "last": "cell(7,0) rest=True foe=(-1,-1)'' imp=n occ=n",
+                "camOrtho": 11.7851,
+                "camRx": 30,
+                "camRy": 45,
+                "camRz": 0,
+                "camPx": -48.9898,
+                "camPy": 40,
+                "camPz": -48.9898,
+                "originVX": 0.5,
+                "originVY": 0.5,
+                "occCount": 73,
+                "plateLocMatch": true,
+                "actorVX": 0.30712,
+                "actorVY": 0.5916
+              }
+            }
+          }
+        }
+      },
+      {
+        "cell": [
+          15,
+          5
+        ],
+        "to": "throne_hall",
+        "ok": true,
+        "detail": {
+          "crossed_to": "throne_hall",
+          "target": "throne_hall",
+          "pose": {
+            "dest": {
+              "ortho": 11.7851,
+              "dbg": {
+                "ok": true,
+                "enq": 193,
+                "deq": 193,
+                "acted": 193,
+                "surf": 478,
+                "busy": false,
+                "last": "cell(15,5) rest=True foe=(-1,-1)'' imp=n occ=n",
+                "camOrtho": 11.7851,
+                "camRx": 30,
+                "camRy": 45,
+                "camRz": 0,
+                "camPx": -48.9898,
+                "camPy": 40,
+                "camPz": -48.9898,
+                "originVX": 0.5,
+                "originVY": 0.5,
+                "occCount": 40,
+                "plateLocMatch": true,
+                "actorVX": 0.62837,
+                "actorVY": 0.35709
+              }
+            },
+            "home": {
+              "ortho": 11.7851,
+              "dbg": {
+                "ok": true,
+                "enq": 194,
+                "deq": 194,
+                "acted": 194,
+                "surf": 479,
+                "busy": false,
+                "last": "cell(8,11) rest=True foe=(-1,-1)'' imp=n occ=n",
+                "camOrtho": 11.7851,
+                "camRx": 30,
+                "camRy": 45,
+                "camRz": 0,
+                "camPx": -48.9898,
+                "camPy": 40,
+                "camPz": -48.9898,
+                "originVX": 0.5,
+                "originVY": 0.5,
+                "occCount": 73,
+                "plateLocMatch": true,
+                "actorVX": 0.66072,
+                "actorVY": 0.681
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  "visual": {
+    "pass": 4,
+    "fail": 0,
+    "cases": [
+      {
+        "cell": [
+          10,
+          9
+        ],
+        "moved": true,
+        "dist_px": 11.5,
+        "tol_px": 74.2,
+        "ok": true,
+        "dist_prev_px": 143.8,
+        "n_blobs": 2,
+        "blob_area_max": 1544,
+        "n_blobs_masked": 5
+      },
+      {
+        "cell": [
+          7,
+          8
+        ],
+        "moved": true,
+        "dist_px": 4.8,
+        "tol_px": 74.2,
+        "ok": true,
+        "dist_prev_px": 11.5,
+        "n_blobs": 4,
+        "blob_area_max": 1603,
+        "n_blobs_masked": 3
+      },
+      {
+        "cell": [
+          2,
+          7
+        ],
+        "moved": true,
+        "dist_px": 2.8,
+        "tol_px": 74.2,
+        "ok": true,
+        "dist_prev_px": 4.8,
+        "n_blobs": 4,
+        "blob_area_max": 1603,
+        "n_blobs_masked": 3
+      },
+      {
+        "cell": [
+          1,
+          1
+        ],
+        "moved": true,
+        "dist_px": 10.9,
+        "tol_px": 74.2,
+        "ok": true,
+        "dist_prev_px": 2.8,
+        "n_blobs": 4,
+        "blob_area_max": 1282,
+        "n_blobs_masked": 2
+      }
+    ],
+    "window": [
+      1280,
+      700
+    ],
+    "capture_scale": 1.0,
+    "diff_params": {
+      "cell_px": 59.4,
+      "merge_px": 27,
+      "min_area_px": 60
+    },
+    "fire_cells": [
+      [
+        5,
+        1
+      ],
+      [
+        6,
+        5
+      ],
+      [
+        10,
+        5
+      ],
+      [
+        14,
+        4
+      ]
+    ]
+  },
+  "harness_errors": [],
+  "door_pose_fail": [],
+  "shots": [
+    "/Users/m1/Codex/session-notes/2026-09-02/worldos-refresh/artifacts/walk-crypt-rw/crypt/shot_crypt_final.png"
+  ],
+  "verdict": "GREEN"
+}

--- a/qa/evidence/walk-tavern-kit-20260902/tavern/walk_report.json
+++ b/qa/evidence/walk-tavern-kit-20260902/tavern/walk_report.json
@@ -1,0 +1,1954 @@
+{
+  "schema_version": 1,
+  "repo_sha": "03acb17b",
+  "manifest_sha256": "0f51fb7ff20b7df588d677ea6e9f7833f7d04864d22454ddd4cc09963c6d0376",
+  "ts": "2026-09-02T07:33:29.270203+00:00",
+  "engine_url": "http://127.0.0.1:8866",
+  "qa_url": "http://127.0.0.1:8972",
+  "room": "tavern",
+  "ortho": 10.5224,
+  "sceneId": "camp_townslice01:registered_world_v1_tavern",
+  "grid": {
+    "cols": 14,
+    "rows": 11
+  },
+  "camera": {
+    "dbg": {
+      "ok": true,
+      "enq": 200,
+      "deq": 200,
+      "acted": 200,
+      "surf": 503,
+      "busy": false,
+      "last": "cell(7,0) rest=True foe=(-1,-1)'' imp=n occ=n",
+      "camOrtho": 10.5224,
+      "camRx": 30,
+      "camRy": 45,
+      "camRz": 0,
+      "camPx": -48.9898,
+      "camPy": 40,
+      "camPz": -48.9898,
+      "originVX": 0.5,
+      "originVY": 0.5,
+      "occCount": 56,
+      "plateLocMatch": true,
+      "actorVX": 0.33128,
+      "actorVY": 0.61977
+    },
+    "fails": [],
+    "ok": true,
+    "pose_mismatch": false
+  },
+  "orphans": [],
+  "path": {
+    "pass": 90,
+    "fail": 0,
+    "violations": []
+  },
+  "reachable": {
+    "pass": 90,
+    "fail": 0,
+    "cases": [
+      {
+        "cell": [
+          1,
+          1
+        ],
+        "landed": [
+          1,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          2
+        ],
+        "landed": [
+          1,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          3
+        ],
+        "landed": [
+          1,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          4
+        ],
+        "landed": [
+          1,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          5
+        ],
+        "landed": [
+          1,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          6
+        ],
+        "landed": [
+          1,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          7
+        ],
+        "landed": [
+          1,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          8
+        ],
+        "landed": [
+          1,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          9
+        ],
+        "landed": [
+          1,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          3
+        ],
+        "landed": [
+          2,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          4
+        ],
+        "landed": [
+          2,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          5
+        ],
+        "landed": [
+          2,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          6
+        ],
+        "landed": [
+          2,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          7
+        ],
+        "landed": [
+          2,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          8
+        ],
+        "landed": [
+          2,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          9
+        ],
+        "landed": [
+          2,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          3
+        ],
+        "landed": [
+          3,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          4
+        ],
+        "landed": [
+          3,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          5
+        ],
+        "landed": [
+          3,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          6
+        ],
+        "landed": [
+          3,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          7
+        ],
+        "landed": [
+          3,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          8
+        ],
+        "landed": [
+          3,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          9
+        ],
+        "landed": [
+          3,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          1
+        ],
+        "landed": [
+          4,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          3
+        ],
+        "landed": [
+          4,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          4
+        ],
+        "landed": [
+          4,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          7
+        ],
+        "landed": [
+          4,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          8
+        ],
+        "landed": [
+          4,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          9
+        ],
+        "landed": [
+          4,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          1
+        ],
+        "landed": [
+          5,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          3
+        ],
+        "landed": [
+          5,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          4
+        ],
+        "landed": [
+          5,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          5
+        ],
+        "landed": [
+          5,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          6
+        ],
+        "landed": [
+          5,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          7
+        ],
+        "landed": [
+          5,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          8
+        ],
+        "landed": [
+          5,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          9
+        ],
+        "landed": [
+          5,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          1
+        ],
+        "landed": [
+          6,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          2
+        ],
+        "landed": [
+          6,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          3
+        ],
+        "landed": [
+          6,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          4
+        ],
+        "landed": [
+          6,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          5
+        ],
+        "landed": [
+          6,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          6
+        ],
+        "landed": [
+          6,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          7
+        ],
+        "landed": [
+          6,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          8
+        ],
+        "landed": [
+          6,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          9
+        ],
+        "landed": [
+          6,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          1
+        ],
+        "landed": [
+          7,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          2
+        ],
+        "landed": [
+          7,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          3
+        ],
+        "landed": [
+          7,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          4
+        ],
+        "landed": [
+          7,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          5
+        ],
+        "landed": [
+          7,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          6
+        ],
+        "landed": [
+          7,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          8
+        ],
+        "landed": [
+          7,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          9
+        ],
+        "landed": [
+          7,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          2
+        ],
+        "landed": [
+          8,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          3
+        ],
+        "landed": [
+          8,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          4
+        ],
+        "landed": [
+          8,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          5
+        ],
+        "landed": [
+          8,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          6
+        ],
+        "landed": [
+          8,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          8
+        ],
+        "landed": [
+          8,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          9
+        ],
+        "landed": [
+          8,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          1
+        ],
+        "landed": [
+          9,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          2
+        ],
+        "landed": [
+          9,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          3
+        ],
+        "landed": [
+          9,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          6
+        ],
+        "landed": [
+          9,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          7
+        ],
+        "landed": [
+          9,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          8
+        ],
+        "landed": [
+          9,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          9
+        ],
+        "landed": [
+          9,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          2
+        ],
+        "landed": [
+          10,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          3
+        ],
+        "landed": [
+          10,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          4
+        ],
+        "landed": [
+          10,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          5
+        ],
+        "landed": [
+          10,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          6
+        ],
+        "landed": [
+          10,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          7
+        ],
+        "landed": [
+          10,
+          7
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          8
+        ],
+        "landed": [
+          10,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          9
+        ],
+        "landed": [
+          10,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          2
+        ],
+        "landed": [
+          11,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          3
+        ],
+        "landed": [
+          11,
+          3
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          4
+        ],
+        "landed": [
+          11,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          5
+        ],
+        "landed": [
+          11,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          6
+        ],
+        "landed": [
+          11,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          8
+        ],
+        "landed": [
+          11,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          9
+        ],
+        "landed": [
+          11,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          1
+        ],
+        "landed": [
+          12,
+          1
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          2
+        ],
+        "landed": [
+          12,
+          2
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          4
+        ],
+        "landed": [
+          12,
+          4
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          5
+        ],
+        "landed": [
+          12,
+          5
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          6
+        ],
+        "landed": [
+          12,
+          6
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          8
+        ],
+        "landed": [
+          12,
+          8
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          9
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      }
+    ]
+  },
+  "impassable": {
+    "pass": 62,
+    "fail": 0,
+    "cases": [
+      {
+        "cell": [
+          0,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          1
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          2
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          3
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          4
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          5
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          6
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          7
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          8
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          9
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          0,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          1,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          1
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          2
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          2,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          1
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          2
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          3,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          2
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          5
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          6
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          4,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          2
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          5,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          6,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          7
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          7,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          1
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          7
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          8,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          4
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          5
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          9,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          1
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          10,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          1
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          7
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          11,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          3
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          7
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          12,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          0
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          1
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          2
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          3
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          4
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          6
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          7
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          8
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          9
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      },
+      {
+        "cell": [
+          13,
+          10
+        ],
+        "landed": [
+          12,
+          9
+        ],
+        "ok": true
+      }
+    ]
+  },
+  "doors": {
+    "pass": 2,
+    "fail": 0,
+    "cases": [
+      {
+        "cell": [
+          7,
+          0
+        ],
+        "to": "crypt",
+        "ok": true,
+        "detail": {
+          "crossed_to": "crypt",
+          "target": "crypt",
+          "pose": {
+            "dest": {
+              "ortho": 11.7851,
+              "dbg": {
+                "ok": true,
+                "enq": 353,
+                "deq": 353,
+                "acted": 353,
+                "surf": 879,
+                "busy": false,
+                "last": "cell(7,0) rest=True foe=(-1,-1)'' imp=n occ=n",
+                "camOrtho": 11.7851,
+                "camRx": 30,
+                "camRy": 45,
+                "camRz": 0,
+                "camPx": -48.9898,
+                "camPy": 40,
+                "camPz": -48.9898,
+                "originVX": 0.5,
+                "originVY": 0.5,
+                "occCount": 73,
+                "plateLocMatch": true,
+                "actorVX": 0.30714,
+                "actorVY": 0.59162
+              }
+            },
+            "home": {
+              "ortho": 10.5224,
+              "dbg": {
+                "ok": true,
+                "enq": 354,
+                "deq": 354,
+                "acted": 354,
+                "surf": 881,
+                "busy": false,
+                "last": "cell(7,0) rest=True foe=(-1,-1)'' imp=n occ=n",
+                "camOrtho": 10.5224,
+                "camRx": 30,
+                "camRy": 45,
+                "camRz": 0,
+                "camPx": -48.9898,
+                "camPy": 40,
+                "camPz": -48.9898,
+                "originVX": 0.5,
+                "originVY": 0.5,
+                "occCount": 56,
+                "plateLocMatch": true,
+                "actorVX": 0.33912,
+                "actorVY": 0.61941
+              }
+            }
+          }
+        }
+      },
+      {
+        "cell": [
+          13,
+          5
+        ],
+        "to": "shop",
+        "ok": true,
+        "detail": {
+          "crossed_to": "shop",
+          "target": "shop",
+          "pose": {
+            "dest": {
+              "ortho": 9.6806,
+              "dbg": {
+                "ok": true,
+                "enq": 355,
+                "deq": 355,
+                "acted": 355,
+                "surf": 882,
+                "busy": false,
+                "last": "cell(13,5) rest=True foe=(-1,-1)'' imp=n occ=n",
+                "camOrtho": 9.6806,
+                "camRx": 30,
+                "camRy": 45,
+                "camRz": 0,
+                "camPx": -48.9898,
+                "camPy": 40,
+                "camPz": -48.9898,
+                "originVX": 0.5,
+                "originVY": 0.5,
+                "occCount": 27,
+                "plateLocMatch": true,
+                "actorVX": 0.39745,
+                "actorVY": 0.66941
+              }
+            },
+            "home": {
+              "ortho": 10.5224,
+              "dbg": {
+                "ok": true,
+                "enq": 356,
+                "deq": 356,
+                "acted": 356,
+                "surf": 883,
+                "busy": false,
+                "last": "cell(6,0) rest=True foe=(-1,-1)'' imp=n occ=n",
+                "camOrtho": 10.5224,
+                "camRx": 30,
+                "camRy": 45,
+                "camRz": 0,
+                "camPx": -48.9898,
+                "camPy": 40,
+                "camPz": -48.9898,
+                "originVX": 0.5,
+                "originVY": 0.5,
+                "occCount": 56,
+                "plateLocMatch": true,
+                "actorVX": 0.66143,
+                "actorVY": 0.72453
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  "visual": {
+    "pass": 4,
+    "fail": 0,
+    "cases": [
+      {
+        "cell": [
+          8,
+          4
+        ],
+        "moved": true,
+        "dist_px": 10.1,
+        "tol_px": 83.2,
+        "ok": true,
+        "dist_prev_px": 199.7,
+        "n_blobs": 2,
+        "blob_area_max": 2068,
+        "n_blobs_masked": 2
+      },
+      {
+        "cell": [
+          5,
+          5
+        ],
+        "moved": true,
+        "dist_px": 7.5,
+        "tol_px": 83.2,
+        "ok": true,
+        "dist_prev_px": 10.1,
+        "n_blobs": 4,
+        "blob_area_max": 2068,
+        "n_blobs_masked": 0
+      },
+      {
+        "cell": [
+          3,
+          3
+        ],
+        "moved": true,
+        "dist_px": 15.0,
+        "tol_px": 83.2,
+        "ok": true,
+        "dist_prev_px": 7.5,
+        "n_blobs": 4,
+        "blob_area_max": 2002,
+        "n_blobs_masked": 0
+      },
+      {
+        "cell": [
+          1,
+          1
+        ],
+        "moved": true,
+        "dist_px": 2.9,
+        "tol_px": 83.2,
+        "ok": true,
+        "dist_prev_px": 15.0,
+        "n_blobs": 4,
+        "blob_area_max": 1678,
+        "n_blobs_masked": 0
+      }
+    ],
+    "window": [
+      1280,
+      700
+    ],
+    "capture_scale": 1.0,
+    "diff_params": {
+      "cell_px": 66.5,
+      "merge_px": 30,
+      "min_area_px": 60
+    },
+    "fire_cells": [
+      [
+        8,
+        1
+      ],
+      [
+        12,
+        3
+      ]
+    ]
+  },
+  "harness_errors": [],
+  "door_pose_fail": [],
+  "shots": [
+    "/Users/m1/Codex/session-notes/2026-09-02/worldos-refresh/artifacts/walk-tavern/tavern/shot_tavern_final.png"
+  ],
+  "verdict": "GREEN"
+}


### PR DESCRIPTION
Refresh charter #1702, Track A step 6 ("mint sha-pinned certs after the data PR's manifest"). Both kit rooms were walk-green on the rebuilt app today (exhaustive, visual 4/0), packaged pins GREEN, player_cert live slice GREEN on the crypt — but only shop + tavern_snug carried certs. This pins plate/boxes/geometry shas + the manifest entry for `crypt` and `tavern` so `test_repo_certifications_are_fresh` now guards them too (any drift ⇒ re-gate). Provenance block records build 07a997e9 / unity b016a7db / main 0c9e305c and the harness-ERROR primitive (no foe in the fixture). Claim class: `walk-certified-on-build` — proves geometry+render registration on the sandbox rig; does NOT prove the owner-installed app (none exists yet).