### PR TITLE
qa: fix six PR #1717 post-merge findings

### DIFF
--- a/qa/qa_sandbox.py
+++ b/qa/qa_sandbox.py
@@ -198,7 +198,7 @@ def _is_churn(key: str) -> bool:
     return key in CHURN_KEYS or any(key.startswith(pre) for pre in CHURN_PREFIXES)
 
 
-def _plist_snapshot() -> dict:
+def _plist_snapshot() -> dict | None:
     """The WHOLE shared domain as {key: str}, minus the churn keys. READ ONLY.
 
     Whole-domain, not just the Screenmanager keys: the leak CHECK must be able to report any key the
@@ -210,15 +210,15 @@ def _plist_snapshot() -> dict:
         p = subprocess.run(["defaults", "export", PLIST_DOMAIN, "-"],
                            capture_output=True, timeout=15)
     except Exception:  # noqa: BLE001
-        return {}
+        return None
     if p.returncode != 0 or not p.stdout:
-        return {}
+        return None
     try:
         data = plistlib.loads(p.stdout)
     except Exception:  # noqa: BLE001
-        return {}
+        return None
     if not isinstance(data, dict):
-        return {}
+        return None
     return {str(k): str(v) for k, v in sorted(data.items()) if not _is_churn(str(k))}
 
 
@@ -290,17 +290,19 @@ def _plist_restore(diff: dict, *, foreign_alive: bool, rig_values: dict) -> dict
                                       f"({want!r}) — someone else wrote it last")
             continue
         if old is None:
-            subprocess.run(["defaults", "delete", PLIST_DOMAIN, key],
-                           capture_output=True, text=True)
-            report["restored"][key] = None
-            continue
-        if not _INT_RE.fullmatch(str(old)):
-            report["skipped"][key] = (f"snapshot value {old!r} is not an integer — refusing to "
-                                      f"`defaults write -int` it")
-            continue
-        subprocess.run(["defaults", "write", PLIST_DOMAIN, key, "-int", str(old)],
-                       capture_output=True, text=True)
-        report["restored"][key] = old
+            cmd, restored = ["defaults", "delete", PLIST_DOMAIN, key], None
+        else:
+            if not _INT_RE.fullmatch(str(old)):
+                report["skipped"][key] = (f"snapshot value {old!r} is not an integer — refusing to "
+                                          f"`defaults write -int` it")
+                continue
+            cmd, restored = ["defaults", "write", PLIST_DOMAIN, key, "-int", str(old)], old
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode:
+            report["skipped"][key] = (f"`defaults {cmd[1]}` failed (rc={result.returncode}) — "
+                                       "the rig value is STILL in the domain")
+        else:
+            report["restored"][key] = restored
     return report
 
 
@@ -573,6 +575,9 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
     win_h = int(win_args[win_args.index("-screen-height") + 1])
 
     plist_before = _plist_snapshot()      # SHARED domain — snapshot now, diff + restore in down()
+    if plist_before is None:
+        raise SystemExit("[sandbox] could not snapshot the shared plist — refusing to launch "
+                         "(a failed read must never be restored as an empty domain).")
     front_before = LQW.front_app()        # {"name","pid"}: focus is handed back BY PID, not by name
 
     # 0c) PREFLIGHT the .app, still before anything is created or spawned. Both of these used to run after the
@@ -648,12 +653,22 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
     # caffeinate is now a SIBLING watcher (`-w <pid>`, exits with the player) in the SAME process
     # group, and -d/-u are gone: -u ASSERTS USER ACTIVITY (wakes and holds the owner's display).
     # -i (idle) + -s (system sleep) still keep App-Nap -> throttled-render -> delayed /shot away.
+    try:
+        owner_active_guard()
+    except SystemExit:
+        _kill_group(engine.pid, "engine", expect_pgid=eng_pgid)
+        raise
     player = subprocess.Popen(argv, env=penv, stdout=ply_log, stderr=subprocess.STDOUT,
                               start_new_session=True)
     player_pgid = os.getpgid(player.pid)
-    caff = subprocess.Popen(["/usr/bin/caffeinate", *CAFFEINATE_FLAGS, "-w", str(player.pid)],
-                            stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT,
-                            start_new_session=False)
+    try:
+        caff = subprocess.Popen(["/usr/bin/caffeinate", *CAFFEINATE_FLAGS, "-w", str(player.pid)],
+                                stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT,
+                                start_new_session=False)
+    except Exception as exc:  # noqa: BLE001
+        caff = None
+        print(f"[sandbox] WARN: caffeinate unavailable ({exc}); continuing without it.",
+              file=sys.stderr)
 
     meta = {"run": run, "campaign": campaign, "state": str(state), "status": "booting",
             "engine": f"http://127.0.0.1:{engine_port}", "qa": f"http://127.0.0.1:{qa_port}",
@@ -661,7 +676,7 @@ def up(run: str, *, campaign: str, engine_port: int, qa_port: int,
             "plist_before": plist_before, "front_before": front_before,
             "pids": {"engine": engine.pid, "player": player.pid},
             "pgids": {"engine": eng_pgid, "player": player_pgid},
-            "caffeinate_pid": caff.pid}
+            "caffeinate_pid": caff.pid if caff else None}
     # ANTI-ORPHAN FENCE: write the metadata BEFORE the readiness wait. Previously it was written
     # after, so a boot timeout raised with nothing on disk and `down` had no pids to kill.
     _meta_path(run).write_text(json.dumps(meta, indent=2) + "\n")
@@ -746,13 +761,16 @@ def down(run: str) -> int:
     # instance writes the domain on quit and cfprefsd caches it, so an earlier diff reads the wrong
     # state and an earlier restore is silently clobbered.
     time.sleep(2.0)
-    before = meta.get("plist_before") or {}
-    after = _plist_snapshot()
-    diff = _plist_diff(before, after)
+    before = meta.get("plist_before")
+    after = _plist_snapshot() if before is not None else None
+    snapshot_ok = before is not None and after is not None
+    diff = _plist_diff(before, after) if snapshot_ok else {}
     foreign = _player_pids() - set(pids.values())
     win = meta.get("win") or []
     rig_values = _rig_written_values(*win[:2]) if len(win) >= 2 else {}
-    report = _plist_restore(diff, foreign_alive=bool(foreign), rig_values=rig_values)
+    report = (_plist_restore(diff, foreign_alive=bool(foreign), rig_values=rig_values)
+              if snapshot_ok else {"restored": {}, "skipped": {},
+                                   "note": "shared plist snapshot unavailable — NOT restored"})
     report.update({"domain": PLIST_DOMAIN, "before": before, "after": after, "changed": diff,
                    "rig_values": rig_values, "foreign_player_pids": sorted(foreign)})
     (_rundir(run) / "prefs_leak.json").write_text(json.dumps(report, indent=2) + "\n")
@@ -768,6 +786,8 @@ def down(run: str) -> int:
                   f"{unrestored} — see {_rundir(run)/'prefs_leak.json'}")
         if report["note"]:
             print(f"[sandbox] {report['note']}", file=sys.stderr)
+    elif report["note"]:
+        print(f"[sandbox] {report['note']}", file=sys.stderr)
     else:
         print("[sandbox] shared plist clean — no non-churn key changed.")
 
@@ -781,7 +801,11 @@ def down(run: str) -> int:
     # the teardown ledger travels WITH the run metadata, not only in prefs_leak.json
     meta["stopped"] = {"plist": report, "orphans": stray["lines"], "leaks": leaks}
     mp.write_text(json.dumps(meta, indent=2) + "\n")
-    mp.rename(mp.with_suffix(".json.stopped"))
+    if leaks or foreign or not snapshot_ok:
+        print("[sandbox] cleanup INCOMPLETE — keeping sandbox.json; re-run `down --run <run>`",
+              file=sys.stderr)
+    else:
+        mp.rename(mp.with_suffix(".json.stopped"))
     print(f"[sandbox] DOWN — state/logs kept at {_rundir(run)} for evidence")
     return 1 if leaks else 0
 

--- a/qa/test_qa_sandbox_window.py
+++ b/qa/test_qa_sandbox_window.py
@@ -219,6 +219,11 @@ def test_plist_snapshot_is_whole_domain_minus_churn(monkeypatch):
     assert _writes(log) == [], "the snapshot is READ-ONLY"
 
 
+def test_plist_snapshot_failure_is_unknown(monkeypatch):
+    monkeypatch.setattr(qa_sandbox.subprocess, "run", lambda *args, **kwargs: _proc(rc=1))
+    assert qa_sandbox._plist_snapshot() is None
+
+
 def test_plist_diff_reports_added_removed_and_changed():
     before = {"a": "1", "gone": "2"}
     after = {"a": "3", "new": "9", "unity.player_session_count": "42"}
@@ -300,6 +305,50 @@ def test_restore_deletes_a_key_that_did_not_exist_before(monkeypatch):
     assert rep["restored"] == {"Screenmanager Resolution Use Native": None}
     assert _writes(log) == [["defaults", "delete", qa_sandbox.PLIST_DOMAIN,
                              "Screenmanager Resolution Use Native"]]
+
+
+def test_restore_does_not_claim_failed_defaults_operations(monkeypatch):
+    log: list = []
+
+    def failed_defaults(cmd, *args, **kwargs):
+        log.append(list(cmd))
+        return _proc(rc=7)
+
+    monkeypatch.setattr(qa_sandbox.subprocess, "run", failed_defaults)
+    diff = {
+        "Screenmanager Resolution Use Native": {"before": None, "after": "0"},
+        "Screenmanager Resolution Width": {"before": "3024", "after": "1280"},
+    }
+    rep = qa_sandbox._plist_restore(diff, foreign_alive=False,
+                                    rig_values=qa_sandbox._rig_written_values(1280, 700))
+    assert rep["restored"] == {}
+    assert set(rep["skipped"]) == set(diff)
+    assert all("failed (rc=7)" in why and "STILL in the domain" in why
+               for why in rep["skipped"].values())
+    assert len(_writes(log)) == 2
+
+
+def test_down_skips_restore_when_plist_snapshot_is_unavailable(monkeypatch, tmp_path):
+    monkeypatch.setattr(qa_sandbox, "ROOT", tmp_path)
+    rd = tmp_path / "r1"
+    rd.mkdir()
+    (rd / "sandbox.json").write_text(json.dumps({
+        "run": "r1", "win": [1280, 700], "pids": {}, "plist_before": None}))
+    monkeypatch.setattr(qa_sandbox, "_plist_snapshot",
+                        lambda: {"Screenmanager Resolution Width": "1280"})
+    monkeypatch.setattr(qa_sandbox, "_player_pids", lambda exe="WorldOSPlayer": set())
+    monkeypatch.setattr(qa_sandbox, "_orphan_report",
+                        lambda **kwargs: {"lines": [], "leaks": [], "port": 8972, "port_pids": []})
+    monkeypatch.setattr(qa_sandbox.time, "sleep", lambda *_: None)
+    log: list = []
+    _fake_defaults(monkeypatch, {}, log)
+
+    assert qa_sandbox.down("r1") == 0
+    assert _writes(log) == [], "an unavailable snapshot must never turn into a delete"
+    report = json.loads((rd / "prefs_leak.json").read_text())
+    assert "unavailable" in report["note"]
+    assert (rd / "sandbox.json").exists()
+    assert not (rd / "sandbox.json.stopped").exists()
 
 
 def test_restore_gating_foreign_player_and_opt_out(monkeypatch):
@@ -594,14 +643,98 @@ def test_down_reports_every_restore_and_skip_in_the_stopped_metadata(monkeypatch
 
     rc = qa_sandbox.down("r1")
     assert rc == 1, "a refused (pid-reused) kill is a leak, not a clean teardown"
-    stopped = json.loads((rd / "sandbox.json.stopped").read_text())["stopped"]
+    assert (rd / "sandbox.json").exists(), "failed teardown keeps metadata retryable"
+    assert not (rd / "sandbox.json.stopped").exists()
+    stopped = json.loads((rd / "sandbox.json").read_text())["stopped"]
     assert stopped["plist"]["restored"] == {"Screenmanager Fullscreen mode": "1"}
     assert set(stopped["plist"]["skipped"]) == {"Screenmanager Window Position Y", "SomeOwnerSetting"}
     assert any("pid reused" in leak for leak in stopped["leaks"])
     assert _writes(log) == [["defaults", "write", qa_sandbox.PLIST_DOMAIN,
                              "Screenmanager Fullscreen mode", "-int", "1"]]
-    out = capsys.readouterr().out
+    captured = capsys.readouterr()
+    out = captured.out
     assert "RESTORED" in out and "LEFT AS-IS" in out and "NOT restored" in out
+    assert "cleanup INCOMPLETE" in captured.err
+
+
+def test_caffeinate_failure_keeps_sandbox_launchable(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(qa_sandbox, "ROOT", tmp_path)
+    monkeypatch.setattr(qa_sandbox, "owner_active_guard", lambda: None)
+    monkeypatch.setattr(qa_sandbox, "_player_windowed_args", lambda *_: [
+        "-screen-fullscreen", "0", "-screen-width", "1280", "-screen-height", "700"])
+    monkeypatch.setattr(qa_sandbox, "_plist_snapshot", lambda: {})
+    monkeypatch.setattr(LQW, "front_app", lambda: None)
+    monkeypatch.setattr(LQW, "wait_for_window", lambda *args, **kwargs: True)
+    monkeypatch.setattr(LQW, "restore_front", lambda *args: False)
+    monkeypatch.setattr(qa_sandbox, "_qa_roots_in_app", lambda app: set())
+    monkeypatch.setattr(qa_sandbox, "_wait", lambda *args, **kwargs: True)
+    monkeypatch.setattr(qa_sandbox, "_assert_windowed", lambda *args, **kwargs: (1280, 700))
+    app = tmp_path / "WorldOSPlayer.app" / "Contents" / "MacOS"
+    app.mkdir(parents=True)
+    (app / "WorldOSPlayer").write_text("")
+    calls: list = []
+
+    class Proc:
+        def __init__(self, pid):
+            self.pid = pid
+
+    def fake_popen(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        if cmd[0] == "/usr/bin/caffeinate":
+            raise OSError("caffeinate unavailable")
+        return Proc(100 if "server.py" in str(cmd) else 200)
+
+    monkeypatch.setattr(qa_sandbox.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(qa_sandbox.subprocess, "run", lambda *args, **kwargs: _proc())
+    monkeypatch.setattr(qa_sandbox.os, "getpgid", lambda pid: pid)
+    meta = qa_sandbox.up("r1", campaign="room", engine_port=8866, qa_port=8972,
+                         seed_cmd="seed {state}", app=app.parent.parent)
+    assert meta["caffeinate_pid"] is None
+    assert len(calls) == 3
+    assert "caffeinate unavailable" in capsys.readouterr().err
+
+
+def test_owner_guard_rechecked_before_player_spawn(monkeypatch, tmp_path):
+    monkeypatch.setattr(qa_sandbox, "ROOT", tmp_path)
+    calls = {"guard": 0, "popen": [], "killed": []}
+
+    def guard():
+        calls["guard"] += 1
+        if calls["guard"] == 2:
+            raise SystemExit(qa_sandbox.OWNER_ACTIVE_RC)
+
+    monkeypatch.setattr(qa_sandbox, "owner_active_guard", guard)
+    monkeypatch.setattr(qa_sandbox, "_player_windowed_args", lambda *_: [
+        "-screen-fullscreen", "0", "-screen-width", "1280", "-screen-height", "700"])
+    monkeypatch.setattr(qa_sandbox, "_plist_snapshot", lambda: {})
+    monkeypatch.setattr(LQW, "front_app", lambda: None)
+    monkeypatch.setattr(qa_sandbox, "_qa_roots_in_app", lambda app: set())
+    monkeypatch.setattr(qa_sandbox, "_wait", lambda *args, **kwargs: True)
+    app = tmp_path / "WorldOSPlayer.app" / "Contents" / "MacOS"
+    app.mkdir(parents=True)
+    (app / "WorldOSPlayer").write_text("")
+
+    class Proc:
+        def __init__(self, pid):
+            self.pid = pid
+
+    def fake_popen(cmd, *args, **kwargs):
+        calls["popen"].append(list(cmd))
+        return Proc(100)
+
+    monkeypatch.setattr(qa_sandbox.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(qa_sandbox.subprocess, "run", lambda *args, **kwargs: _proc())
+    monkeypatch.setattr(qa_sandbox.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(qa_sandbox, "_kill_group",
+                        lambda pid, label="", expect_pgid=None:
+                        calls["killed"].append((pid, label, expect_pgid)) or "")
+    with pytest.raises(SystemExit) as ei:
+        qa_sandbox.up("r1", campaign="room", engine_port=8866, qa_port=8972,
+                      seed_cmd="seed {state}", app=app.parent.parent)
+    assert ei.value.code == qa_sandbox.OWNER_ACTIVE_RC
+    assert calls["guard"] == 2
+    assert len(calls["popen"]) == 1, "the second owner check must precede player/caffeinate Popen"
+    assert calls["killed"] == [(100, "engine", 100)]
 
 
 # ── Phase 2 (C# badge) — RED until the Editor rebuild lands ───────────────────────────────────────

--- a/qa/test_walk_test.py
+++ b/qa/test_walk_test.py
@@ -248,6 +248,34 @@ def test_classify_verdict_orphans_and_visual_are_walkability():
     assert W.classify_verdict(_base_report(visual={"fail": 1})) == ("RED", 1)
 
 
+def test_run_gate_visual_preflight_error_is_harness_error(monkeypatch, tmp_path):
+    """A capture/preflight fault is ERROR/2, not a vacuous visual RED/1."""
+    monkeypatch.setattr(W, "_room_ortho", lambda room: 1.0)
+    monkeypatch.setattr(W, "_get", lambda url: {"grid": {"sceneId": "room"},
+                                                 "tokens": [{"x": 0, "y": 0}],
+                                                 "doors": []})
+    monkeypatch.setattr(W, "_post", lambda *args, **kwargs: {})
+    monkeypatch.setattr(W, "walkmask_from_surface", lambda surf: {
+        "cols": 3, "rows": 3, "walkable": [(1, 1)], "doors": [], "blocked": []})
+    monkeypatch.setattr(W, "check_camera_pose", lambda *args: [])
+    monkeypatch.setattr(W, "classify_camera_fails", lambda *args: ([], []))
+    monkeypatch.setattr(W, "orphan_cells", lambda *args: [])
+    monkeypatch.setattr(W, "bfs_reachable", lambda *args: {(1, 1)})
+    monkeypatch.setattr(W, "_sample", lambda *args: [])
+    monkeypatch.setattr(W, "_load_room_geometry", lambda room: {})
+    monkeypatch.setattr(W, "fire_anchor_cells", lambda *args: set())
+    monkeypatch.setattr(W, "select_visual_cells", lambda *args: [(1, 1)])
+    monkeypatch.setattr(W, "_visual_registration", lambda *args, **kwargs: {
+        "pass": 0, "fail": 0, "cases": [], "error": "capture preflight failed"})
+    monkeypatch.setattr(W, "_capture_shot", lambda *args, **kwargs: None)
+    monkeypatch.setattr(W, "_drive_and_check", lambda *args, **kwargs: (True, (0, 0), {}))
+    report = W.run_gate("room", "http://engine", "http://qa", stride=1,
+                        out=tmp_path, settle=0, move_timeout=0, visual=1)
+    assert report["visual"]["fail"] == 0
+    assert report["verdict"] == "ERROR"
+    assert report["harness_errors"] == ["visual: capture preflight failed"]
+
+
 def test_is_drive_error_only_matches_the_sentinel():
     """A drive-error string is harness; a settled cell list or a plain None (timeout) is not."""
     assert W.is_drive_error("drive-error:HTTPError") is True

--- a/qa/walk_test.py
+++ b/qa/walk_test.py
@@ -835,8 +835,12 @@ def run_gate(room: str, engine: str, qa: str, *, stride: int, out: Path,
                                                 settle, move_timeout, fire_cells=fire_cells)
         # a requested visual gate that measured NOTHING must fail loud, never read as a vacuous GREEN
         if not report["visual"]["cases"]:
-            report["visual"]["fail"] += 1
-            report["visual"]["error"] = "visual registration requested but produced no measurable cases"
+            err = report["visual"].get("error")
+            if err:  # preflight/harness fault, not a room verdict
+                report["harness_errors"].append(f"visual: {err}")
+            else:
+                report["visual"]["fail"] += 1
+                report["visual"]["error"] = "visual registration requested but produced no measurable cases"
 
     # 6) OCCLUSION evidence — a /shot near an occluder for the human contact sheet (non-gating here).
     shot = _capture_shot(qa, out, f"{room}_final")


### PR DESCRIPTION
## Summary
Follow-up for PR #1717's post-merge review: make sandbox teardown and walk-gate error handling fail closed while preserving retryability and owner settings.

## Linked Issue
Post-merge follow-up for PR #1717; the orchestrator owns replies/resolution on the original threads.

## Changes
- T2: classify visual capture/preflight errors as harness `ERROR`, not room `RED`.
- T3: retain `sandbox.json` when teardown has leaks or a foreign player, so `down` remains retryable.
- T4: tolerate unavailable `caffeinate` and record a nullable watcher PID.
- T5: distinguish failed shared-plist snapshots from an empty domain; refuse launch and skip restore when unavailable.
- T6: check `defaults` delete/write return codes and report failed restores as skipped.
- T7: re-check owner activity immediately before player spawn and unwind the engine on refusal.

## Thread dispositions (source: DISPOSITION.md)
- `PRRT_kwDOSlB5c86eaRSd` → FIXED NOW (T2; RELEASE_BLOCKING)
- `PRRT_kwDOSlB5c86eaRSi` → FIXED NOW (T3; RELEASE_BLOCKING)
- `PRRT_kwDOSlB5c86eaRSn` → FIXED NOW (T4; NON_BLOCKING)
- `PRRT_kwDOSlB5c86eaRSt` → FIXED NOW (T5; RELEASE_BLOCKING)
- `PRRT_kwDOSlB5c86eaRS0` → FIXED NOW (T6; NON_BLOCKING)
- `PRRT_kwDOSlB5c86eaRS-` → FIXED NOW (T7; NON_BLOCKING)

T1, T8, and T9 are intentionally out of scope; no original #1717 threads are being replied to or resolved here.

## Licensing / CLA
- [x] I have read `CLA.md` and submit this contribution under the WorldOS Contributor License Agreement.
- [x] I have not included confidential information, private customer data, private imported content, or third-party-restricted material.
- [x] Any third-party material in this PR is clearly identified with source and license.

## Review Thread State
- Current-head unresolved review threads: none at creation; original #1717 threads remain orchestrator-owned.
- P0-P2 blocker count: 0 in this follow-up.
- P3/advisory count: 0 known.
- Top-level bot comments requiring action: none known.
- Check annotations requiring action: none known.
- Bot rerun status: pending PR creation.

## Validation
- `uv run --directory servers/engine python -m pytest /Users/m1/worldos-wt-rigfix/qa/test_qa_sandbox_window.py /Users/m1/worldos-wt-rigfix/qa/test_walk_test.py -q -p no:xdist` — 101 passed, 1 xfailed.
- `bash qa/fast_gate.sh` — 257 passed.
- `git diff --check HEAD^..HEAD` — passed.

## Release / WorldOS Proof Tier
- [x] Local or fast smoke only
- [ ] Release proof
- [ ] Runtime/customer proof
- [ ] WorldOS RRI/persona proof required

## Release Notes / Changelog
- Release-note impact: no product/runtime behavior change; QA harness safety only.
- Verification/evidence tail needed? no.

## Safety / Rollback
No live sandbox run or production/runtime mutation was performed. Revert this single follow-up commit to restore the prior harness behavior.

## Evidence
- Disposition ledger: `/Users/m1/Codex/session-notes/2026-09-02/worldos-refresh/artifacts/rig/threads/DISPOSITION.md` (local source of truth).
- Claim class: `unit-tested-fix` — proves the six behaviors under unit tests; does not prove a live sandbox run.

## Notes For Next Agent
- Exact candidate head: `ec6533f850b0242f0d275ec4e1aa378d6d86b1c0`.
- Merge method requested: `--auto --squash` (never `--admin`).
