### PR TITLE
owner_install: trap scope, DM run reset on reseed, DM serving-state check, shader guarantee, longer consumption probe (post-merge review of #1733, #1753)

### DIFF
--- a/docs/OWNER-INSTALL.md
+++ b/docs/OWNER-INSTALL.md
@@ -23,15 +23,21 @@ Stopping before any write is load-bearing: a viewer still accepting `POST /move`
 
 1. bootstrap `owner-session`, poll `/session-surface` for 200 (90 s).
 2. kickstart `owner-player`, poll `POST /debug` on 8981 for 200 (60 s) — Unity binds that port only once the player is up, so a single curl races normal startup latency.
-3. kickstart `owner-dm`.
-4. prove the campaign was **consumed**, not merely served: `/session-surface` `campaign_id == adventure_demo_v1`, the player's `surf > 0`, `plateLocMatch == true`, and `camOrtho` equal to that location's `cameraPin.ortho` in `extensions/renderers/unity/plates_manifest.json`.
+3. remove any stale DM heartbeat, kickstart `owner-dm`, and require its new
+   `<state>/agent_play_runs/owner/serve.heartbeat` within 60 s. The serve loop refreshes it every
+   poll; refusal prints the tail of `<state>/owner-dm{,.err}.log` so auth/model-open failures are visible.
+4. prove the campaign was **consumed**, not merely served: after `/debug` first answers, poll for up
+   to 180 s until `surf > 0` and `plateLocMatch == true`, then require `/session-surface`
+   `campaign_id == adventure_demo_v1` and `camOrtho` equal to that location's `cameraPin.ortho` in
+   `extensions/renderers/unity/plates_manifest.json`. The result and elapsed seconds are written to
+   the install ledger.
 
 Refuse-on-red means packaged pins GREEN, zero `KitRoom_` strings in `level0`, FRESH crypt and tavern certifications, and a build identity that is either `--build-sha` or a sibling `build-report.txt` **stamped `result=Succeeded`**. `BuildMacOSPlayer.StampFailedReport` writes a nonempty `result=Failed` report beside a possibly stale app, so nonempty is not identity. Any RED or ERROR exits 1 before a write.
 
 ## Refresh and removal
 
-- `qa/owner_install.sh refresh --sha COMMIT [--reseed]` stops all three agents, verifies the new commit is a fast-forward of the pinned checkout, moves it detached, optionally reseeds, then repeats the ordered start and the consumption proof.
-- `qa/owner_install.sh status` prints each LaunchAgent plus the explicit-port `/session-surface` and `/debug` codes.
+- `qa/owner_install.sh refresh --sha COMMIT [--reseed]` stops all three agents, verifies the new commit is a fast-forward of the pinned checkout, moves it detached, optionally reseeds, then repeats the ordered start and the consumption proof. Every reseed archives the prior `agent_play_runs/owner` directory and `chat.jsonl` with one UTC timestamp before starting a fresh DM context/cursor.
+- `qa/owner_install.sh status` prints each LaunchAgent, the explicit-port `/session-surface` and `/debug` codes, and DM heartbeat presence/path.
 - `qa/owner_install.sh uninstall` removes all three agents/plists but keeps app and state. `--purge` also removes the exact installed app and owner state paths.
 
 ## Rollback
@@ -58,5 +64,6 @@ qa/owner_install.sh restore /Users/m1/Codex/session-notes/<UTC-date>/worldos-ref
 - [ ] T10: a nonempty `build-report.txt` is not a successful build — require `result=Succeeded`.
 - [ ] T11: the session needs `WORLDOS_ART_REPO_ROOT=/Users/m1/WorldOS`; the gitignored `_private` art exists only in the canonical checkout, so the owner worktree as art root reports every image missing.
 - [ ] T12: two agents render pixels but answer nothing — `org.worldos.owner-dm` is what consumes `WORLDOS_PLAYER_MOVES`.
+- [ ] T13: a listening player is not yet a consuming player — allow the first surface up to 180 s, then ledger the final result.
 
 Dry-run proof is `installer-dry-run-verified`: gates, plist rendering, and the named app were checked. It does not prove live install behavior, installed-build G1, or owner-play G4.

--- a/docs/OWNER-INSTALL.md
+++ b/docs/OWNER-INSTALL.md
@@ -32,7 +32,7 @@ Stopping before any write is load-bearing: a viewer still accepting `POST /move`
    `extensions/renderers/unity/plates_manifest.json`. The result and elapsed seconds are written to
    the install ledger.
 
-Refuse-on-red means packaged pins GREEN, zero `KitRoom_` strings in `level0`, FRESH crypt and tavern certifications, and a build identity that is either `--build-sha` or a sibling `build-report.txt` **stamped `result=Succeeded`**. `BuildMacOSPlayer.StampFailedReport` writes a nonempty `result=Failed` report beside a possibly stale app, so nonempty is not identity. Any RED or ERROR exits 1 before a write.
+Refuse-on-red means packaged pins GREEN, zero `KitRoom_` strings in `level0`, FRESH crypt and tavern certifications, and a sibling `build-report.txt` **stamped `result=Succeeded` and naming both required shaders**. `--build-sha` is supplemental provenance; it cannot replace the shader-bearing report. `BuildMacOSPlayer.StampFailedReport` writes a nonempty `result=Failed` report beside a possibly stale app, so nonempty is not identity. Any RED or ERROR exits 1 before a write.
 
 ## Refresh and removal
 

--- a/qa/agent_play.sh
+++ b/qa/agent_play.sh
@@ -66,6 +66,7 @@ done
 RUNS_ROOT="${WORLDOS_AGENT_PLAY_ROOT:-qa/agent_play_runs}"   # repo-relative by default; absolute is fine
 case "$RUNS_ROOT" in /*) RUN_DIR="$RUNS_ROOT/$RUN" ;; *) RUN_DIR="$ROOT/$RUNS_ROOT/$RUN" ;; esac
 SESSION="$RUN_DIR/session.json"
+HEARTBEAT="$RUN_DIR/serve.heartbeat"
 
 # ── session file helpers (the durable binding; `say`/`serve`/`status`/`stop` need only --run) ────
 ap_sget() { python3 -c 'import json,sys
@@ -342,6 +343,7 @@ ap_serve() {
   ap_sset stopped "" serve_pid "$$" >/dev/null  # a fresh serve un-stops the run and owns its PID
   echo "[agent-play] serving run=$RUN chat=$CHAT moves=$MOVES campaign=$CAMPAIGN_ID dm=$WORLDOS_DM_MODEL max_beats=$label"
   while [ "$AP_SERVE_STOP" = "0" ]; do
+    touch "$HEARTBEAT"                       # explicit serving-state marker, refreshed every poll
     # `stop --run <name>` stamps the session, which is how another shell asks this loop to exit
     # (SIGTERM is the other way; the LaunchAgent uses that one).
     if [ -n "$(ap_sget stopped)" ]; then echo "[agent-play] session marked stopped — exiting serve"; break; fi
@@ -415,6 +417,7 @@ print(f"{tot:.4f}")' "$RUN_DIR/$RUN.dm.*.jsonl" 2>/dev/null || echo 0)"
   echo "run=$RUN campaign=$cid state=$state"
   echo "beats=$used/$total  quest=${status:-unknown}  stamps=$stamps  spend_usd=$spend"
   echo "chat=$(ap_sget chat_path)  session=$SESSION  stopped=$(ap_sget stopped)"
+  echo "serve_heartbeat=$([ -f "$HEARTBEAT" ] && echo PRESENT || echo MISSING) path=$HEARTBEAT"
 }
 
 ap_stop() {

--- a/qa/agent_play.sh
+++ b/qa/agent_play.sh
@@ -67,6 +67,7 @@ RUNS_ROOT="${WORLDOS_AGENT_PLAY_ROOT:-qa/agent_play_runs}"   # repo-relative by 
 case "$RUNS_ROOT" in /*) RUN_DIR="$RUNS_ROOT/$RUN" ;; *) RUN_DIR="$ROOT/$RUNS_ROOT/$RUN" ;; esac
 SESSION="$RUN_DIR/session.json"
 HEARTBEAT="$RUN_DIR/serve.heartbeat"
+STARTING="$RUN_DIR/serve.starting"
 
 # ── session file helpers (the durable binding; `say`/`serve`/`status`/`stop` need only --run) ────
 ap_sget() { python3 -c 'import json,sys
@@ -316,6 +317,7 @@ $event_adv"
 # never re-answers a line it already answered.
 AP_SERVE_STOP=0
 ap_serve_cleanup() {
+  rm -f "$HEARTBEAT" "$STARTING"
   [ "$(ap_sget serve_pid)" = "$$" ] && ap_sset serve_pid "" >/dev/null || true
 }
 ap_move_text() {
@@ -331,6 +333,8 @@ else:
     print(f"[{kind}] {detail}")'
 }
 ap_serve() {
+  mkdir -p "$RUN_DIR"; rm -f "$HEARTBEAT"; : > "$STARTING"
+  trap 'rm -f "$HEARTBEAT" "$STARTING"' EXIT
   if [ ! -s "$SESSION" ]; then
     [ -n "$ENGINE" ] && [ -n "$STATE_IN" ] || { echo "[agent-play] serve on a fresh run needs --engine and --state (or run \`start\` first)" >&2; exit 2; }
     ap_start
@@ -341,6 +345,7 @@ ap_serve() {
   trap 'AP_SERVE_STOP=1' TERM INT
   trap 'ap_serve_cleanup' EXIT
   ap_sset stopped "" serve_pid "$$" >/dev/null  # a fresh serve un-stops the run and owns its PID
+  rm -f "$STARTING"
   echo "[agent-play] serving run=$RUN chat=$CHAT moves=$MOVES campaign=$CAMPAIGN_ID dm=$WORLDOS_DM_MODEL max_beats=$label"
   while [ "$AP_SERVE_STOP" = "0" ]; do
     touch "$HEARTBEAT"                       # explicit serving-state marker, refreshed every poll
@@ -417,7 +422,7 @@ print(f"{tot:.4f}")' "$RUN_DIR/$RUN.dm.*.jsonl" 2>/dev/null || echo 0)"
   echo "run=$RUN campaign=$cid state=$state"
   echo "beats=$used/$total  quest=${status:-unknown}  stamps=$stamps  spend_usd=$spend"
   echo "chat=$(ap_sget chat_path)  session=$SESSION  stopped=$(ap_sget stopped)"
-  echo "serve_heartbeat=$([ -f "$HEARTBEAT" ] && echo PRESENT || echo MISSING) path=$HEARTBEAT"
+  if [ -f "$HEARTBEAT" ]; then echo "serve_heartbeat=PRESENT path=$HEARTBEAT"; elif [ -f "$STARTING" ]; then echo "serve_heartbeat=STARTING path=$HEARTBEAT"; else echo "serve_heartbeat=MISSING path=$HEARTBEAT"; fi
 }
 
 ap_stop() {

--- a/qa/owner_install.sh
+++ b/qa/owner_install.sh
@@ -8,7 +8,7 @@ STATE="$HOME/Library/Application Support/WorldOS/owner_demo"
 AGENTS="$HOME/Library/LaunchAgents"; SESSION=org.worldos.owner-session; PLAYER=org.worldos.owner-player
 DM=org.worldos.owner-dm; DM_SCRIPT=qa/agent_play.sh
 ENGINE_PORT=8776; QA_PORT=8981; BUILD_SHA=; BUILD_REPORT=; SHA=; STAGE=; RESEED=0; PURGE=0
-DM_RUN="$STATE/agent_play_runs/owner"; DM_HEARTBEAT="$DM_RUN/serve.heartbeat"
+DM_RUN="$STATE/agent_play_runs/owner"; DM_HEARTBEAT="$DM_RUN/serve.heartbeat"; DM_STARTING="$DM_RUN/serve.starting"
 DM_LOG="$STATE/owner-dm.log"; DM_ERR="$STATE/owner-dm.err.log"
 START_PROBE_TMP=
 die(){ printf 'OWNER INSTALL REFUSED: %s\n' "$*" >&2; exit 1; }
@@ -29,7 +29,7 @@ ledger_consumption(){
   local ledger=$1 result=$2 elapsed=$3 detail=$4
   [[ -n "$ledger" && -f "$ledger" ]] || return 0
   python3 "$ROOT/qa/owner_install_verify.py" ledger "$ledger" --result "$result" \
-    --elapsed "$elapsed" --detail "$detail" || echo "OWNER INSTALL NOTE: could not update $ledger" >&2
+    --elapsed "$elapsed" --detail "$detail" || { echo "OWNER INSTALL REFUSED: could not update $ledger" >&2; return 1; }
 }
 
 reset_dm_run(){
@@ -47,8 +47,17 @@ reset_dm_run(){
 }
 
 await_dm(){
-  local secs=$1 i log
-  for ((i=0; i<secs; i++)); do [[ -f "$DM_HEARTBEAT" ]] && return 0; sleep 1; done
+  local secs=$1 i log starting=0
+  for ((i=0; i<secs; i++)); do
+    [[ -f "$DM_HEARTBEAT" ]] && return 0
+    [[ ! -f "$DM_STARTING" ]] || starting=1
+    if ((starting && i > 1)) && ! dm_running; then break; fi
+    sleep 1
+  done
+  if ((starting)) && dm_running; then
+    echo "DM cold open still running after ${secs}s; startup marker and LaunchAgent are live."
+    return 0
+  fi
   echo "OWNER INSTALL DM LOG TAIL (heartbeat missing):" >&2
   for log in "$DM_LOG" "$DM_ERR"; do
     [[ ! -f "$log" ]] || { echo "--- ${log##*/} ---" >&2; tail -n 20 "$log" >&2; }
