### PR TITLE
docs: G3 route-incomplete wording, packaged_pins --repo path, §9 finish line scoped per gate (post-merge threads of #1724/#1725)

### DIFF
--- a/docs/ACTIVE-GOAL.md
+++ b/docs/ACTIVE-GOAL.md
@@ -11,7 +11,7 @@
 **Execute PRODUCT-ROADMAP.md's sprints in charter order.** The only finish lines are:
 
 1. **Owner check-in** — a new message from the owner is always a stop-and-respond point.
-2. **DEMO COMPLETION (PRODUCT-ROADMAP §9) — all four gates G1-G4 measured green on an owner-installed build** (the governing milestone since 2026-07-22; charter #1702 as of 2026-09-02), then the first TOWN world (Track C, epic #1640). GA v1.1.0 (milestone #36) remains the Act I terminus AFTER that — not a finish line for the current run.
+2. **DEMO COMPLETION (PRODUCT-ROADMAP §9) — all four gates green as §9 defines them: G1 certified gates on the OWNER-INSTALLED build with build identity, G2 the N≥3 blind-adjudicated text arc, G3 the walked full route in the sandbox player, G4 the owner playthrough** (the governing milestone since 2026-07-22; charter #1702 as of 2026-09-02), then the first TOWN world (Track C, epic #1640). GA v1.1.0 (milestone #36) remains the Act I terminus AFTER that — not a finish line for the current run.
 3. **A VERIFIED blocker on ALL parallel lanes simultaneously** — see Blocker Law below.
 
 **Nothing else is "done."** Completing a task list, finishing a PR batch, closing a sprint,

--- a/docs/ROOM-PIPELINE-RUNBOOK.md
+++ b/docs/ROOM-PIPELINE-RUNBOOK.md
@@ -603,7 +603,7 @@ PY="uv run --directory $WOS/servers/engine python"                # relative qa/
 # 0. build identity (the "build sha" in SCORECARD rows = the player BINARY sha256 prefix; unity repo head + engine main are recorded beside it)
 shasum -a 256 "$APP/Contents/MacOS/WorldOSPlayer" | cut -c1-8; git -C /Users/m1/worldos-unity rev-parse --short HEAD; git -C $WOS rev-parse --short main
 strings "$(find "$APP/Contents/Resources/Data" -name level0 | head -1)" | grep -c KitRoom_   # must be 0 (contamination gate)
-$PY $WOS/qa/packaged_pins.py "$APP" --repo                          # packaged plate/boxes/manifest per room == repo → GREEN required
+$PY $WOS/qa/packaged_pins.py "$APP" --repo "$WOS"                   # packaged plate/boxes/manifest per room == repo root → GREEN required
 # 1. the registered-world fixture (party seeded IN the crypt; no monsters) — the kit rooms live only here
 $PY $WOS/qa/qa_sandbox.py up --run g1 --campaign registered_world_v1 --app "$APP" \
   --seed-cmd "uv run --directory $WOS/servers/engine python $WOS/qa/seed_gfx_registered_world.py {state}"

--- a/docs/roadmap/NOW.md
+++ b/docs/roadmap/NOW.md
@@ -26,8 +26,9 @@ LOCALLY on `/Users/m1/worldos-unity` (Stdio MCP bridge:
   exists · **G2 FAIL 0/3** at the 15-beat budget (root cause: the `opus` alias now resolves to
   Opus 5, which invents extra fights and overruns a knife-edge budget; the July DM model completes
   at beat 19 under 20) → ruler raised to **20 beats** (#1722, predeclared) and the N=3 re-run at 20
-  is in flight · **G3 NAV-GREEN / VQA-ERROR** (6/6 stages arrived; scorer credential now fixed,
-  re-run pending) · **G4 PENDING** (owner install kit in flight; local ad-hoc-signed build).
+  is in flight · **G3 ROUTE-INCOMPLETE** (the 6 walked stages camp→snug→camp→crypt→throne→camp all ARRIVED, but the
+  binding §9 route also needs the return-for-reward leg back to Keeper Maera — not walked, #1709; VQA scorer
+  credential now fixed, full-route re-run pending) · **G4 PENDING** (owner install kit in flight; local ad-hoc-signed build).
 - **Shipping surface = the 3D-first KIT chain** (crypt kit v1 / tavern kit v2 plates, kit-derived
   sidecars, per-object gate #1703, build contamination gate #1705). Paint-first generation is
   RETIRED for new rooms; legacy rooms (throne/shop/snug/camp) carry the registration debt G1 measures.
@@ -61,7 +62,7 @@ service (Rodin Business), the camp-hub art fork (taste — post frames first).
 - **Port 8766 is the claude-max bridge**, not WorldOS: owner engine 8776 / QA 8981; sandbox
   8866 / 8972; every tool still defaults to 8766/8971 → always pass ports.
 - `BuildMacOSPlayer.EnsurePackaged` sources the Unity project ROOT (not StreamingAssets) →
-  sync data there before a build and run `qa/packaged_pins.py <app> --repo` after.
+  sync data there before a build and run `qa/packaged_pins.py <app> --repo /Users/m1/WorldOS` after (`--repo` takes the repo root).
 - `qa/adventure_eval.py --runs` needs ABSOLUTE prefixes (relative ones aggregate nothing — #1709).
 - Never launch the player outside `qa/qa_sandbox.py` (windowed contract) with the Editor open; one
   heavy Unity process at a time.


### PR DESCRIPTION
Three valid post-merge findings folded: (1) NOW.md's G3 row now says ROUTE-INCOMPLETE — the six walked stages arrived but the binding §9 route includes the return-for-reward leg to Keeper Maera, which is not walked (#1709); (2) `qa/packaged_pins.py --repo` takes the repo root — NOW.md and the G1 gate recipe (#1726) wrote it bare, so the documented command could not run; (3) ACTIVE-GOAL's finish line over-claimed 'all four gates on an owner-installed build' — scoped per §9 (G1 installed build, G2 text arc, G3 sandbox walked route, G4 owner). Charter #1702. Claim class: `docs-registration`.