### PR TITLE
qa_sandbox: teardown keeps meta only with work left + non-zero rc; refuse an empty snapshot of an existing plist (review of #1729)

### DIFF
--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -523,7 +523,7 @@ took over the developer's only display and the Mac had to be rebooted. Now:
   if it changed AND still holds the exact value this rig writes (`Fullscreen mode`=3, the requested
   `Resolution Width/Height`, `Use Native`=0). The cosmetic `Window Position X/Y`, anything the owner
   wrote last, and any non-integer value are REPORTED and left alone. See `<rundir>/prefs_leak.json`
-  and the `stopped` block in `sandbox.json.stopped`.
+  and the `stopped` block in `sandbox.json.stopped` (or `sandbox.json` if cleanup is incomplete).
 - **Telling them apart today:** window geometry, `lsof -nP -iTCP:8972 -sTCP:LISTEN -t` (owner = 8971),
   and `sandbox.json`. The rig's window TITLE is still `WorldOSPlayer` — the badge is Phase 2,
   `docs/qa/QA-RIG-WINDOW-BADGE.md`.

--- a/qa/qa_sandbox.py
+++ b/qa/qa_sandbox.py
@@ -219,6 +219,8 @@ def _plist_snapshot() -> dict | None:
         return None
     if not isinstance(data, dict):
         return None
+    if not data and (Path.home() / "Library/Preferences" / f"{PLIST_DOMAIN}.plist").exists():
+        return None
     return {str(k): str(v) for k, v in sorted(data.items()) if not _is_churn(str(k))}
 
 
@@ -762,15 +764,21 @@ def down(run: str) -> int:
     # state and an earlier restore is silently clobbered.
     time.sleep(2.0)
     before = meta.get("plist_before")
-    after = _plist_snapshot() if before is not None else None
-    snapshot_ok = before is not None and after is not None
-    diff = _plist_diff(before, after) if snapshot_ok else {}
+    legacy_meta = before is None
+    after = None if legacy_meta else _plist_snapshot()
+    snapshot_ok = legacy_meta or after is not None
+    diff = _plist_diff(before, after) if snapshot_ok and not legacy_meta else {}
     foreign = _player_pids() - set(pids.values())
     win = meta.get("win") or []
     rig_values = _rig_written_values(*win[:2]) if len(win) >= 2 else {}
-    report = (_plist_restore(diff, foreign_alive=bool(foreign), rig_values=rig_values)
-              if snapshot_ok else {"restored": {}, "skipped": {},
-                                   "note": "shared plist snapshot unavailable — NOT restored"})
+    if legacy_meta:
+        report = {"restored": {}, "skipped": {},
+                  "note": "legacy metadata has no plist_before — nothing to restore"}
+    elif snapshot_ok:
+        report = _plist_restore(diff, foreign_alive=bool(foreign), rig_values=rig_values)
+    else:
+        report = {"restored": {}, "skipped": {},
+                  "note": "shared plist snapshot unavailable — NOT restored"}
     report.update({"domain": PLIST_DOMAIN, "before": before, "after": after, "changed": diff,
                    "rig_values": rig_values, "foreign_player_pids": sorted(foreign)})
     (_rundir(run) / "prefs_leak.json").write_text(json.dumps(report, indent=2) + "\n")
@@ -801,13 +809,15 @@ def down(run: str) -> int:
     # the teardown ledger travels WITH the run metadata, not only in prefs_leak.json
     meta["stopped"] = {"plist": report, "orphans": stray["lines"], "leaks": leaks}
     mp.write_text(json.dumps(meta, indent=2) + "\n")
-    if leaks or foreign or not snapshot_ok:
-        print("[sandbox] cleanup INCOMPLETE — keeping sandbox.json; re-run `down --run <run>`",
+    keep_meta = bool(leaks or not snapshot_ok or (foreign and diff))
+    if keep_meta:
+        print(f"[sandbox] cleanup INCOMPLETE ({len(leaks)} leak(s), foreign {sorted(foreign)}, "
+              f"snapshot_ok={snapshot_ok}) — keeping {mp}; re-run `down --run {run}`",
               file=sys.stderr)
     else:
         mp.rename(mp.with_suffix(".json.stopped"))
     print(f"[sandbox] DOWN — state/logs kept at {_rundir(run)} for evidence")
-    return 1 if leaks else 0
+    return 1 if keep_meta else 0
 
 
 def _listeners(port: int) -> set:

--- a/qa/test_qa_sandbox_window.py
+++ b/qa/test_qa_sandbox_window.py
@@ -224,6 +224,16 @@ def test_plist_snapshot_failure_is_unknown(monkeypatch):
     assert qa_sandbox._plist_snapshot() is None
 
 
+def test_plist_snapshot_empty_export_of_existing_domain_is_unreadable(monkeypatch, tmp_path):
+    prefs = tmp_path / "Library" / "Preferences"
+    prefs.mkdir(parents=True)
+    (prefs / f"{qa_sandbox.PLIST_DOMAIN}.plist").write_bytes(plistlib.dumps({"stale": 1}))
+    monkeypatch.setattr(qa_sandbox.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(qa_sandbox.subprocess, "run",
+                        lambda *args, **kwargs: _proc(stdout=plistlib.dumps({})))
+    assert qa_sandbox._plist_snapshot() is None
+
+
 def test_plist_diff_reports_added_removed_and_changed():
     before = {"a": "1", "gone": "2"}
     after = {"a": "3", "new": "9", "unity.player_session_count": "42"}
@@ -333,9 +343,9 @@ def test_down_skips_restore_when_plist_snapshot_is_unavailable(monkeypatch, tmp_
     rd = tmp_path / "r1"
     rd.mkdir()
     (rd / "sandbox.json").write_text(json.dumps({
-        "run": "r1", "win": [1280, 700], "pids": {}, "plist_before": None}))
-    monkeypatch.setattr(qa_sandbox, "_plist_snapshot",
-                        lambda: {"Screenmanager Resolution Width": "1280"})
+        "run": "r1", "win": [1280, 700], "pids": {},
+        "plist_before": {"Screenmanager Resolution Width": "3024"}}))
+    monkeypatch.setattr(qa_sandbox, "_plist_snapshot", lambda: None)
     monkeypatch.setattr(qa_sandbox, "_player_pids", lambda exe="WorldOSPlayer": set())
     monkeypatch.setattr(qa_sandbox, "_orphan_report",
                         lambda **kwargs: {"lines": [], "leaks": [], "port": 8972, "port_pids": []})
@@ -343,12 +353,73 @@ def test_down_skips_restore_when_plist_snapshot_is_unavailable(monkeypatch, tmp_
     log: list = []
     _fake_defaults(monkeypatch, {}, log)
 
-    assert qa_sandbox.down("r1") == 0
+    assert qa_sandbox.down("r1") == 1
     assert _writes(log) == [], "an unavailable snapshot must never turn into a delete"
     report = json.loads((rd / "prefs_leak.json").read_text())
     assert "unavailable" in report["note"]
     assert (rd / "sandbox.json").exists()
     assert not (rd / "sandbox.json.stopped").exists()
+
+
+def test_down_renames_meta_for_foreign_player_when_diff_is_empty(monkeypatch, tmp_path):
+    monkeypatch.setattr(qa_sandbox, "ROOT", tmp_path)
+    rd = tmp_path / "r1"
+    rd.mkdir()
+    (rd / "sandbox.json").write_text(json.dumps({
+        "run": "r1", "win": [1280, 700], "pids": {},
+        "plist_before": {"SomeOwnerSetting": "7"}}))
+    monkeypatch.setattr(qa_sandbox, "_plist_snapshot", lambda: {"SomeOwnerSetting": "7"})
+    monkeypatch.setattr(qa_sandbox, "_player_pids", lambda exe="WorldOSPlayer": {999})
+    monkeypatch.setattr(qa_sandbox, "_orphan_report",
+                        lambda **kwargs: {"lines": [], "leaks": [], "port": 8972,
+                                          "port_pids": []})
+    monkeypatch.setattr(qa_sandbox.time, "sleep", lambda *_: None)
+
+    assert qa_sandbox.down("r1") == 0
+    assert not (rd / "sandbox.json").exists()
+    assert (rd / "sandbox.json.stopped").exists()
+
+
+def test_down_keeps_meta_and_returns_one_for_foreign_player_with_diff(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(qa_sandbox, "ROOT", tmp_path)
+    rd = tmp_path / "r1"
+    rd.mkdir()
+    (rd / "sandbox.json").write_text(json.dumps({
+        "run": "r1", "win": [1280, 700], "pids": {},
+        "plist_before": {"Screenmanager Fullscreen mode": "1"}}))
+    monkeypatch.setattr(qa_sandbox, "_plist_snapshot",
+                        lambda: {"Screenmanager Fullscreen mode": "3"})
+    monkeypatch.setattr(qa_sandbox, "_player_pids", lambda exe="WorldOSPlayer": {999})
+    monkeypatch.setattr(qa_sandbox, "_orphan_report",
+                        lambda **kwargs: {"lines": [], "leaks": [], "port": 8972,
+                                          "port_pids": []})
+    monkeypatch.setattr(qa_sandbox.time, "sleep", lambda *_: None)
+
+    assert qa_sandbox.down("r1") == 1
+    assert (rd / "sandbox.json").exists()
+    assert not (rd / "sandbox.json.stopped").exists()
+    err = capsys.readouterr().err
+    assert ("cleanup INCOMPLETE (0 leak(s), foreign [999], snapshot_ok=True)"
+            in err)
+    assert f"keeping {rd / 'sandbox.json'}" in err
+    assert "re-run `down --run r1`" in err
+
+
+def test_down_renames_legacy_meta_without_plist_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setattr(qa_sandbox, "ROOT", tmp_path)
+    rd = tmp_path / "r1"
+    rd.mkdir()
+    (rd / "sandbox.json").write_text(json.dumps({"run": "r1", "pids": {}}))
+    monkeypatch.setattr(qa_sandbox, "_plist_snapshot",
+                        lambda: pytest.fail("legacy metadata must not snapshot"))
+    monkeypatch.setattr(qa_sandbox, "_player_pids", lambda exe="WorldOSPlayer": set())
+    monkeypatch.setattr(qa_sandbox, "_orphan_report",
+                        lambda **kwargs: {"lines": [], "leaks": [], "port": 8972,
+                                          "port_pids": []})
+    monkeypatch.setattr(qa_sandbox.time, "sleep", lambda *_: None)
+
+    assert qa_sandbox.down("r1") == 0
+    assert (rd / "sandbox.json.stopped").exists()
 
 
 def test_restore_gating_foreign_player_and_opt_out(monkeypatch):


### PR DESCRIPTION
## Summary

Follow-up for the cross-model review of merged PR #1729. Teardown now keeps retryable metadata only when cleanup work remains, returns non-zero when it keeps that metadata, and rejects an empty snapshot of an existing preferences plist.

## Linked Issue

Review follow-up for #1729 (the original PR is merged; no new issue was required).

## Changes

- F1: treat foreign-player teardown as clean when the plist diff is empty; preserve metadata and fail closed when leaks, an unreadable snapshot, or a foreign player plus a non-empty diff remain; handle legacy metadata without `plist_before`.
- F2: classify an empty `defaults export` as unreadable when the domain plist exists.
- F3: document that incomplete teardown leaves the `stopped` block in `sandbox.json`.

## Licensing / CLA

- [x] I have read `CLA.md` and submit this contribution under the WorldOS Contributor License Agreement.
- [x] I have not included confidential information, private customer data, private imported content, or third-party-restricted material.
- [x] Any third-party material in this PR is clearly identified with source and license.

## Review Thread State

- Current-head unresolved review threads: none known at creation.
- P0-P2 blocker count: 0 known.
- P3/advisory count: 0 known.
- Top-level bot comments requiring action: none known.
- Check annotations requiring action: pending PR checks.
- Bot rerun status: pending PR creation.

## Validation

- `uv run --directory servers/engine python -m pytest /Users/m1/worldos-wt-rigfix2/qa/test_qa_sandbox_window.py -q -p no:xdist` — 49 passed, 1 xfailed.
- `/Users/m1/worldos-wt-rigfix2/qa/fast_gate.sh` — 257 passed.
- `git diff --check` — passed.

## Release / WorldOS Proof Tier

- [x] Local or fast smoke only
- [ ] Release proof
- [ ] Runtime/customer proof
- Claim class: `unit-tested-fix` — proves the requested deterministic harness behaviors under unit tests; does not prove a live sandbox run or customer/runtime behavior.

## Release Notes / Changelog

- Release-note impact: no product/runtime behavior change; QA harness safety and teardown retryability only.
- Verification/evidence tail needed? no.

## Safety / Rollback

No live sandbox run or production/runtime mutation was performed. Revert commit `365cd009` to restore the prior harness behavior.

## Evidence

- Scratch/evidence path: `/Users/m1/Codex/session-notes/2026-09-02/worldos-refresh/artifacts/rig/threads/review-1729/`

## Notes For Next Agent

- Exact candidate head: `365cd009`.
- Requested merge method: `gh pr merge --auto --squash` (never `--admin`).