@@ -56,24 +65,31 @@ await_dm(){
   die "DM never reached serving state (no $DM_HEARTBEAT within ${secs}s)"
 }
 
+dm_running(){ launchctl print "gui/$(id -u)/$DM" 2>/dev/null | grep -q 'state = running'; }
+monotonic_seconds(){ python3 -c 'import time; print(int(time.monotonic()))'; }
 await_consumed(){
-  local surface=$1 debug=$2 secs=$3 ledger=${4:-} i msg detail
+  local surface=$1 debug=$2 secs=$3 ledger=${4:-} start now elapsed=0 timeout msg detail
   curl -fsS --max-time 5 "http://127.0.0.1:$ENGINE_PORT/session-surface" >"$surface"
-  for ((i=0; i<=secs; i++)); do
-    curl -fsS --max-time 5 -X POST -H 'Content-Type: application/json' -d '{}' \
+  start=$(monotonic_seconds)
+  while ((elapsed < secs)); do
+    now=$(monotonic_seconds); elapsed=$((now - start)); ((elapsed < secs)) || break
+    timeout=$((secs - elapsed)); ((timeout > 5)) && timeout=5
+    curl -fsS --max-time "$timeout" -X POST -H 'Content-Type: application/json' -d '{}' \
       "http://127.0.0.1:$QA_PORT/debug" >"$debug" 2>/dev/null || printf '{}\n' >"$debug"
+    now=$(monotonic_seconds); elapsed=$((now - start))
     if python3 "$ROOT/qa/owner_install_verify.py" player-ready "$debug" >/dev/null 2>&1; then
       if msg=$(python3 "$ROOT/qa/owner_install_verify.py" consumed --surface "$surface" --debug "$debug" \
           --manifest "$OWNER_REPO/extensions/renderers/unity/plates_manifest.json" 2>&1); then
-        ledger_consumption "$ledger" GREEN "$i" "$msg"
-        printf '%s (elapsed=%ss)\n' "$msg" "$i"; cat "$debug"; echo; return 0
+        ledger_consumption "$ledger" GREEN "$elapsed" "$msg" || die "could not update consumption verdict in $ledger"
+        printf '%s (elapsed=%ss)\n' "$msg" "$elapsed"; cat "$debug"; echo; return 0
       fi
-      ledger_consumption "$ledger" REFUSED "$i" "$msg"; die "$msg"
+      ledger_consumption "$ledger" REFUSED "$elapsed" "$msg" || die "could not update consumption verdict in $ledger"
+      die "$msg"
     fi
-    ((i == secs)) || sleep 1
+    ((elapsed >= secs)) || sleep 1
   done
-  detail=$(cat "$debug"); ledger_consumption "$ledger" REFUSED "$secs" "last /debug: $detail"
-  echo "OWNER INSTALL last /debug after ${secs}s: $detail" >&2
+  detail=$(cat "$debug"); ledger_consumption "$ledger" REFUSED "$elapsed" "last /debug: $detail" || die "could not update consumption verdict in $ledger"
+  echo "OWNER INSTALL last /debug after ${elapsed}s: $detail" >&2
   die "player never reached surf>0 with plateLocMatch=true within ${secs}s"
 }
 
