### PR TITLE
client: close the parley panel on location change (#1522) + /debug parleyOpen

### DIFF
--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -743,6 +743,10 @@ public class CombatSurfaceClient : MonoBehaviour
                 _locId = (loc["id"] as string) ?? _locId;
         }
         catch (System.Exception e) { Debug.LogWarning("[CSC] surface-extras parse: " + e.Message); }
+        // #1522: `location.id` has just been refreshed above — this is the one seam BOTH surface consumers
+        // cross (ApplyJson's poll and Post's /move re-render), so the parley dismissal hangs here rather
+        // than on the plate swap (which no-ops when the manifest has no entry for the destination room).
+        MaybeCloseParleyOnLocationChange();
     }
 
     // W6.1 (#1460): a cheap order-preserving fingerprint of the occluder set + its location, so
@@ -2661,7 +2665,11 @@ public class CombatSurfaceClient : MonoBehaviour
                     sb.Append("{\"ok\":true,\"enq\":").Append(_dbgEnq).Append(",\"deq\":").Append(_dbgDeq)
                       .Append(",\"acted\":").Append(_dbgActed).Append(",\"surf\":").Append(_dbgSurf)
                       .Append(",\"busy\":").Append(_busy ? "true" : "false")
-                      .Append(",\"last\":\"").Append(_dbgLast).Append("\"");
+                      .Append(",\"last\":\"").Append(_dbgLast).Append("\"")
+                      // #1522: parley panel open/closed, so the journey gate can assert the panel is
+                      // dismissed after a cross_door without reading pixels. Unconditional (outside the
+                      // camera-pose block) — an absent field means an OLD build, never "closed".
+                      .Append(",\"parleyOpen\":").Append(_parleyOpen ? "true" : "false");
                     if (_dbgCamValid)  // #1583: camera pose for qa/walk_test.py (omitted on an old build)
                     {
                         var ic = System.Globalization.CultureInfo.InvariantCulture;
@@ -2899,7 +2907,11 @@ public class CombatSurfaceClient : MonoBehaviour
     // /move `say` lane the browser dialogue uses. Pure consumer; scrolling text + one input, parchment-
     // styled to match the onboarding HUD. Closed with Esc or the Leave button.
     string _parleyNpc = "";
-    bool _parleyOpen = false;
+    // #1522: volatile — the off-thread QA /debug responder reads this flag to report `parleyOpen`.
+    volatile bool _parleyOpen = false;
+    // #1522: the location.id the panel was opened in. The parley binds to an NPC in ONE room, so a
+    // surface whose location.id no longer matches this latch dismisses the panel (MaybeCloseParleyOnLocationChange).
+    string _parleyLocId = "";
     string _parleyHeader = "";
     string _parleyBody = "";
     string _parleyReply = "";
@@ -2911,6 +2923,7 @@ public class CombatSurfaceClient : MonoBehaviour
     {
         _parleyNpc = npcId;
         _parleyOpen = true;
+        _parleyLocId = _locId;   // #1522: the room this panel belongs to; a location change closes it
         _parleyReply = "";
         _parleyScroll = Vector2.zero;
         // Speaker name from the surface's name cache (populated in ApplySurf); the fetch enriches the header.
@@ -2919,7 +2932,31 @@ public class CombatSurfaceClient : MonoBehaviour
         StartCoroutine(LoadParleySurface(npcId));
     }
 
-    void CloseParley() { _parleyOpen = false; _parleyNpc = ""; }
+    // The ONE close path (Esc, the Leave button, and the #1522 location-change dismissal all land here).
+    // #1522: clears the bound NPC, the room latch, the fetched header/body and the pending reply, so a
+    // reopened panel never shows a previous conversation's text. Idempotent — safe to call when closed.
+    void CloseParley()
+    {
+        _parleyOpen = false; _parleyNpc = ""; _parleyLocId = "";
+        _parleyHeader = ""; _parleyBody = ""; _parleyReply = ""; _parleyScroll = Vector2.zero;
+    }
+
+    // #1522: the parley panel is CLIENT-ONLY state (the engine has no parley state — only
+    // generate_parley_options), so nothing else dismisses it when the party leaves the NPC's room. Every
+    // surface parse (the poll AND the /move re-render that follows a cross_door) checks the freshly parsed
+    // location.id against the latch OpenParley took, and closes through the SAME CloseParley path the Leave
+    // button uses — no second close path to drift. Idempotent: CloseParley clears the flag, so the next
+    // poll's check is a no-op. An EMPTY latch (the panel opened before any surface carried a location
+    // block) ADOPTS the first id seen rather than closing on it.
+    void MaybeCloseParleyOnLocationChange()
+    {
+        if (!_parleyOpen || string.IsNullOrEmpty(_locId)) return;
+        if (string.IsNullOrEmpty(_parleyLocId)) { _parleyLocId = _locId; return; }
+        if (_parleyLocId == _locId) return;
+        string npc = _parleyNpc, from = _parleyLocId;
+        CloseParley();
+        Debug.Log("[CSC] parley closed on location change (" + from + " -> " + _locId + ", npc=" + npc + ")");
+    }
 
     // Fetch GET /parley-surface?npc=<id> and read a display header + any prompt defensively (the parley
     // surface is a skill/DC menu, not a chat log — so this reads a name/header if present and otherwise
@@ -2931,6 +2968,9 @@ public class CombatSurfaceClient : MonoBehaviour
         {
             req.timeout = 8;
             yield return req.SendWebRequest();
+            // #1522: the panel may have been dismissed mid-flight (a cross_door location change) — a stale
+            // response must not repopulate the state CloseParley cleared.
+            if (!_parleyOpen || _parleyNpc != npcId) yield break;
             if (!Ok(req)) { _parleyBody = "You approach " + _parleyHeader + "."; yield break; }
             try
             {
@@ -2963,6 +3003,7 @@ public class CombatSurfaceClient : MonoBehaviour
         _busy = true;
         yield return PostSimple("{\"kind\":\"say\",\"text\":\"" + JsonEsc(text) + "\",\"campaign\":\"" + CampaignId + "\"}", "say");
         _busy = false;
+        if (!_parleyOpen) yield break;   // #1522: closed mid-flight (a location change) — leave it cleared
         _parleyReply = "";
         _parleyBody = "You said: “" + text + "”";
     }


### PR DESCRIPTION
Closes #1522.

## Root cause
The parley panel is **client-only** state — the engine has no parley state at all (only `generate_parley_options`) — and nothing dismissed it when a `cross_door` relocated the party. `CombatSurfaceClient` closed the panel on exactly two triggers (Esc, the Leave button); the plate swap / occluder rebuild / camera re-fit path never touched it, so the panel survived the room swap and hung over the destination scene. That is the demo's **first beat** (talk to Keeper Maera in `tavern_snug`, then walk to the crypt).

## Fix
- `ParseSurfaceExtras` is the one seam **both** surface consumers cross (`ApplyJson`'s poll and `Post`'s `/move` re-render) and is where `location.id` is refreshed — the dismissal hangs there rather than on the plate swap, which no-ops when the manifest has no entry for the destination room.
- `OpenParley` latches the room (`_parleyLocId`); a surface whose `location.id` no longer matches closes the panel through the **same `CloseParley` path the Leave button uses** — no second close path to drift. Idempotent (the flag is cleared, so the next poll no-ops); an empty latch adopts the first id seen rather than closing on it. One `Debug.Log` line per close.
- `CloseParley` now clears the whole panel state: bound NPC, room latch, header, body, pending reply, scroll.
- The two in-flight coroutines (`LoadParleySurface`, `SpeakParley`) bail instead of repopulating a panel that was closed under them.
- QA: `GET /debug` gains an additive top-level **`parleyOpen`** bool, outside the camera-pose block, so an absent field means an OLD build — never "closed".

Diff: **1 file, +44 / -3**. Engine untouched (engine stays sole writer).

## Verification

**1. COMPILE — GREEN.** Deployed to `/Users/m1/worldos-unity/Assets/CombatSurfaceClient.cs`, Editor opened headed+windowed, `refresh_unity` then `read_console {types:["error"]}` → **0 errors**.

**2. BUILD + PIXELS — GREEN.** `Tools/WorldOS/Build/macOS Player (Universal)` → `result=Succeeded`, `totalErrors=0`, `StandaloneOSX x64ARM64`. `strings .../Data/level0 | grep -c KitRoom_` = **0**. `qa/packaged_pins.py` → **PINS GREEN (0 drift)** (8 rooms + effects registry). Player binary sha256 `bf890b43`; unity repo head `c90a5967`.

Windowed sandbox on the adventure fixture (`qa_sandbox.py up --run p1522 --campaign adventure_demo_v1`, engine :8866 / QA :8972), party seeded at `camp_clearing`:

| step | `/debug parleyOpen` | location |
|---|---|---|
| start | `false` | `camp_clearing` |
| cross door `[8,0]` → tavern | `false` | `tavern_snug` |
| click Keeper Maera's cell `(5,3)` (the viewer `parley_approach` path) | **`true`** | `tavern_snug` |
| click door cell `[5,0]` (`cross_door`) | **`false`** | `camp_clearing` |

Player log: `[CSC] parley closed on location change (tavern_snug -> camp_clearing, npc=char_dff00674064b)`

Frames (eyeballed):
- **A** `session-notes/2026-09-02/worldos-refresh/artifacts/fix-1522/frameA_parley_open_tavern_snug.png` — tavern snug plate, parchment panel bottom-right: "Keeper Maera / You approach Keeper Maera (neutral). What do you say?", reply field + Speak/Leave.
- **B** `session-notes/2026-09-02/worldos-refresh/artifacts/fix-1522/frameB_after_cross_door_camp.png` — camp clearing plate, firepit, "To Tavern Snug" / "To Crypt" door labels, **no panel anywhere in frame**.

**3. UNIT — NOT ADDED.** There is no C# test harness for the WorldOS client scripts (`grep -rn '\[Test\]|\[UnityTest\]'` over `extensions/renderers/unity/` → 0 hits; the only `.asmdef`s under `worldos-unity/Assets` belong to third-party packages). No harness was invented; the `/debug parleyOpen` field is the machine-readable assertion the journey gate can use instead.

## Claim class
`pixel-verified-on-sandbox-build` — proves the panel closes on a door crossing in the sandbox player built from this branch. Does **not** prove the owner-installed app, and the pre-fix binary was not rebuilt to re-reproduce the bug (the negative case rests on the recorded #1522 evidence + the absence of any `CloseParley` caller on the location-change path before this commit).
