### PR TITLE
viewer: neutral placeholder captions (no art-brief leak) + session-derived "Where last we stood" recap (#1764)

### DIFF
--- a/viewer/openworlds/chrome.jsx
+++ b/viewer/openworlds/chrome.jsx
@@ -285,13 +285,77 @@ function Pill({ children, tone, dot }) {
   return <span className={`pill ${tone || ""} ${dot ? "dot" : ""}`}>{children}</span>;
 }
 
-function Placeholder({ label, w, h, framed, style, children, className }) {
+// #1764: `label` is authored as an ART-DIRECTION BRIEF for the image generator ("cover
+// illustration · 16:9 · painted hero scene") and doubles as the <img> alt text — and it was ALSO
+// printed verbatim inside the empty frame, so a player with no cached art read the generator's
+// notes as UI copy ("There's a note where the picture should be. It says cover illustration, 16
+// by 9, painted hero scene."). Split the two uses: the brief stays on the element as
+// `data-art-brief` (generators and QA read it there, and <Img> still passes it as alt), while the
+// VISIBLE fallback becomes a short neutral SLOT NAME — "Cover art", "Scene art · Crypt". The
+// placeholder mechanism itself is correct design and is untouched.
+const _PH_SLOT_NAMES = {
+  "cover illustration": "Cover art",
+  "illustration": "Cover art",
+  "cover": "Cover art",
+  "vignette": "Scene art",
+  "scene": "Scene art",
+  "chronicle": "Scene art",
+  "backdrop": "Scene art",
+  "sketch": "Sketch",
+  "portrait": "Portrait",
+  "plate": "Plate",
+  "token": "Token",
+  "icon": "Icon",
+  "map": "Map",
+  "seal": "Seal",
+};
+// Aspect ratios are pure art direction and never a subject.
+const _PH_ASPECT_RE = /^\d+\s*[:x×]\s*\d+$/i;
+
+// Turn an art brief into a caption a player can read. Segments are the brief's "·" parts: the
+// first recognised SLOT word names the frame, and at most one SHORT (≤2 words) remaining segment
+// survives as the subject — a longer segment is direction prose ("painted hero scene"), not a
+// name, and is dropped rather than shown.
+function phCaption(label) {
+  const parts = String(label == null ? "" : label)
+    .split("·")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (!parts.length) return "";
+  let slot = "";
+  const rest = [];
+  for (const part of parts) {
+    if (!slot && _PH_SLOT_NAMES[part.toLowerCase()]) { slot = _PH_SLOT_NAMES[part.toLowerCase()]; continue; }
+    rest.push(part);
+  }
+  let subject = "";
+  for (const part of rest) {
+    if (_PH_ASPECT_RE.test(part)) continue;
+    if (part.split(/\s+/).length > 2) continue;
+    subject = part.charAt(0).toUpperCase() + part.slice(1);
+    break;
+  }
+  if (slot) {
+    const full = subject ? `${slot} · ${subject}` : slot;
+    // A caption that merely replays a multi-part brief has not de-briefed anything — the frame
+    // would still read as the generator's note. Keep the slot name alone in that case.
+    if (parts.length > 1 && full.toLowerCase() === String(label).trim().toLowerCase()) return slot;
+    return full;
+  }
+  // No slot word — a bare display name ("Longsword", "Aidan · full art"): show the name alone.
+  return subject;
+}
+
+function Placeholder({ label, caption, w, h, framed, style, children, className }) {
+  const brief = label == null ? "" : String(label);
+  const text = caption != null ? caption : phCaption(brief);
   return (
     <div
       className={`placeholder ${framed ? "framed" : ""} ${className || ""}`}
       style={{ width: w, height: h, ...(style || {}) }}
+      data-art-brief={brief || undefined}
     >
-      {children || <span className="ph-label">{label}</span>}
+      {children || (text ? <span className="ph-label">{text}</span> : null)}
     </div>
   );
 }
@@ -626,5 +690,5 @@ function TitleBar({ campaign, location, day, capability, nativeStatus }) {
 Object.assign(window, {
   NAV_GROUPS, NAV_BOTTOM, ALL_NAV, getGroupForScreen, getDefaultScreen,
   Glyph, CornerOrnament, Divider, SectionTitle, Pill,
-  Placeholder, Img, IconPlate, BrassButton, Panel, NavRail, TabBar, CapabilityBadge, TitleBar,
+  Placeholder, phCaption, Img, IconPlate, BrassButton, Panel, NavRail, TabBar, CapabilityBadge, TitleBar,
 });

--- a/viewer/openworlds/screen-launcher.jsx
+++ b/viewer/openworlds/screen-launcher.jsx
@@ -354,7 +354,7 @@ function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" })
                   </div>
 
                   {/* Recap with side sketch */}
-                  <SectionTitle ordinal="·">Where last we stood</SectionTitle>
+                  <SectionTitle ordinal="·">{c.recapLabel || "Where last we stood"}</SectionTitle>
                   <div style={{ display: "grid", gridTemplateColumns: "100px 1fr", gap: 14, alignItems: "start" }}>
                     <div style={{ transform: "rotate(-2deg)" }}>
                       <Img scope={c.imageScope || ""} label="sketch · last scene" w={100} h={120} framed fit="cover" />

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -6982,6 +6982,50 @@ def _relative_time_label(ts: float, *, now: float) -> str:
     return time.strftime("%Y-%m-%d", time.localtime(ts))
 
 
+# #1764: how much of the last beat the launcher's "Where last we stood" card carries. A recap is a
+# reminder, not the chronicle — the full beat is one click away on the table's history band.
+_RECAP_MAX = 240
+# Session-log kinds whose text is a beat rather than a mechanism dump.
+_RECAP_NARRATION_KINDS = ("narration", "scene", "dm")
+
+
+def _recap_snip(text: str) -> str:
+    """One short, player-facing snip of a beat, always cut on a word boundary."""
+    flat = " ".join(str(text or "").split())
+    if len(flat) <= _RECAP_MAX:
+        return flat
+    head = flat[:_RECAP_MAX]
+    cut = head.rfind(" ")
+    return (head[:cut] if cut > 0 else head).rstrip() + "\u2026"
+
+
+def _session_derived_recap(campaign_dir: Path, snapshot: dict) -> str:
+    """The chronicle's OWN last words, read from the session log (#1764).
+
+    The launcher used to print ``snapshot["summary"]``, which for a seeded campaign is the
+    AUTHORING blurb — so a player twelve beats into a crypt read the harness's own wording back.
+    Prefer the tail of the campaign's session log (the same read-only projection the chronicle
+    band uses): the last narration beat, else the last event of any kind. Returns "" when there
+    is no session history at all, which is the caller's signal to fall back to the fixture.
+    """
+    rows = _session_event_tail_from_dir(campaign_dir, snapshot, limit=24)
+    narration = ""
+    latest = ""
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        kind = _text(row.get("kind") or row.get("type"), "narration").lower()
+        text = _text(row.get("text") or row.get("detail") or row.get("summary"))
+        if not text:
+            continue
+        snip = _recap_snip(text)
+        speaker = _text(row.get("speaker") or row.get("label") or row.get("who"))
+        latest = f"{speaker}: \u201c{snip}\u201d" if kind == "dialogue" and speaker else snip
+        if kind in _RECAP_NARRATION_KINDS:
+            narration = snip
+    return narration or latest
+
+
 def _infer_catalog_provider(state_root: Path, source: str) -> str:
     if source == "qa":
         return "QA"
@@ -7028,14 +7072,24 @@ def build_openworlds_campaign_summary(
     source_label = "QA run" if source == "qa" else "Play save"
     where = location or world
     subtitle = f"{source_label} · {where}" if where else source_label
-    recap = _text(snapshot.get("summary"))
-    if not recap:
-        if active_quests:
-            recap = f"{active_quests} active quest{'s' if active_quests != 1 else ''} remain in motion."
-        elif location:
-            recap = f"The party is gathered near {location}."
-        else:
-            recap = "This chronicle is ready to continue."
+    # #1764: "Where last we stood" is a SESSION recap. Prefer what the party actually did; the
+    # seed's `summary` is authoring copy and is shown only for a chronicle nobody has played yet.
+    sessions = _session_count(campaign_dir)
+    recap = _session_derived_recap(campaign_dir, snapshot)
+    if recap or sessions:
+        recap_source = "session"
+        if not recap:
+            # Played, but the tail carried no projectable prose — still never the seed blurb.
+            if active_quests:
+                recap = f"{active_quests} active quest{'s' if active_quests != 1 else ''} remain in motion."
+            elif location:
+                recap = f"The party is gathered near {location}."
+            else:
+                recap = "This chronicle is ready to continue."
+    else:
+        recap_source = "fixture"
+        recap = _text(snapshot.get("summary")) or "This chronicle has not been opened yet."
+    recap_label = "Where last we stood" if recap_source == "session" else "New campaign"
 
     resume_url = f"/openworlds/?campaign={quote(campaign_id)}" if can_resume else ""
     legacy_dashboard_url = f"/dashboard?campaign={quote(campaign_id)}" if can_resume else ""
@@ -7051,7 +7105,7 @@ def build_openworlds_campaign_summary(
         "chapter": str(snapshot.get("day") or "I"),
         "lastPlayed": _relative_time_label(last_played, now=now),
         "last_played": last_played,
-        "sessions": _session_count(campaign_dir),
+        "sessions": sessions,
         "region": location or world,
         "day": day,
         "world": world,
@@ -7072,6 +7126,8 @@ def build_openworlds_campaign_summary(
         "legacyDashboardUrl": legacy_dashboard_url,
         "monitorUrl": "/monitor",
         "recap": recap,
+        "recapSource": recap_source,
+        "recapLabel": recap_label,
     }
 
 

--- a/viewer/tests/test_launcher_recap_source.py
+++ b/viewer/tests/test_launcher_recap_source.py
@@ -1,0 +1,125 @@
+"""#1764 (B): "Where last we stood" must show the SESSION, not the seed's fixture blurb.
+
+The launcher's chronicle detail card projected `snapshot["summary"]` verbatim — for a seeded
+campaign that is the AUTHORING blurb, so a player twelve beats into a crypt read
+"A five-room quest loop: camp hub <-> tavern … The A-series adventure-eval fixture." with the
+ASCII arrows and the harness wording included. The engine already writes the session log the
+chronicle band reads; the launcher simply never used it.
+
+These tests exercise the real `build_openworlds_campaign_summary` (the code path behind
+/openworlds/campaigns.json) against a hand-written campaign dir:
+
+  • a PLAYED campaign recaps its own last beat and never the fixture summary;
+  • a NEVER-PLAYED campaign still falls back to the summary, labelled "New campaign".
+
+stdlib-only, no engine process; the viewer only READS (engine stays sole writer).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server_recap_source", _SERVER_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+server = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(server)
+
+FIXTURE_SUMMARY = (
+    "A five-room quest loop: camp hub <-> tavern (Keeper Maera) <-> shop, and camp <-> crypt "
+    "(goblins) <-> throne hall (the Goblin Boss). The A-series adventure-eval fixture."
+)
+LAST_BEAT = (
+    "The slate-carrier drops its burden and the crypt goes loud; an arrow takes you high on the "
+    "left shoulder as the green lamp gutters."
+)
+
+
+def _snapshot(*, session_id: str | None) -> dict:
+    snap = {
+        "id": "adventure_demo_v1",
+        "world_id": "adventure-demo",
+        "title": "The Crypt Below",
+        "summary": FIXTURE_SUMMARY,
+        "day": 1,
+        "time_of_day": "afternoon",
+        "party": ["pc1"],
+        "characters": {"pc1": {"id": "pc1", "name": "Aidan", "kind": "player"}},
+        "current_location_id": "crypt",
+        "locations": {"crypt": {"id": "crypt", "name": "The Crypt"}},
+        "quests": {"q1": {"id": "q1", "status": "active", "title": "Clear the crypt"}},
+    }
+    if session_id:
+        snap["active_session_id"] = session_id
+        snap["session_ids"] = [session_id]
+    return snap
+
+
+class LauncherRecapSourceTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+
+    def _campaign_dir(self, *, played: bool) -> tuple[Path, dict]:
+        cdir = self._tmp / "campaigns" / "adventure_demo_v1"
+        (cdir / "sessions").mkdir(parents=True, exist_ok=True)
+        sid = "session-f8a9a52f" if played else None
+        snap = _snapshot(session_id=sid)
+        (cdir / "snapshot.json").write_text(json.dumps(snap), encoding="utf-8")
+        if played:
+            rows = [
+                {"t": 1788350000.0, "kind": "system", "text": "Session 1 began: The Crypt Below",
+                 "speaker": None, "payload": None},
+                {"t": 1788350100.0, "kind": "narration", "text": LAST_BEAT,
+                 "speaker": None, "payload": None},
+                {"t": 1788350200.0, "kind": "combat", "text": "Aidan rolls a death save: pending.",
+                 "speaker": "Aidan", "payload": {"event": "death_save"}},
+            ]
+            (cdir / "sessions" / f"{sid}.jsonl").write_text(
+                "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8"
+            )
+        return cdir, snap
+
+    def _summary(self, *, played: bool) -> dict:
+        cdir, snap = self._campaign_dir(played=played)
+        return server.build_openworlds_campaign_summary(
+            "play",
+            "run-1",
+            "adventure_demo_v1",
+            snap,
+            campaign_dir=cdir,
+            state_root=self._tmp,
+            last_played=time.time(),
+            current=True,
+            can_resume=True,
+            now=time.time(),
+        )
+
+    def test_played_campaign_never_shows_the_fixture_summary(self):
+        """The seed's authoring blurb must not reach a player who has played (#1764)."""
+        row = self._summary(played=True)
+        self.assertNotIn("adventure-eval fixture", row["recap"])
+        self.assertNotIn("<->", row["recap"])
+        self.assertNotEqual(row["recap"], FIXTURE_SUMMARY)
+
+    def test_played_campaign_recaps_its_own_session_history(self):
+        """The recap is derived from the session log's last narration beat."""
+        row = self._summary(played=True)
+        self.assertIn("slate-carrier", row["recap"])
+        self.assertEqual(row["recapSource"], "session")
+        self.assertEqual(row["recapLabel"], "Where last we stood")
+
+    def test_never_played_campaign_falls_back_to_the_summary_as_new(self):
+        """With no session history the fixture summary is still shown — labelled New campaign."""
+        row = self._summary(played=False)
+        self.assertEqual(row["recap"], FIXTURE_SUMMARY)
+        self.assertEqual(row["recapSource"], "fixture")
+        self.assertEqual(row["recapLabel"], "New campaign")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -1366,7 +1366,14 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertEqual(campaign["dashboardUrl"], "/openworlds/?campaign=camp_live")
         self.assertEqual(campaign["legacyDashboardUrl"], "/dashboard?campaign=camp_live")
         self.assertEqual([p["name"] for p in campaign["party"]], ["Tav", "Jaheira"])
-        self.assertEqual(campaign["recap"], "The party reached the inn and caught its breath.")
+        # #1764: "Where last we stood" is a SESSION recap, so a campaign that HAS a session log
+        # (this fixture writes sessions/sess_1.jsonl) must never be recapped with the seed's
+        # authoring `summary` — the launcher falls back to a session-derived line instead. The
+        # fixture's session row carries no projectable prose, so the quest line is used.
+        self.assertEqual(campaign["recap"], "1 active quest remain in motion.")
+        self.assertEqual(campaign["recapSource"], "session")
+        self.assertEqual(campaign["recapLabel"], "Where last we stood")
+        self.assertNotEqual(campaign["recap"], "The party reached the inn and caught its breath.")
         encoded = json.dumps(campaign)
         self.assertNotIn("private note", encoded)
         self.assertNotIn("hidden agenda", encoded)

--- a/viewer/tests/test_placeholder_caption.py
+++ b/viewer/tests/test_placeholder_caption.py
@@ -1,0 +1,141 @@
+"""#1764 (A): the art-missing placeholder must never print the generator's brief at the player.
+
+`Placeholder`'s `label` prop is authored as an ART-DIRECTION BRIEF for the image generator
+("cover illustration · 16:9 · painted hero scene") and doubles as the <img> alt text — and the
+shipped component rendered it VERBATIM inside the empty frame. The agent playtest caught five
+visible .ph-label spans on the launcher/openworlds screens and the player read them as UI copy:
+"There's a note where the picture should be. It says cover illustration, 16 by 9, painted hero
+scene."
+
+These tests render the REAL shipped `Placeholder` out of chrome.jsx (transpiled with the bundled
+Babel, executed under node's vm — the test_dialogue_npc_header harness) and assert:
+
+  • the visible caption is a short NEUTRAL slot name, never the brief;
+  • no art-direction token (aspect ratio, "painted", "illustration", "vignette") survives to
+    the screen;
+  • the brief is still carried on the element as `data-art-brief`, so generators and QA keep
+    the art direction they need.
+
+Skipped if node is not on PATH.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+OPENWORLDS = HERE.parent / "openworlds"
+CHROME = OPENWORLDS / "chrome.jsx"
+BABEL = OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
+
+# The exact briefs the playtest saw rendered as visible captions (issue #1764), plus the
+# aspect-ratio/direction-laden cover brief that produced the player quote.
+PLAYTEST_BRIEFS = [
+    "cover illustration · 16:9 · painted hero scene",
+    "vignette · crypt",
+    "scene · crypt",
+    "sketch · last scene",
+    "seal",
+    "scene · battlefield",
+    "chronicle · a bloodied slate carried into the dark",
+]
+
+# Words that only ever come from art direction — none may reach a player-visible caption.
+ART_DIRECTION_TOKENS = ["16:9", "painted", "illustration", "vignette", "4:3", "hero scene"]
+
+
+def _node() -> str:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node not on PATH; skipping JS-behavior test")
+    return node
+
+
+def _render_placeholders(briefs: list[str]) -> list[dict]:
+    """Render the real <Placeholder label=…> for each brief; return {caption, brief_attr, props}."""
+    program = (
+        "const fs = require('fs'); const vm = require('vm');\n"
+        + "const Babel = require(%s);\n" % json.dumps(str(BABEL))
+        + "const src = fs.readFileSync(%s, 'utf8');\n" % json.dumps(str(CHROME))
+        + "const code = Babel.transform(src, { presets: ['react'], filename: 'chrome.jsx' }).code;\n"
+        + "function h(type, props, ...children){ return { type: (typeof type==='function'?(type.name||'C'):type),"
+        + " props: props||{}, children: children.flat(Infinity).filter(c=>c!=null) }; }\n"
+        + "const React = { useState:(v)=>[typeof v==='function'?v():v,()=>{}], useRef:()=>({current:null}),"
+        + " useCallback:(f)=>f, useEffect:()=>{}, createElement:h, Fragment:'F' };\n"
+        + "const sb = { React, document:{ addEventListener(){}, removeEventListener(){} } };\n"
+        + "sb.window = sb;\n"
+        + "vm.createContext(sb); vm.runInContext(code, sb);\n"
+        + "const Placeholder = sb.window.Placeholder;\n"
+        + "if (typeof Placeholder !== 'function') throw new Error('Placeholder not exported on window');\n"
+        + "function textOf(n){ if(n==null) return ''; if(typeof n==='string'||typeof n==='number') return String(n);"
+        + " if(Array.isArray(n)) return n.map(textOf).join(''); let s='';"
+        + " if(n.children) s+=n.children.map(textOf).join(''); return s; }\n"
+        + "const briefs = " + json.dumps(briefs) + ";\n"
+        + "const out = briefs.map((label) => { const tree = Placeholder({ label, w: 100, h: 100, framed: true });\n"
+        + "  return { caption: textOf(tree), props: JSON.stringify(tree.props || {}) }; });\n"
+        + "process.stdout.write(JSON.stringify(out));\n"
+    )
+    proc = subprocess.run(
+        [_node(), "--input-type=commonjs"], input=program, text=True, capture_output=True
+    )
+    if proc.returncode != 0:
+        raise AssertionError(f"node failed: {proc.stderr}")
+    return json.loads(proc.stdout)
+
+
+def test_1764_caption_is_never_the_brief():
+    """No rendered caption may repeat the art-direction brief it was fed."""
+    rendered = _render_placeholders(PLAYTEST_BRIEFS)
+    assert len(rendered) == len(PLAYTEST_BRIEFS)
+    for brief, out in zip(PLAYTEST_BRIEFS, rendered):
+        caption = out["caption"]
+        if "\u00b7" not in brief:
+            # A one-word brief ("seal") is already the slot's display name — nothing to leak.
+            continue
+        # A multi-part brief is art direction. Replaying it — whole or in part, and regardless of
+        # casing (.ph-label is lowercased by CSS, so case is no defence) — is the shipped defect.
+        assert brief.lower() not in caption.lower(), (
+            f"the generator brief {brief!r} is printed at the player as {caption!r} (#1764)"
+        )
+        assert caption.strip().lower() != brief.strip().lower(), (
+            f"the caption is still the brief, only re-cased: {caption!r}"
+        )
+
+
+def test_1764_caption_carries_no_art_direction_tokens():
+    """Aspect ratios and direction words ('painted hero scene') never reach the screen."""
+    rendered = _render_placeholders(PLAYTEST_BRIEFS)
+    for brief, out in zip(PLAYTEST_BRIEFS, rendered):
+        low = out["caption"].lower()
+        for token in ART_DIRECTION_TOKENS:
+            assert token not in low, (
+                f"art-direction token {token!r} leaked into the caption {out['caption']!r} "
+                f"(from brief {brief!r})"
+            )
+
+
+def test_1764_caption_is_a_short_neutral_slot_name():
+    """The caption reads as a slot name ('Scene art · Crypt'), not prose."""
+    rendered = _render_placeholders(PLAYTEST_BRIEFS)
+    by_brief = dict(zip(PLAYTEST_BRIEFS, (r["caption"] for r in rendered)))
+    assert by_brief["cover illustration · 16:9 · painted hero scene"] == "Cover art"
+    assert by_brief["vignette · crypt"] == "Scene art · Crypt"
+    assert by_brief["scene · crypt"] == "Scene art · Crypt"
+    assert by_brief["sketch \u00b7 last scene"] == "Sketch"
+    assert by_brief["seal"] == "Seal"
+    for caption in by_brief.values():
+        assert caption, "an art slot must still be captioned (not blank)"
+        assert len(caption) <= 32, f"caption too long to be a slot name: {caption!r}"
+
+
+def test_1764_brief_survives_as_a_data_attribute_for_generators():
+    """The brief is not lost — it stays on the element for the image generators."""
+    rendered = _render_placeholders(PLAYTEST_BRIEFS)
+    for brief, out in zip(PLAYTEST_BRIEFS, rendered):
+        assert brief in out["props"], (
+            f"brief {brief!r} must remain available to generators (data-art-brief); props={out['props']}"
+        )


### PR DESCRIPTION
Closes #1764.

Two viewer defects from the four-lens agent playtest (wf_586299cd), adversarially reproduced on a fresh sandbox before filing.

## (A) The placeholder printed the generator's art brief at the player

`chrome.jsx` `Placeholder` reused the `label` prop — authored as an **art-direction brief** for the image generator, and doubling as the `<img>` alt text — as the visible fallback caption. Wherever art was missing the player read the generator's notes as UI copy:

> "There's a note where the picture should be. It says cover illustration, 16 by 9, painted hero scene."

Five such `.ph-label` spans were visible on the launcher.

**Fix — split the two uses.** The brief stays on the element as `data-art-brief` (generators and QA read it there; `<Img>` still passes it as `alt`), and the visible fallback becomes a short neutral **slot name** via a new `phCaption`:

| brief (unchanged, still the generation hint) | caption the player sees |
|---|---|
| `cover illustration · 16:9 · painted hero scene` | `Cover art` |
| `vignette · crypt` | `Scene art · Crypt` |
| `scene · crypt` | `Scene art · Crypt` |
| `sketch · last scene` | `Sketch` |
| `seal` | `Seal` |

Aspect ratios and any >2-word direction phrase are dropped; a caption that would merely replay a multi-part brief collapses to the slot name alone (case is no defence — `.ph-label` is lowercased by CSS). The placeholder mechanism itself is correct design and is untouched.

## (B) "Where last we stood" showed the seed's fixture blurb, never a session recap

The launcher card printed `snapshot["summary"]` — for a seeded campaign that is **authoring copy**, so a player twelve beats into a crypt read `…camp hub <-> tavern (Keeper Maera) <-> shop… The A-series adventure-eval fixture.` verbatim, ASCII arrows and harness wording included.

`build_openworlds_campaign_summary` now prefers a **session-derived** recap read from the campaign's own session log, via the existing read-only `_session_event_tail_from_dir` projection: the last narration beat, else the last event of any kind, bounded to 240 chars on a word boundary. A *played* campaign whose tail carries no projectable prose falls back to the existing quest/location lines — still never the seed blurb. Only a chronicle with **no** session history shows `summary`, and that row is labelled **"New campaign"** (new `recapSource` / `recapLabel` fields, rendered by `screen-launcher.jsx`).

Live against the QA sandbox (`adventure_demo_v1`), the card now reads:

> The doorway is one stride away. It has a knife, one arm, and nowhere to go — and behind it the light is going out of the cart-track.

The viewer stays a read-only projection; the engine remains sole writer.

## Tests

Red-first on both defects (both suites confirmed failing before the fix):

- `viewer/tests/test_placeholder_caption.py` — renders the **real** shipped `Placeholder` out of `chrome.jsx` through the vendored-Babel/node `vm` harness: a caption may never replay a multi-part brief (case-insensitively) nor carry an art-direction token, must stay ≤32 chars, and the brief must survive as `data-art-brief`.
- `viewer/tests/test_launcher_recap_source.py` — exercises the real `build_openworlds_campaign_summary`: a played campaign recaps its own last beat and never the fixture summary; a never-played one keeps `summary`, labelled `New campaign`.
- `test_openworlds_static`'s recap assertion encoded the old behaviour on a fixture that **has** a session log; updated with the reason inline.

Full viewer suite: **905 passed, 8 skipped**.

## Claim class

`unit-tested-fix` + one eyeballed screenshot. Verified by eye against a viewer run from this worktree on port 8996 over the sandbox state dir (`/tmp/worldos-qa-sandbox/play1/state`, campaign `adventure_demo_v1`) — launcher and play screen both captured. **Does not prove:** anything about generated art itself (the `/image` 404s are the correct null-provider path, not a defect), nor any surface other than the launcher card and the placeholder frames.

### Noted, not fixed (out of scope for this ticket)

The **play screen's** scene blurb and the Encounter card still print the same fixture `summary` (visible in the play-screen capture) — a different surface with a different builder. And the seed itself still ships harness wording ("The A-series adventure-eval fixture") in a player-visible field, which #1764 flags as a separate content fix.