@@ -195,6 +211,6 @@ restore)
   start_and_probe; echo "RESTORED from $RECEIPT (worktree ${PRIOR_WT:-unchanged})";;
 refresh)
   [[ -n "$SHA" ]] || die "refresh requires --sha"; stop_agents; WT=$(resolve_worktree "$SHA"); require_dm "$OWNER_REPO"; if ((RESEED)); then RECEIPT=$(receipt_dir); mkdir -p "$RECEIPT"; [[ ! -d "$STATE" ]] || ditto "$STATE" "$RECEIPT/owner_demo"; echo "Restore state: ditto '$RECEIPT/owner_demo' '$STATE'"; reset_dm_run "$STATE"; WORLDOS_STATE_DIR="$STATE" uv run --directory "$OWNER_REPO/servers/engine" python "$OWNER_REPO/qa/seed_adventure_demo.py" "$STATE"; fi; start_and_probe; echo "REFRESHED $WT";;
-status) for L in "$SESSION" "$PLAYER" "$DM"; do launchctl print "gui/$(id -u)/$L" || true; done; echo "engine /session-surface $(engine_code)"; echo "player /debug $(player_code)"; echo "dm heartbeat $([[ -f "$DM_HEARTBEAT" ]] && echo PRESENT || echo MISSING) ($DM_HEARTBEAT)";;
+status) for L in "$SESSION" "$PLAYER" "$DM"; do launchctl print "gui/$(id -u)/$L" || true; done; echo "engine /session-surface $(engine_code)"; echo "player /debug $(player_code)"; if [[ -f "$DM_HEARTBEAT" ]]; then M=PRESENT; elif [[ -f "$DM_STARTING" ]]; then M=STARTING; else M=MISSING; fi; echo "dm heartbeat $M ($DM_HEARTBEAT)";;
 uninstall) stop_agents; rm -f "$AGENTS/$SESSION.plist" "$AGENTS/$PLAYER.plist" "$AGENTS/$DM.plist"; if ((PURGE)); then rm -rf "$TARGET_APP" "$STATE"; fi; echo "Uninstalled agents; app/state $([[ $PURGE == 1 ]] && echo purged || echo kept).";;
 *) usage;; esac

