### PR TITLE
deps: pin mcp<2 in servers/{rules,engine,voice} (2.x removes fastmcp; migration tracked)

### DIFF
--- a/servers/engine/pyproject.toml
+++ b/servers/engine/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "WorldOS game-engine MCP: authoritative D&D 5e state, dice, combat, encounters, XP, persistence."
 requires-python = ">=3.11,<3.13"
 dependencies = [
-  "mcp>=1.28.1",
+  "mcp>=1.28.1,<2",
   "pydantic>=2.6",
 ]
 

--- a/servers/engine/uv.lock
+++ b/servers/engine/uv.lock
@@ -780,7 +780,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "pydantic", specifier = ">=2.6" },
 ]
 

--- a/servers/rules/pyproject.toml
+++ b/servers/rules/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "WorldOS rules MCP: D&D 5e SRD lookup (spells, monsters, conditions, rules) with fuzzy matching."
 requires-python = ">=3.11,<3.13"
 dependencies = [
-  "mcp>=1.28.1",
+  "mcp>=1.28.1,<2",
   "httpx>=0.27",
   "rapidfuzz>=3.6",
 ]

--- a/servers/rules/uv.lock
+++ b/servers/rules/uv.lock
@@ -717,7 +717,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "rapidfuzz", specifier = ">=3.6" },
 ]
 

--- a/servers/voice/pyproject.toml
+++ b/servers/voice/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "WorldOS voice MCP: swappable text-to-speech (Kokoro local default; ElevenLabs optional)."
 requires-python = ">=3.11,<3.13"
 dependencies = [
-  "mcp>=1.28.1",
+  "mcp>=1.28.1,<2",
 ]
 
 [dependency-groups]

--- a/servers/voice/uv.lock
+++ b/servers/voice/uv.lock
@@ -2027,7 +2027,7 @@ kokoro = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mcp", specifier = ">=1.28.1" }]
+requires-dist = [{ name = "mcp", specifier = ">=1.28.1,<2" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Problem

All three server pyprojects declared `mcp>=1.28.1` **unbounded**:

- `servers/rules/pyproject.toml`
- `servers/engine/pyproject.toml`
- `servers/voice/pyproject.toml`

mcp 2.x turns `mcp.server.fastmcp` into a **raising stub**. Every one of these servers imports `FastMCP` from that module, so any fresh resolve that picks up 2.x is a hard break. The committed `uv.lock`s were the only thing holding the line — the declared constraint permitted the break.

## Change

Constraint is now `mcp>=1.28.1,<2` in all three, with each `uv.lock` regenerated via `uv lock`.

Each lock moved **exactly one line** (the `requires-dist` specifier). `mcp` still resolves to **1.28.1** in all three, and no other package moved:

```
 servers/engine/pyproject.toml | 2 +-
 servers/engine/uv.lock        | 2 +-
 servers/rules/pyproject.toml  | 2 +-
 servers/rules/uv.lock         | 2 +-
 servers/voice/pyproject.toml  | 2 +-
 servers/voice/uv.lock         | 2 +-
```

## Scope

This is **only the guardrail**. The actual 2.x port — fastmcp stub → `MCPServer`, 4 import sites, 184 `@mcp.tool` decorators, the viewer `sys.modules` shim — is tracked in #1728 and is not attempted here.

## Verification (local, exit 0 on every command)

Collection, run bare per server:

| server | `pytest --collect-only -q -p no:xdist` | exit |
|---|---|---|
| rules | 16 tests collected | 0 |
| engine | 3553 tests collected | 0 |
| voice | 17 tests collected | 0 |

Full CI suites as documented in `.github/workflows/ci.yml` (`uv run --directory servers/<name> --group dev pytest -q --cov=. --cov-report=term-missing`):

| server | result | exit |
|---|---|---|
| engine | 3553 passed in 77s | 0 |
| rules | 16 passed | 0 |
| voice | 17 passed | 0 |

Refs #1728