--- a/qa/owner_install.sh
+++ b/qa/owner_install.sh
@@ -89,13 +89,10 @@ preflight(){
   # Unity's StampFailedReport writes a nonempty result=Failed report beside a stale .app,
   # so "readable and nonempty" is not build identity — require the stamped success.
   BUILD_REPORT="$(dirname "$app")/build-report.txt"
-  if [[ -r "$BUILD_REPORT" && -s "$BUILD_REPORT" ]]; then
-    python3 "$ROOT/qa/owner_install_verify.py" build-report "$BUILD_REPORT" || die "build-report.txt beside $app does not record a successful build"
-  else
-    BUILD_REPORT=; [[ -n "$BUILD_SHA" ]] || die "no successful build-report.txt beside $app and no --build-sha"
-  fi
+  [[ -r "$BUILD_REPORT" && -s "$BUILD_REPORT" ]] || die "build-report.txt is required beside $app (a --build-sha cannot prove the built shaders)"
+  python3 "$ROOT/qa/owner_install_verify.py" build-report "$BUILD_REPORT" || die "build-report.txt beside $app does not record a successful build with both required shaders"
   [[ -f "$ROOT/$DM_SCRIPT" ]] || echo "OWNER INSTALL NOTE: $ROOT/$DM_SCRIPT is absent; install will refuse until the DM loop lands." >&2
-  echo "OWNER INSTALL PREFLIGHT GREEN (pins GREEN; KitRoom_=0; crypt+tavern FRESH; build identity ${BUILD_REPORT:+build-report result=Succeeded}${BUILD_REPORT:+ }${BUILD_REPORT:-via --build-sha $BUILD_SHA})"
+  echo "OWNER INSTALL PREFLIGHT GREEN (pins GREEN; KitRoom_=0; crypt+tavern FRESH; build identity build-report result=Succeeded $BUILD_REPORT)"
 }
 
 receipt_dir(){ echo "/Users/m1/Codex/session-notes/$(date -u +%F)/worldos-refresh/artifacts/owner-install/backup-$(date -u +%Y%m%dT%H%M%SZ)"; }

--- a/qa/owner_install.sh
+++ b/qa/owner_install.sh
@@ -8,6 +8,9 @@ STATE="$HOME/Library/Application Support/WorldOS/owner_demo"
 AGENTS="$HOME/Library/LaunchAgents"; SESSION=org.worldos.owner-session; PLAYER=org.worldos.owner-player
 DM=org.worldos.owner-dm; DM_SCRIPT=qa/agent_play.sh
 ENGINE_PORT=8776; QA_PORT=8981; BUILD_SHA=; BUILD_REPORT=; SHA=; STAGE=; RESEED=0; PURGE=0
+DM_RUN="$STATE/agent_play_runs/owner"; DM_HEARTBEAT="$DM_RUN/serve.heartbeat"
+DM_LOG="$STATE/owner-dm.log"; DM_ERR="$STATE/owner-dm.err.log"
+START_PROBE_TMP=
 die(){ printf 'OWNER INSTALL REFUSED: %s\n' "$*" >&2; exit 1; }
 usage(){ echo "usage: $0 preflight|dry-run|install [app] [--stage dir] [--sha sha] [--build-sha sha] | refresh --sha sha [--reseed] | restore <receipt-dir> | status | uninstall [--purge]"; exit 2; }
 
@@ -21,6 +24,58 @@ await_code(){ local fn=$1 want=$2 secs=$3 what=$4 code='' i; for ((i=0; i<secs; 
 # for a DM to answer, so without qa/agent_play.sh serve the demo cannot be played at all.
 require_dm(){ local s="$1/$DM_SCRIPT"
   if [[ ! -f "$s" ]] || ! grep -qE '(^|[^[:alnum:]_])serve([^[:alnum:]_]|$)' "$s"; then die "$s has no 'serve' mode: the owner-dm agent would start nothing and every say/do/check would queue forever"; fi; }
+
+ledger_consumption(){
+  local ledger=$1 result=$2 elapsed=$3 detail=$4
+  [[ -n "$ledger" && -f "$ledger" ]] || return 0
+  python3 "$ROOT/qa/owner_install_verify.py" ledger "$ledger" --result "$result" \
+    --elapsed "$elapsed" --detail "$detail" || echo "OWNER INSTALL NOTE: could not update $ledger" >&2
+}
+
+reset_dm_run(){
+  local state=$1 stamp run chat moved=0
+  stamp=$(date -u +%Y%m%dT%H%M%SZ); run="$state/agent_play_runs/owner"; chat="$state/chat.jsonl"
+  if [[ -e "$run" ]]; then
+    [[ ! -e "$state/agent_play_runs/owner.archived-$stamp" ]] || die "DM archive timestamp collision: $stamp"
+    mv "$run" "$state/agent_play_runs/owner.archived-$stamp"; moved=1
+  fi
+  if [[ -e "$chat" ]]; then
+    [[ ! -e "$state/chat.archived-$stamp.jsonl" ]] || die "chat archive timestamp collision: $stamp"
+    mv "$chat" "$state/chat.archived-$stamp.jsonl"; moved=1
+  fi
+  ((moved == 0)) || echo "Archived prior DM run/chat at timestamp $stamp; reseed will start fresh."
+}
+
+await_dm(){
+  local secs=$1 i log
+  for ((i=0; i<secs; i++)); do [[ -f "$DM_HEARTBEAT" ]] && return 0; sleep 1; done
+  echo "OWNER INSTALL DM LOG TAIL (heartbeat missing):" >&2
+  for log in "$DM_LOG" "$DM_ERR"; do
+    [[ ! -f "$log" ]] || { echo "--- ${log##*/} ---" >&2; tail -n 20 "$log" >&2; }
+  done
+  die "DM never reached serving state (no $DM_HEARTBEAT within ${secs}s)"
+}
+
+await_consumed(){
+  local surface=$1 debug=$2 secs=$3 ledger=${4:-} i msg detail
+  curl -fsS --max-time 5 "http://127.0.0.1:$ENGINE_PORT/session-surface" >"$surface"
+  for ((i=0; i<=secs; i++)); do
+    curl -fsS --max-time 5 -X POST -H 'Content-Type: application/json' -d '{}' \
+      "http://127.0.0.1:$QA_PORT/debug" >"$debug" 2>/dev/null || printf '{}\n' >"$debug"
+    if python3 "$ROOT/qa/owner_install_verify.py" player-ready "$debug" >/dev/null 2>&1; then
+      if msg=$(python3 "$ROOT/qa/owner_install_verify.py" consumed --surface "$surface" --debug "$debug" \
+          --manifest "$OWNER_REPO/extensions/renderers/unity/plates_manifest.json" 2>&1); then
+        ledger_consumption "$ledger" GREEN "$i" "$msg"
+        printf '%s (elapsed=%ss)\n' "$msg" "$i"; cat "$debug"; echo; return 0
+      fi
+      ledger_consumption "$ledger" REFUSED "$i" "$msg"; die "$msg"
+    fi
+    ((i == secs)) || sleep 1
+  done
+  detail=$(cat "$debug"); ledger_consumption "$ledger" REFUSED "$secs" "last /debug: $detail"
+  echo "OWNER INSTALL last /debug after ${secs}s: $detail" >&2
+  die "player never reached surf>0 with plateLocMatch=true within ${secs}s"
+}
 
 preflight(){
   local app=$1 out kit room
@@ -80,19 +135,18 @@ resolve_worktree(){
 # Session FIRST, then the player, then the DM — only the session plist sets RunAtLoad, so
 # `bootstrap` starts exactly one process and nothing races the engine (#1612's two-kick trap).
 start_and_probe(){
-  local domain tmp; domain="gui/$(id -u)"
+  local domain tmp ledger=${1:-}; domain="gui/$(id -u)"
+  tmp=$(mktemp -d); START_PROBE_TMP=$tmp; trap 'rm -rf "$START_PROBE_TMP"' EXIT
   launchctl bootstrap "$domain" "$AGENTS/$SESSION.plist" 2>/dev/null || launchctl kickstart -k "$domain/$SESSION"
   await_code engine_code 200 90 "engine /session-surface never reached 200 on :$ENGINE_PORT"
   launchctl bootstrap "$domain" "$AGENTS/$PLAYER.plist" 2>/dev/null || true; launchctl kickstart -k "$domain/$PLAYER"
   # Unity binds :$QA_PORT only once the player is up; a single curl races normal startup.
   await_code player_code 200 60 "player QA listener never answered /debug on :$QA_PORT within 60s"
+  rm -f "$DM_HEARTBEAT"                    # a prior serve must not satisfy this start
   launchctl bootstrap "$domain" "$AGENTS/$DM.plist" 2>/dev/null || true; launchctl kickstart -k "$domain/$DM"
-  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' RETURN EXIT
-  curl -fsS --max-time 5 "http://127.0.0.1:$ENGINE_PORT/session-surface" >"$tmp/surface.json"
-  curl -fsS --max-time 5 -X POST -H 'Content-Type: application/json' -d '{}' "http://127.0.0.1:$QA_PORT/debug" >"$tmp/debug.json"
-  python3 "$ROOT/qa/owner_install_verify.py" consumed --surface "$tmp/surface.json" --debug "$tmp/debug.json" \
-    --manifest "$OWNER_REPO/extensions/renderers/unity/plates_manifest.json" || die "the installed player never applied the seeded campaign"
-  cat "$tmp/debug.json"; echo
+  await_dm 60
+  await_consumed "$tmp/surface.json" "$tmp/debug.json" 180 "$ledger"
+  trap - EXIT; rm -rf "$tmp"; START_PROBE_TMP=
 }
 
 MODE=${1:-}; [[ -n "$MODE" ]] || usage; shift
@@ -117,10 +171,11 @@ install)
   echo "Rollback (one line, yields a running installation): '$ROOT/qa/owner_install.sh' restore '$RECEIPT'"
   WT=$(resolve_worktree "$SHA"); require_dm "$OWNER_REPO"
   mkdir -p "$(dirname "$TARGET_APP")"; ditto "$APP" "$TARGET_APP"; xattr -dr com.apple.quarantine "$TARGET_APP"; codesign --force --deep --sign - "$TARGET_APP"; echo "Installed with ad-hoc signing; this demo build is unnotarized (accepted)."
+  reset_dm_run "$STATE"
   WORLDOS_STATE_DIR="$STATE" uv run --directory "$OWNER_REPO/servers/engine" python "$OWNER_REPO/qa/seed_adventure_demo.py" "$STATE"
   mkdir -p "$AGENTS"; render "$RECEIPT" install "$TARGET_APP" "$WT" "$RECEIPT/install-ledger.json"
   for L in "$SESSION" "$PLAYER" "$DM"; do install -m 0644 "$RECEIPT/$L.plist" "$AGENTS/$L.plist"; done
-  start_and_probe;;
+  start_and_probe "$RECEIPT/install-ledger.json";;
 restore)
   RECEIPT=$APP  # `restore` takes the receipt dir in the positional slot, not an app
   [[ -d "$RECEIPT" && -f "$RECEIPT/restore.json" ]] || die "restore needs a receipt dir holding restore.json"
@@ -142,7 +197,7 @@ restore)
   done
   start_and_probe; echo "RESTORED from $RECEIPT (worktree ${PRIOR_WT:-unchanged})";;
 refresh)
-  [[ -n "$SHA" ]] || die "refresh requires --sha"; stop_agents; WT=$(resolve_worktree "$SHA"); require_dm "$OWNER_REPO"; if ((RESEED)); then RECEIPT=$(receipt_dir); mkdir -p "$RECEIPT"; [[ ! -d "$STATE" ]] || ditto "$STATE" "$RECEIPT/owner_demo"; echo "Restore state: ditto '$RECEIPT/owner_demo' '$STATE'"; WORLDOS_STATE_DIR="$STATE" uv run --directory "$OWNER_REPO/servers/engine" python "$OWNER_REPO/qa/seed_adventure_demo.py" "$STATE"; fi; start_and_probe; echo "REFRESHED $WT";;
-status) for L in "$SESSION" "$PLAYER" "$DM"; do launchctl print "gui/$(id -u)/$L" || true; done; echo "engine /session-surface $(engine_code)"; echo "player /debug $(player_code)";;
+  [[ -n "$SHA" ]] || die "refresh requires --sha"; stop_agents; WT=$(resolve_worktree "$SHA"); require_dm "$OWNER_REPO"; if ((RESEED)); then RECEIPT=$(receipt_dir); mkdir -p "$RECEIPT"; [[ ! -d "$STATE" ]] || ditto "$STATE" "$RECEIPT/owner_demo"; echo "Restore state: ditto '$RECEIPT/owner_demo' '$STATE'"; reset_dm_run "$STATE"; WORLDOS_STATE_DIR="$STATE" uv run --directory "$OWNER_REPO/servers/engine" python "$OWNER_REPO/qa/seed_adventure_demo.py" "$STATE"; fi; start_and_probe; echo "REFRESHED $WT";;
+status) for L in "$SESSION" "$PLAYER" "$DM"; do launchctl print "gui/$(id -u)/$L" || true; done; echo "engine /session-surface $(engine_code)"; echo "player /debug $(player_code)"; echo "dm heartbeat $([[ -f "$DM_HEARTBEAT" ]] && echo PRESENT || echo MISSING) ($DM_HEARTBEAT)";;
 uninstall) stop_agents; rm -f "$AGENTS/$SESSION.plist" "$AGENTS/$PLAYER.plist" "$AGENTS/$DM.plist"; if ((PURGE)); then rm -rf "$TARGET_APP" "$STATE"; fi; echo "Uninstalled agents; app/state $([[ $PURGE == 1 ]] && echo purged || echo kept).";;
 *) usage;; esac

--- a/qa/owner_install_plists.py
+++ b/qa/owner_install_plists.py
@@ -60,6 +60,8 @@ def render_plists(repo: Path, app: Path, state: Path, uv: Path,
           "ProgramArguments": ["/bin/bash", str(repo / DM_SCRIPT), "serve", "--run", "owner",
                                "--engine", f"http://127.0.0.1:{engine_port}", "--state", str(state),
                                "--campaign", CAMPAIGN],
+          "StandardOutPath": str(state / "owner-dm.log"),
+          "StandardErrorPath": str(state / "owner-dm.err.log"),
           # WORLDOS_AGENT_PLAY_ROOT: agent_play.sh defaults its run dir to <repo>/qa/agent_play_runs.
           # The owner's run holds the durable chat cursor, so it belongs beside the state the receipt
           # backs up — not inside the pinned checkout that `refresh --sha` moves out from under it.

--- a/qa/owner_install_verify.py
+++ b/qa/owner_install_verify.py
@@ -12,8 +12,10 @@ its camera ortho must equal that location's plates_manifest pin.
 """
 from __future__ import annotations  # 3.9 system python runs these
 
-import argparse, json, sys
+import argparse, json, os, sys
 from pathlib import Path
+
+from check_always_included_shaders import REQUIRED_SHADERS
 
 CAMPAIGN = "adventure_demo_v1"
 ORTHO_TOL = 0.05
@@ -27,6 +29,12 @@ def check_build_report(text: str) -> dict:
             fields[key.strip()] = value.strip()
     if fields.get("result") != "Succeeded":
         raise ValueError(f"build-report.txt result={fields.get('result') or '<missing>'!s}, not Succeeded")
+    shader_line = fields.get("alwaysIncludedShaders", "")
+    listed = {name.strip() for name in shader_line.split(",") if name.strip()}
+    missing = [name for name in REQUIRED_SHADERS if name not in listed]
+    if missing:
+        raise ValueError(
+            f"alwaysIncludedShaders={shader_line or '<missing>'}; missing {', '.join(missing)}")
     return fields
 
 
@@ -42,10 +50,7 @@ def check_consumed(surface: dict, debug: dict, manifest: dict) -> str:
     loc = (surface.get("location") or {}).get("id") or ""
     if not loc:
         raise ValueError("session surface names no current location")
-    if int(debug.get("surf") or 0) <= 0:
-        raise ValueError("player applied 0 surfaces — it never reached the engine")
-    if debug.get("plateLocMatch") is not True:
-        raise ValueError(f"player plate does not match the party location {loc!r}")
+    check_player_ready(debug)
     cam, pin = debug.get("camOrtho"), plate_ortho(manifest, loc)
     if pin is not None:
         if cam is None:
@@ -55,19 +60,43 @@ def check_consumed(surface: dict, debug: dict, manifest: dict) -> str:
     return f"CONSUMED: {CAMPAIGN} live at {loc} (surf={debug.get('surf')}, camOrtho={cam}, pin={pin})"
 
 
+def check_player_ready(debug: dict) -> None:
+    if int(debug.get("surf") or 0) <= 0:
+        raise ValueError("player applied 0 surfaces — it never reached the engine")
+    if debug.get("plateLocMatch") is not True:
+        raise ValueError("player plate does not match the engine location")
+
+
+def record_consumption(path: Path, result: str, elapsed: int, detail: str) -> None:
+    data = json.loads(path.read_text())
+    data.setdefault("gate_results", {})["consumption"] = {
+        "result": result, "elapsed_seconds": elapsed, "detail": detail}
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2) + "\n")
+    os.replace(tmp, path)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     sub = ap.add_subparsers(dest="cmd", required=True)
     sub.add_parser("build-report").add_argument("path", type=Path)
+    sub.add_parser("player-ready").add_argument("path", type=Path)
     con = sub.add_parser("consumed")
     for flag in ("surface", "debug", "manifest"):
         con.add_argument(f"--{flag}", required=True, type=Path)
+    led = sub.add_parser("ledger")
+    led.add_argument("path", type=Path); led.add_argument("--result", required=True)
+    led.add_argument("--elapsed", required=True, type=int); led.add_argument("--detail", required=True)
     args = ap.parse_args()
     try:
         if args.cmd == "build-report":
             print("build identity: " + json.dumps(check_build_report(args.path.read_text()), sort_keys=True))
-        else:
+        elif args.cmd == "player-ready":
+            check_player_ready(json.loads(args.path.read_text()))
+        elif args.cmd == "consumed":
             print(check_consumed(*(json.loads(p.read_text()) for p in (args.surface, args.debug, args.manifest))))
+        else:
+            record_consumption(args.path, args.result, args.elapsed, args.detail)
     except (ValueError, OSError, json.JSONDecodeError) as exc:
         print(f"OWNER INSTALL REFUSED: {exc}", file=sys.stderr)
         return 1

--- a/qa/test_owner_install.py
+++ b/qa/test_owner_install.py
@@ -1,4 +1,4 @@
-import json, plistlib, re, subprocess, sys
+import json, plistlib, re, shlex, subprocess, sys
 from pathlib import Path
 import pytest
 
@@ -39,6 +39,8 @@ def test_a_dm_consumer_agent_is_rendered(tmp_path):
     # inside the pinned checkout that `refresh --sha` moves out from under it.
     assert dm["EnvironmentVariables"]["WORLDOS_AGENT_PLAY_ROOT"] == str(tmp_path / "state/agent_play_runs")
     assert dm["EnvironmentVariables"]["WORLDOS_DM_MODEL"] == "opus"
+    assert dm["StandardOutPath"] == str(tmp_path / "state/owner-dm.log")
+    assert dm["StandardErrorPath"] == str(tmp_path / "state/owner-dm.err.log")
 
 
 def test_the_viewer_writes_the_exact_chat_file_the_dm_tails(tmp_path):
@@ -77,8 +79,16 @@ def test_failed_or_unstamped_build_reports_are_refused(report):
 
 
 def test_successful_build_report_is_accepted():
-    fields = OIV.check_build_report("result=Succeeded\ntotalErrors=0\nbuildEndedAt=9/2/2026 10:38:41 AM\n")
+    fields = OIV.check_build_report(
+        "result=Succeeded\ntotalErrors=0\nbuildEndedAt=9/2/2026 10:38:41 AM\n"
+        "alwaysIncludedShaders=WorldOS/OccluderDepth,WorldOS/ActorSilhouette\n")
     assert fields["result"] == "Succeeded" and fields["buildEndedAt"].startswith("9/2/2026")
+
+
+def test_build_report_missing_required_shader_is_refused_with_the_line():
+    line = "alwaysIncludedShaders=WorldOS/OccluderDepth"
+    with pytest.raises(ValueError, match=r"alwaysIncludedShaders=.*ActorSilhouette"):
+        OIV.check_build_report(f"result=Succeeded\n{line}\n")
 
 
 def _debug(**over):
@@ -102,12 +112,97 @@ def test_consumed_proof_refuses_a_player_that_never_applied_the_campaign(surface
     with pytest.raises(ValueError): OIV.check_consumed(surface, debug, MANIFEST)
 
 
-def _fake_app(tmp_path, report="result=Succeeded\n"):
+def _fake_app(tmp_path, report=("result=Succeeded\n"
+                                "alwaysIncludedShaders=WorldOS/OccluderDepth,WorldOS/ActorSilhouette\n")):
     app = tmp_path / "Bad.app"; (app / "Contents/MacOS").mkdir(parents=True); (app / "Contents/Resources/Data").mkdir(parents=True)
     binary = app / "Contents/MacOS/WorldOSPlayer"; binary.write_text("bad"); binary.chmod(0o755)
     (app / "Contents/Resources/Data/level0").write_text("clean")
     if report is not None: (tmp_path / "build-report.txt").write_text(report)
     return app
+
+
+def _owner_shell(tmp_path, body):
+    prefix = Path(SH).read_text().split("\nMODE=", 1)[0].replace(
+        'ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)', f'ROOT={shlex.quote(str(QA.parent))}')
+    return subprocess.run(["/bin/bash", "-c", prefix + "\n" + body], text=True, capture_output=True,
+                          env={"HOME": str(tmp_path / "home"), "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                               "TMPDIR": str(tmp_path)})
+
+
+def _probe_stubs(work, heartbeat=True):
+    launch = 'mkdir -p "$DM_RUN"; touch "$DM_HEARTBEAT"' if heartbeat else ":"
+    return f'''STATE={shlex.quote(str(work / "state"))}
+DM_RUN="$STATE/agent_play_runs/owner"; DM_HEARTBEAT="$DM_RUN/serve.heartbeat"
+DM_LOG="$STATE/owner-dm.log"; DM_ERR="$STATE/owner-dm.err.log"
+mkdir -p "$STATE"
+launchctl() {{ [[ "$*" != *"$DM"* ]] || {{ {launch}; }}; }}
+await_code() {{ :; }}
+curl() {{ printf '%s\\n' '{{"campaign_id":"adventure_demo_v1","location":{{"id":"camp_clearing"}},"surf":4,"plateLocMatch":true,"camOrtho":13.0}}'; }}
+python3() {{ :; }}
+sleep() {{ :; }}
+mktemp() {{ mkdir -p {shlex.quote(str(work / "probe-tmp"))}; printf '%s\\n' {shlex.quote(str(work / "probe-tmp"))}; }}
+'''
+
+
+def test_start_probe_trap_is_scoped_and_cleans_success_and_failure(tmp_path):
+    success = tmp_path / "success"
+    ok = _owner_shell(tmp_path, _probe_stubs(success) + "start_and_probe\n")
+    assert ok.returncode == 0, ok.stderr
+    assert not (success / "probe-tmp").exists()
+
+    failed = tmp_path / "failed"
+    body = _probe_stubs(failed) + "python3() { return 1; }\nstart_and_probe\n"
+    bad = _owner_shell(tmp_path, body)
+    assert bad.returncode == 1
+    assert not (failed / "probe-tmp").exists()
+
+
+def test_reseed_archives_the_dm_run_and_chat_before_starting_fresh(tmp_path):
+    state = tmp_path / "state"
+    run = state / "agent_play_runs/owner"
+    run.mkdir(parents=True)
+    (run / "session.json").write_text('{"chat_cursor": 9}')
+    (state / "chat.jsonl").write_text('{"role":"player","text":"old"}\n')
+    out = _owner_shell(tmp_path, f"reset_dm_run {shlex.quote(str(state))}\n")
+    assert out.returncode == 0, out.stderr
+    assert not run.exists() and not (state / "chat.jsonl").exists()
+    archived = list((state / "agent_play_runs").glob("owner.archived-*"))
+    assert len(archived) == 1 and (archived[0] / "session.json").is_file()
+    assert len(list(state.glob("chat.archived-*.jsonl"))) == 1
+
+
+def test_missing_dm_heartbeat_refuses_with_last_log_lines(tmp_path):
+    work = tmp_path / "missing-heartbeat"
+    state = work / "state"; state.mkdir(parents=True)
+    (state / "owner-dm.err.log").write_text("auth/model open failed\n")
+    result = _owner_shell(tmp_path, _probe_stubs(work, heartbeat=False) + "start_and_probe\n")
+    assert result.returncode == 1
+    assert "heartbeat" in result.stderr and "auth/model open failed" in result.stderr
+    script = (QA / "agent_play.sh").read_text()
+    assert re.search(r'touch .*HEARTBEAT', script), "serve must touch its heartbeat every poll"
+
+
+def test_consumption_probe_waits_through_initial_zero_and_records_green(tmp_path):
+    work = tmp_path / "consumption"; work.mkdir()
+    ledger = work / "ledger.json"; ledger.write_text('{"gate_results": {}}')
+    count = work / "count"
+    body = f'''OWNER_REPO={shlex.quote(str(QA.parent))}
+curl() {{
+  case "$*" in
+    *session-surface*) printf '%s\\n' '{{"campaign_id":"adventure_demo_v1","location":{{"id":"camp_clearing"}}}}' ;;
+    *) n=0; [[ ! -f {shlex.quote(str(count))} ]] || n=$(<{shlex.quote(str(count))}); n=$((n+1)); printf '%s' "$n" >{shlex.quote(str(count))};
+       if ((n < 3)); then printf '%s\\n' '{{"surf":0,"plateLocMatch":false,"camOrtho":13.0}}';
+       else printf '%s\\n' '{{"surf":4,"plateLocMatch":true,"camOrtho":13.0}}'; fi ;;
+  esac
+}}
+sleep() {{ :; }}
+await_consumed {shlex.quote(str(work / "surface.json"))} {shlex.quote(str(work / "debug.json"))} 180 {shlex.quote(str(ledger))}
+'''
+    out = _owner_shell(tmp_path, body)
+    assert out.returncode == 0, out.stderr
+    assert count.read_text() == "3" and "elapsed=2s" in out.stdout
+    assert json.loads(ledger.read_text())["gate_results"]["consumption"]["result"] == "GREEN"
+    assert re.search(r"await_consumed .* 180", (QA / "owner_install.sh").read_text())
 
 
 def test_preflight_refuses_red_before_writing(tmp_path):

--- a/qa/test_owner_install.py
+++ b/qa/test_owner_install.py
@@ -51,7 +51,7 @@ def test_the_viewer_writes_the_exact_chat_file_the_dm_tails(tmp_path):
     line goes unanswered while both halves look correct in isolation.
     """
     script = (QA / "agent_play.sh").read_text()
-    derived = re.search(r'chat_path "\$state/([\w.]+)"', script)
+    derived = re.search(r'chat_path(?:=| )"\$state/([\w.]+)"', script)
     assert derived, "agent_play.sh no longer derives chat_path from the state dir"
     session, _p, dm = OIP.render_plists(Path("/Users/m1/worldos-owner"), tmp_path / "a.app", tmp_path / "state", Path("/opt/homebrew/bin/uv"))
     state_dir = Path(dm["ProgramArguments"][dm["ProgramArguments"].index("--state") + 1])
@@ -193,6 +193,32 @@ def test_missing_dm_heartbeat_refuses_with_last_log_lines(tmp_path):
     assert re.search(r'touch .*HEARTBEAT', script), "serve must touch its heartbeat every poll"
 
 
+def test_cold_open_starting_marker_is_accepted_only_while_dm_job_is_live(tmp_path):
+    work = tmp_path / "cold-open"
+    body = _probe_stubs(work, heartbeat=False) + '''
+DM_STARTING="$DM_RUN/serve.starting"
+mkdir -p "$DM_RUN"; touch "$DM_STARTING"
+launchctl() { echo "state = running"; }
+await_dm 60
+'''
+    result = _owner_shell(tmp_path, body)
+    assert result.returncode == 0, result.stderr
+    assert "cold open still running" in result.stdout
+
+    dead = _owner_shell(tmp_path, _probe_stubs(work, heartbeat=False) + '''
+DM_STARTING="$DM_RUN/serve.starting"; mkdir -p "$DM_RUN"; touch "$DM_STARTING"
+launchctl() { echo "state = exited"; }
+await_dm 60
+''')
+    assert dead.returncode == 1
+
+
+def test_serve_markers_are_removed_when_the_dm_loop_exits():
+    script = (QA / "agent_play.sh").read_text()
+    assert 'STARTING="$RUN_DIR/serve.starting"' in script
+    assert re.search(r"trap '[^']*rm -f[^']*HEARTBEAT[^']*STARTING[^']*' EXIT", script)
+
+
 def test_consumption_probe_waits_through_initial_zero_and_records_green(tmp_path):
     work = tmp_path / "consumption"; work.mkdir()
     ledger = work / "ledger.json"; ledger.write_text('{"gate_results": {}}')
@@ -211,9 +237,32 @@ await_consumed {shlex.quote(str(work / "surface.json"))} {shlex.quote(str(work /
 '''
     out = _owner_shell(tmp_path, body)
     assert out.returncode == 0, out.stderr
-    assert count.read_text() == "3" and "elapsed=2s" in out.stdout
+    assert count.read_text() == "3" and "elapsed=0s" in out.stdout
     assert json.loads(ledger.read_text())["gate_results"]["consumption"]["result"] == "GREEN"
     assert re.search(r"await_consumed .* 180", (QA / "owner_install.sh").read_text())
+
+
+def test_consumption_probe_uses_monotonic_elapsed_time():
+    script = (QA / "owner_install.sh").read_text()
+    assert "time.monotonic" in script
+    assert not re.search(r'ledger_consumption .* "\$i"', script)
+
+
+def test_consumption_success_refuses_if_the_ledger_cannot_be_updated(tmp_path):
+    work = tmp_path / "bad-ledger"; work.mkdir()
+    ledger = work / "ledger.json"; ledger.write_text("not-json")
+    body = f'''OWNER_REPO={shlex.quote(str(QA.parent))}
+curl() {{
+  case "$*" in
+    *session-surface*) printf '%s\n' '{{"campaign_id":"adventure_demo_v1","location":{{"id":"camp_clearing"}}}}' ;;
+    *) printf '%s\n' '{{"surf":4,"plateLocMatch":true,"camOrtho":13.0}}' ;;
+  esac
+}}
+await_consumed {shlex.quote(str(work / "surface.json"))} {shlex.quote(str(work / "debug.json"))} 180 {shlex.quote(str(ledger))}
+'''
+    out = _owner_shell(tmp_path, body)
+    assert out.returncode == 1
+    assert "could not update" in out.stderr
 
 
 def test_preflight_refuses_red_before_writing(tmp_path):

--- a/qa/test_owner_install.py
+++ b/qa/test_owner_install.py
@@ -91,6 +91,17 @@ def test_build_report_missing_required_shader_is_refused_with_the_line():
         OIV.check_build_report(f"result=Succeeded\n{line}\n")
 
 
+def test_build_sha_cannot_bypass_the_required_shader_report(tmp_path):
+    app = _fake_app(tmp_path, report=None)
+    body = f'''BUILD_SHA=deadbeef
+python3() {{ echo "PINS GREEN"; }}
+preflight {shlex.quote(str(app))}
+'''
+    out = _owner_shell(tmp_path, body)
+    assert out.returncode == 1
+    assert "build-report.txt is required" in out.stderr
+
+
 def _debug(**over):
     base = {"ok": True, "surf": 4, "plateLocMatch": True, "camOrtho": 13.0}
     return {**base, **over}


### PR DESCRIPTION
Closes #1753. Follow-up to the four valid post-merge P1 threads on #1733.

What changed:
- scope the start/probe EXIT cleanup so success cannot fire a stale local-variable trap and failure still removes scratch;
- rotate the owner DM run plus chat log before every reseed;
- add a per-poll serve heartbeat, a bounded live cold-open marker, launchd log capture, a 60-second serving-state gate, and heartbeat status/cleanup;
- require a build-report.txt naming both WorldOS/OccluderDepth and WorldOS/ActorSilhouette; --build-sha cannot bypass it;
- poll player consumption against a monotonic 180-second deadline, print elapsed time, fail closed on ledger-write failure, and persist the final result.

Proof at fa32ba63d136d78e164dc750b161f1da8424ef52:
- red-first owner installer regressions, then 31 passed: uv run --directory servers/engine python -m pytest /Users/m1/worldos-wt-installer-followups/qa/test_owner_install.py -q -p no:xdist
- reconciled agent-play + owner-installer suites: 44 passed
- bash -n qa/owner_install.sh and qa/agent_play.sh
- shellcheck qa/owner_install.sh
- qa/fast_gate.sh: 257 passed
- GitNexus detect_changes: LOW, 6 files, no affected execution flow
- 168 non-test changed lines
- real dry-run: /Users/m1/worldos-unity/BuildOutput/WorldOSPlayer.app -> /Users/m1/Codex/session-notes/2026-09-02/worldos-refresh/artifacts/custody/dry-run-fa32ba63/install-ledger.json

Review dispositions:
- Codex P1 cold-open deadline: fixed with a bounded startup marker plus live LaunchAgent check while retaining the requested 60-second gate.
- Codex P2 build-SHA bypass: fixed and regression-tested.
- Codex P2 probe timing: fixed with monotonic elapsed time.
- Codex P2 ledger persistence: fixed fail-closed.
- Codex P2 stale heartbeat: fixed through the existing serve lifecycle cleanup landed by #1767.

Claim class: installer-dry-run-verified. This does not prove a live install/refresh/restore, installed-build G1, a live DM answer, runtime safety, or G4. No command touched the live owner instance on 8776/8981.