### PR TITLE
agent_play serve: kill in-flight DM tree on stop, pid identity, durable intent consumption + the remaining #1772 gaps

### DIFF
--- a/qa/agent_play.sh
+++ b/qa/agent_play.sh
@@ -124,6 +124,32 @@ ap_kill_tree() {
   for child in $children; do ap_kill_tree "$signal" "$child"; done
   kill -s "$signal" "$pid" 2>/dev/null || true
 }
+ap_tree_identities() {
+  local pid="$1" child children started
+  children="$(pgrep -P "$pid" 2>/dev/null || true)"
+  for child in $children; do ap_tree_identities "$child"; done
+  started="$(ap_pid_lstart "$pid" || true)"
+  [ -n "$started" ] && printf '%s|%s\n' "$pid" "$started"
+}
+ap_identity_live() {
+  local pid="$1" expected="$2" actual
+  ap_pid_live "$pid" || return 1
+  actual="$(ap_pid_lstart "$pid")"
+  [ -n "$actual" ] && [ "$actual" = "$expected" ]
+}
+ap_tree_live() {
+  local identities="$1" pid expected
+  while IFS='|' read -r pid expected; do
+    [ -n "$pid" ] && ap_identity_live "$pid" "$expected" && return 0
+  done <<< "$identities"
+  return 1
+}
+ap_signal_tree() {
+  local signal="$1" identities="$2" pid expected
+  while IFS='|' read -r pid expected; do
+    if [ -n "$pid" ] && ap_identity_live "$pid" "$expected"; then ap_kill_tree "$signal" "$pid"; fi
+  done <<< "$identities"
+}
 
 # ── beat wiring (only `start`/`say`/`serve` need it) ─────────────────────────────────────────────
 ap_bind() {
@@ -257,7 +283,7 @@ os.replace(p+".tmp", p)' "$SESSION" \
     run "$RUN" engine "$ENGINE" state_dir "$state" campaign_id "$cid" \
     quest_title "${WORLDOS_AGENT_PLAY_QUEST:-The Crypt Below}" dm_model "$model" budget "$budget" \
     beats "$beats" beats_used 0 chat_cursor "$chat_cursor" chat_path "$chat_path" \
-    move_cursor "$move_cursor" moves_path "$moves_path" serve_pid "" \
+    move_cursor "$move_cursor" moves_path "$moves_path" serve_pid "" clarifies_used 0 \
     serve_lstart "" \
     dm_session_id "$(python3 -c 'import uuid;print(uuid.uuid4())')" \
     created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" stopped ""
@@ -428,7 +454,7 @@ ap_serve() {
     ap_start
   fi
   ap_bind
-  local max="${MAX_BEATS_IN:-0}" served=0 cursor lines move_cursor move_lines row role text kind move_id label source rc=0 lstart
+  local max="${MAX_BEATS_IN:-0}" served=0 cursor lines move_cursor move_lines row role text kind move_id label source rc=0 lstart clarifies
   label="$max"; [ "$max" -gt 0 ] || label="unlimited"
   trap 'AP_SERVE_STOP=1' TERM INT
   trap 'ap_serve_cleanup' EXIT
@@ -471,7 +497,12 @@ except Exception: print("")')"
       sleep 2 || true
       continue
     fi
-    if [ "$kind" != "clarify" ] && ! ap_budget_available; then
+    clarifies="$(ap_sget clarifies_used 0)"; clarifies="${clarifies:-0}"
+    if [ "$kind" = "clarify" ] && [ "$clarifies" -ge 3 ]; then
+      ap_consume_move "$((move_cursor + 1))" "$row" "$text" "$kind"
+      chatlog dm "[system] you've asked 3 questions this turn — act now; the DM will fill in anything else" '{"system":true}'
+      continue
+    elif [ "$kind" != "clarify" ] && ! ap_budget_available; then
       chatlog dm "[system] $(ap_budget_message)" '{"system":true}'
       rc=2
       break
@@ -479,8 +510,11 @@ except Exception: print("")')"
     echo "[agent-play] player $source: ${text:0:100}"
     if [ "$source" = "chat" ]; then ap_sset chat_cursor "$((cursor + 1))" >/dev/null
     else ap_consume_move "$((move_cursor + 1))" "$row" "$text" "$kind"; fi
+    if [ "$kind" = "clarify" ]; then ap_sset clarifies_used "$((clarifies + 1))" >/dev/null
+    else ap_sset clarifies_used 0 >/dev/null; fi
     if [ "${WORLDOS_AGENT_PLAY_TEST_CRASH_AFTER_CONSUME:-0}" = "1" ]; then kill -KILL "$$"; fi
     if [ "$kind" = "clarify" ]; then ap_do_clarify "$row" || true
+    elif [ "$source" = "chat" ]; then ap_do_beat "$kind" "$text" "" || true; served=$((served + 1))
     else ap_do_beat "$kind" "$text" "$row" || true; served=$((served + 1)); fi
     if [ "$max" -gt 0 ] && [ "$served" -ge "$max" ]; then break; fi
   done
@@ -522,23 +556,25 @@ ap_stop() {
   ap_require_session
   # shellcheck source=lib_beat_driver.sh
   . "$ROOT/qa/lib_beat_driver.sh"
-  local stopped pid i closeout
+  local stopped pid i closeout tree
   STATE_DIR="$(ap_sget state_dir)"
   worldos_stream_tailer_kill_pidfile "$STATE_DIR" 2>/dev/null || true
   stopped="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   ap_sset stopped "$stopped" >/dev/null
   pid="$(ap_sget serve_pid)"
   if ap_serve_owned; then
-    ap_kill_tree TERM "$pid"
+    tree="$(ap_tree_identities "$pid")"
+    ap_signal_tree TERM "$tree"
     i=0
-    while ap_serve_owned; do
-      if [ "$i" -ge 40 ]; then ap_kill_tree KILL "$pid"; fi
+    while ap_tree_live "$tree"; do
+      if [ "$i" -ge 40 ]; then ap_signal_tree KILL "$tree"; fi
       [ "$i" -lt 50 ] || { echo "[agent-play] owned serve pid $pid did not exit" >&2; return 1; }
       sleep 0.1; i=$((i + 1))
     done
   elif [ -n "$pid" ]; then
     echo "[agent-play] stale/unowned serve pid $pid not signaled" >&2
   fi
+  rm -f "$HEARTBEAT" "$STARTING"
   ap_sset serve_pid "" serve_lstart "" >/dev/null
   closeout="$RUN_DIR/closeout.json"
   python3 - "$SESSION" "$RUN_DIR/$RUN.quest_trace.json" "$RUN_DIR/$RUN.dm.*.jsonl" "$closeout" <<'PY'

--- a/qa/agent_play.sh
+++ b/qa/agent_play.sh
@@ -99,9 +99,30 @@ ap_budget_available() {
   fi
 }
 ap_pid_live() {
+  local pid="$1" stat
+  case "$pid" in ""|*[!0-9]*) return 1 ;; esac
+  kill -0 "$pid" 2>/dev/null || return 1
+  stat="$(ps -o stat= -p "$pid" 2>/dev/null || true)"
+  case "$stat" in *Z*) return 1 ;; esac
+  [ -n "$stat" ]
+}
+ap_pid_lstart() {
   local pid="$1"
   case "$pid" in ""|*[!0-9]*) return 1 ;; esac
-  kill -0 "$pid" 2>/dev/null
+  ps -o lstart= -p "$pid" 2>/dev/null | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+ap_serve_owned() {
+  local pid expected actual
+  pid="$(ap_sget serve_pid)"; expected="$(ap_sget serve_lstart)"
+  [ -n "$expected" ] && ap_pid_live "$pid" || return 1
+  actual="$(ap_pid_lstart "$pid")"
+  [ -n "$actual" ] && [ "$actual" = "$expected" ]
+}
+ap_kill_tree() {
+  local signal="$1" pid="$2" child children
+  children="$(pgrep -P "$pid" 2>/dev/null || true)"
+  for child in $children; do ap_kill_tree "$signal" "$child"; done
+  kill -s "$signal" "$pid" 2>/dev/null || true
 }
 
 # ── beat wiring (only `start`/`say`/`serve` need it) ─────────────────────────────────────────────
@@ -142,18 +163,21 @@ ap_bind() {
 # printed to stderr and appended to <run-dir>/dryrun_cmds.log (what the unit test asserts on).
 ap_install_dry_run_turn() {
   adv_dm_turn() {
-    local sid="$1" first="$2" msg="$3" resume=() extra=()
+    local sid="$1" first="$2" msg="$3" resume=() extra=() safe_env=() env_arg
     [ "$first" = "0" ] && resume=(--resume "$sid") || resume=(--session-id "$sid")
     worldos_dm_lean_args "$first" "$CAMPAIGN_ID" "$WORLDOS_LEAN_TAIL"
     if [ "${#WORLDOS_DM_LEAN_SESSION[@]}" -gt 0 ]; then resume=("${WORLDOS_DM_LEAN_SESSION[@]}"); extra=("${WORLDOS_DM_LEAN_EXTRA[@]}"); fi
     worldos_dm_effort_arg "$first"
     worldos_stream_flag_arg
     local cmd
+    for env_arg in "${DUO_ENV[@]}"; do
+      case "$env_arg" in CLAUDE_CODE_OAUTH_TOKEN=*) safe_env+=(CLAUDE_CODE_OAUTH_TOKEN=\<redacted\>) ;; *) safe_env+=("$env_arg") ;; esac
+    done
     # shlex.quote via python3, NOT printf %q: bash 3.2's %q emits raw bytes for non-ASCII and the
     # DM prompt is full of em-dashes — the escaped form must stay valid UTF-8 to be logged/read back.
     # NOTE the \n escaping: the DM prompt is multi-line, and the log is one command per line.
     cmd="$(python3 -c 'import shlex,sys; print(" ".join(shlex.quote(a) for a in sys.argv[1:]).replace(chr(10), chr(92)+"n"))' \
-      timeout "$(worldos_dm_timeout "$first")" "${DUO_ENV[@]}" claude -p "$msg" \
+      timeout "$(worldos_dm_timeout "$first")" "${safe_env[@]}" claude -p "$msg" \
       ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" \
       --strict-mcp-config --model "$WORLDOS_DM_MODEL" ${WORLDOS_DM_EFFORT[@]+"${WORLDOS_DM_EFFORT[@]}"} \
       --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
@@ -234,6 +258,7 @@ os.replace(p+".tmp", p)' "$SESSION" \
     quest_title "${WORLDOS_AGENT_PLAY_QUEST:-The Crypt Below}" dm_model "$model" budget "$budget" \
     beats "$beats" beats_used 0 chat_cursor "$chat_cursor" chat_path "$chat_path" \
     move_cursor "$move_cursor" moves_path "$moves_path" serve_pid "" \
+    serve_lstart "" \
     dm_session_id "$(python3 -c 'import uuid;print(uuid.uuid4())')" \
     created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" stopped ""
   ap_bind
@@ -264,12 +289,21 @@ ap_say() {
   [ -n "$TEXT" ] || { echo "[agent-play] say needs the player text: qa/agent_play.sh say --run $RUN \"…\"" >&2; exit 2; }
   ap_budget_available || exit $?
   ap_bind
-  chatlog player "$TEXT"                     # the viewer's play screen shows the player line too
-  if ap_pid_live "$(ap_sget serve_pid)"; then
+  if ap_serve_owned; then
+    python3 - "$MOVES" "$TEXT" <<'PY'
+import fcntl, json, os, sys
+path, text = sys.argv[1:]
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(path, "a", encoding="utf-8") as handle:
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    handle.write(json.dumps({"role": "player", "kind": "say", "text": text}) + "\n")
+    handle.flush(); os.fsync(handle.fileno())
+PY
     echo "[agent-play] queued for serve"
     return 0
   fi
-  ap_do_beat "$TEXT"; local rc=$?
+  chatlog player "$TEXT"                     # the viewer's play screen shows the player line too
+  ap_do_beat "say" "$TEXT" ""; local rc=$?
   # Keep the `serve` cursor past everything we just wrote, so the two entry points can never
   # double-answer the same line.
   local lines=0; [ -f "$CHAT" ] && lines="$(wc -l < "$CHAT" | tr -d ' ')"
@@ -277,9 +311,9 @@ ap_say() {
   return $rc
 }
 
-# ONE player line -> ONE DM beat (the shared body of `say` and `serve`). $1 = the player's text.
+# ONE player intent -> ONE DM beat. $1=kind $2=display text $3=structured payload (optional).
 ap_do_beat() {
-  local ptext="$1" beat used total dsid prog prev_day prev_tod prev_loc runbook director event_adv
+  local kind="$1" ptext="$2" payload="$3" beat used total dsid prog prev_day prev_tod prev_loc runbook director event_adv action
   used="$(ap_sget beats_used 0)"; total="$(ap_sget beats 20)"
   beat=$((used + 1))
   ap_budget_available || return $?
@@ -291,9 +325,17 @@ ap_do_beat() {
   runbook="$(worldos_runbook_for_beat "$beat" "$total" "$prev_loc" "$STATE_DIR" || true)"
   director="$(worldos_director_advisory "$ROOT" "$STATE_DIR" || true)"
   event_adv="$(worldos_event_advisory "$ROOT" "$STATE_DIR" || true)"
-  ap_beat "$dsid" 0 "The player does:
+  if [ -n "$payload" ]; then
+    action="The player submits this structured move intent exactly as recorded:
+$payload
 
-[say] $ptext
+Honor its top-level kind; do not reinterpret an action as speech."
+  else
+    action="The player does:
+
+[$kind] $ptext"
+  fi
+  ap_beat "$dsid" 0 "$action
 
 Resolve it through the engine (roll/attack/travel as needed), then PLAY the next beat as a full lived scene — any NPC or companion in the scene SPEAKS at least one quoted line; weave the open moment back to the player. Mark quest objectives with complete_objective as they land, and run real combat in the crypt/throne hall.
 
@@ -311,6 +353,18 @@ $event_adv"
   return 0
 }
 
+ap_do_clarify() {
+  local payload="$1" dsid used
+  dsid="$(ap_sget dm_session_id)"; used="$(ap_sget beats_used 0)"
+  ap_beat "$dsid" 0 "The player asks this NON-TURN clarification:
+$payload
+
+Answer only what the character can perceive or know. Do not resolve an action, advance the scene, spend a turn, or advance time. Return concise in-fiction prose or quoted dialogue."
+  ap_record_dm "clarify" || return 1
+  printf '%s\n' "$AP_DM_REPLY"
+  echo "[agent-play] clarify answered | beats=$used/$(ap_sget beats 20)"
+}
+
 # serve — the foreground loop the owner instance's org.worldos.owner-dm LaunchAgent runs. Tails the
 # viewer's chat.jsonl for NEW player lines and answers each with exactly ONE DM beat through the same
 # ap_do_beat path `say` uses. The consumed-line cursor is persisted in the session file, so a restart
@@ -318,7 +372,7 @@ $event_adv"
 AP_SERVE_STOP=0
 ap_serve_cleanup() {
   rm -f "$HEARTBEAT" "$STARTING"
-  [ "$(ap_sget serve_pid)" = "$$" ] && ap_sset serve_pid "" >/dev/null || true
+  [ "$(ap_sget serve_pid)" = "$$" ] && ap_sset serve_pid "" serve_lstart "" >/dev/null || true
 }
 ap_move_text() {
   python3 -c 'import json,sys
@@ -327,10 +381,44 @@ except Exception: raise SystemExit(1)
 if m.get("role") != "player": raise SystemExit(1)
 kind=str(m.get("kind") or "move")
 if isinstance(m.get("x"), int) and isinstance(m.get("y"), int):
-    print(f"[move] walks to ({m[chr(120)]},{m[chr(121)]})")
+    print(f"[{kind}] walks to ({m[chr(120)]},{m[chr(121)]})")
+elif kind == "set_seed_param":
+    force=" force=true" if m.get("force") is True else ""
+    param=json.dumps(m.get("param")); value=json.dumps(m.get("value"))
+    print(f"[{kind}] param={param} value={value}{force}")
 else:
     detail=next((str(m[k]) for k in ("text","name","target","target_id","skill","weapon") if m.get(k) not in (None,"")), "acts")
     print(f"[{kind}] {detail}")'
+}
+ap_move_kind() {
+  python3 -c 'import json,sys
+try: m=json.loads(sys.stdin.read())
+except Exception: raise SystemExit(1)
+if m.get("role") != "player": raise SystemExit(1)
+print(str(m.get("kind") or "move"))'
+}
+ap_consume_move() {
+  local next="$1" row="$2" text="$3" kind="$4"
+  python3 - "$SESSION" "$CHAT" "$MOVES" "$next" "$row" "$text" "$kind" <<'PY'
+import hashlib, json, os, sys
+session_path, chat_path, moves_path, cursor, raw, text, kind = sys.argv[1:]
+move_id = hashlib.sha256(f"{moves_path}:{cursor}:{raw}".encode()).hexdigest()
+seen = False
+try:
+    with open(chat_path, encoding="utf-8") as handle:
+        seen = any((json.loads(line).get("move_id") == move_id) for line in handle if line.strip())
+except (FileNotFoundError, ValueError):
+    pass
+if not seen:
+    with open(chat_path, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps({"role":"player", "text":text, "move_id":move_id, "move_kind":kind}) + "\n")
+        handle.flush(); os.fsync(handle.fileno())
+data = json.load(open(session_path)); data["move_cursor"] = cursor
+tmp = session_path + ".tmp"
+with open(tmp, "w") as handle:
+    json.dump(data, handle, indent=2); handle.flush(); os.fsync(handle.fileno())
+os.replace(tmp, session_path)
+PY
 }
 ap_serve() {
   mkdir -p "$RUN_DIR"; rm -f "$HEARTBEAT"; : > "$STARTING"
@@ -340,11 +428,12 @@ ap_serve() {
     ap_start
   fi
   ap_bind
-  local max="${MAX_BEATS_IN:-0}" served=0 cursor lines move_cursor move_lines row role text label source rc=0
+  local max="${MAX_BEATS_IN:-0}" served=0 cursor lines move_cursor move_lines row role text kind move_id label source rc=0 lstart
   label="$max"; [ "$max" -gt 0 ] || label="unlimited"
   trap 'AP_SERVE_STOP=1' TERM INT
   trap 'ap_serve_cleanup' EXIT
-  ap_sset stopped "" serve_pid "$$" >/dev/null  # a fresh serve un-stops the run and owns its PID
+  lstart="$(ap_pid_lstart "$$")"; [ -n "$lstart" ] || { echo "[agent-play] cannot identify serve process" >&2; return 1; }
+  ap_sset stopped "" serve_pid "$$" serve_lstart "$lstart" >/dev/null
   rm -f "$STARTING"
   echo "[agent-play] serving run=$RUN chat=$CHAT moves=$MOVES campaign=$CAMPAIGN_ID dm=$WORLDOS_DM_MODEL max_beats=$label"
   while [ "$AP_SERVE_STOP" = "0" ]; do
@@ -362,13 +451,19 @@ ap_serve() {
 try: print((json.loads(sys.stdin.read()) or {}).get("role") or "")
 except Exception: print("")')"
       if [ "$role" != "player" ]; then ap_sset chat_cursor "$((cursor + 1))" >/dev/null; continue; fi
+      move_id="$(printf '%s' "$row" | python3 -c 'import json,sys
+try: print((json.loads(sys.stdin.read()) or {}).get("move_id") or "")
+except Exception: print("")')"
+      if [ -n "$move_id" ]; then ap_sset chat_cursor "$((cursor + 1))" >/dev/null; continue; fi
+      kind="say"
       text="$(printf '%s' "$row" | python3 -c 'import json,sys
 try: print((json.loads(sys.stdin.read()) or {}).get("text") or "")
 except Exception: print("")')"
     elif [ "${move_lines:-0}" -gt "$move_cursor" ]; then
       source="move"; row="$(sed -n "$((move_cursor + 1))p" "$MOVES")"
       text="$(printf '%s' "$row" | ap_move_text 2>/dev/null || true)"
-      if [ -z "$text" ]; then ap_sset move_cursor "$((move_cursor + 1))" >/dev/null; continue; fi
+      kind="$(printf '%s' "$row" | ap_move_kind 2>/dev/null || true)"
+      if [ -z "$text" ] || [ -z "$kind" ]; then ap_sset move_cursor "$((move_cursor + 1))" >/dev/null; continue; fi
     else
       if [ "$max" -gt 0 ] && [ "$served" -ge "$max" ]; then break; fi
       # --dry-run DRAINS and exits (a test must not idle forever); the real loop idle-polls at 2s.
@@ -376,19 +471,17 @@ except Exception: print("")')"
       sleep 2 || true
       continue
     fi
-    if ! ap_budget_available; then
+    if [ "$kind" != "clarify" ] && ! ap_budget_available; then
       chatlog dm "[system] $(ap_budget_message)" '{"system":true}'
       rc=2
       break
     fi
     echo "[agent-play] player $source: ${text:0:100}"
-    ap_do_beat "$text" || true
-    served=$((served + 1))
-    # Advance by exactly ONE row: our own dm reply lands at the END of the file and is skipped by the
-    # role check when we reach it. Jumping to the file length here would swallow any player line that
-    # queued up BEHIND the one we just answered.
     if [ "$source" = "chat" ]; then ap_sset chat_cursor "$((cursor + 1))" >/dev/null
-    else ap_sset move_cursor "$((move_cursor + 1))" >/dev/null; fi
+    else ap_consume_move "$((move_cursor + 1))" "$row" "$text" "$kind"; fi
+    if [ "${WORLDOS_AGENT_PLAY_TEST_CRASH_AFTER_CONSUME:-0}" = "1" ]; then kill -KILL "$$"; fi
+    if [ "$kind" = "clarify" ]; then ap_do_clarify "$row" || true
+    else ap_do_beat "$kind" "$text" "$row" || true; served=$((served + 1)); fi
     if [ "$max" -gt 0 ] && [ "$served" -ge "$max" ]; then break; fi
   done
   ap_serve_cleanup
@@ -435,15 +528,18 @@ ap_stop() {
   stopped="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   ap_sset stopped "$stopped" >/dev/null
   pid="$(ap_sget serve_pid)"
-  if ap_pid_live "$pid"; then
-    kill -TERM "$pid"
+  if ap_serve_owned; then
+    ap_kill_tree TERM "$pid"
     i=0
-    while ap_pid_live "$pid" && ! ps -o stat= -p "$pid" 2>/dev/null | grep -q Z; do
-      [ "$i" -lt 50 ] || { echo "[agent-play] serve pid $pid did not exit after SIGTERM" >&2; return 1; }
+    while ap_serve_owned; do
+      if [ "$i" -ge 40 ]; then ap_kill_tree KILL "$pid"; fi
+      [ "$i" -lt 50 ] || { echo "[agent-play] owned serve pid $pid did not exit" >&2; return 1; }
       sleep 0.1; i=$((i + 1))
     done
+  elif [ -n "$pid" ]; then
+    echo "[agent-play] stale/unowned serve pid $pid not signaled" >&2
   fi
-  ap_sset serve_pid "" >/dev/null
+  ap_sset serve_pid "" serve_lstart "" >/dev/null
   closeout="$RUN_DIR/closeout.json"
   python3 - "$SESSION" "$RUN_DIR/$RUN.quest_trace.json" "$RUN_DIR/$RUN.dm.*.jsonl" "$closeout" <<'PY'
 import glob, json, os, sys

--- a/qa/test_agent_play.py
+++ b/qa/test_agent_play.py
@@ -85,7 +85,9 @@ def _pid_live(pid: int) -> bool:
         os.kill(pid, 0)
     except ProcessLookupError:
         return False
-    return True
+    stat = subprocess.run(["ps", "-o", "stat=", "-p", str(pid)], capture_output=True,
+                          text=True, check=False).stdout.strip()
+    return bool(stat) and "Z" not in stat
 
 
 # ── start: session file + chat.jsonl format + the exact dry-run command ────────────────────────
@@ -216,6 +218,8 @@ def test_serve_answers_each_new_player_line_exactly_once(sandbox):
     assert "beats served: 2" in proc.stdout
     cmds = (sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log").read_text().splitlines()
     assert len(cmds) == 3, cmds   # the cold open + one beat per player line
+    assert "[say] I raise my shield." in cmds[1]
+    assert "[say] I call out to the dark." in cmds[2]
 
     roles = [r["role"] for r in _chat_rows(sandbox["state"])]
     assert roles == ["dm", "player", "player", "dm", "dm"], roles
@@ -327,6 +331,31 @@ def test_clarify_answers_without_spending_a_beat_or_ticking_time(sandbox):
     assert "How far is the door?" in (sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log").read_text()
 
 
+def test_serve_caps_consecutive_clarifications_and_resets_after_an_action(sandbox):
+    assert _start(sandbox).returncode == 0
+    moves = sandbox["state"] / "player_moves.jsonl"
+    intents = [
+        {"role": "player", "kind": "clarify", "text": f"Question {index}?"}
+        for index in range(1, 5)
+    ] + [
+        {"role": "player", "kind": "do", "text": "open the door"},
+        {"role": "player", "kind": "clarify", "text": "What is beyond it?"},
+    ]
+    moves.write_text("".join(json.dumps(intent) + "\n" for intent in intents))
+
+    proc = _run(sandbox["tmp"], "serve", "--run", sandbox["run"],
+                "--max-beats", "2", "--dry-run")
+    assert proc.returncode == 0, proc.stderr
+    cmds = (sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log").read_text().splitlines()
+    assert len(cmds) == 6, cmds  # open + 3 clarifies + one action + reset clarify
+    assert not any("Question 4?" in cmd for cmd in cmds)
+    assert "What is beyond it?" in cmds[-1]
+    assert any(row.get("system") and "questions this turn" in row["text"]
+               for row in _chat_rows(sandbox["state"]))
+    session = json.loads(_session_path(sandbox).read_text())
+    assert session["beats_used"] == "1" and session["clarifies_used"] == "1"
+
+
 def test_serve_surfaces_budget_exhaustion_as_dm_system_row(sandbox):
     assert _start(sandbox).returncode == 0
     _patch_session(sandbox, beats_used="4", beats="4")
@@ -380,12 +409,13 @@ def test_stop_terminates_recorded_serve_and_writes_bounded_closeout(sandbox):
             fake_serve.wait(timeout=5)
 
 
-def test_stop_terminates_an_inflight_serve_process_tree(sandbox):
+def test_stop_terminates_a_term_resistant_dm_orphan_and_clears_heartbeat(sandbox):
     assert _start(sandbox).returncode == 0
     child_file = sandbox["tmp"] / "dm-child.pid"
     fake_serve = subprocess.Popen([
         "bash", "-c",
-        f"trap 'exit 0' TERM; value=$(sh -c 'echo $$ > {child_file}; exec sleep 30'); echo \"$value\"",
+        f"bash -c 'trap \"\" TERM; echo $$ > {child_file}; while :; do sleep 1; done' & "
+        "trap 'exit 0' TERM; wait",
     ])
     try:
         deadline = time.monotonic() + 2
@@ -394,6 +424,8 @@ def test_stop_terminates_an_inflight_serve_process_tree(sandbox):
         assert child_file.exists(), "fake DM child never started"
         child_pid = int(child_file.read_text().strip())
         _patch_session(sandbox, serve_pid=str(fake_serve.pid), serve_lstart=_pid_lstart(fake_serve.pid))
+        heartbeat = sandbox["tmp"] / "runs" / sandbox["run"] / "serve.heartbeat"
+        heartbeat.touch()
         proc = _run(sandbox["tmp"], "stop", "--run", sandbox["run"], timeout=10)
         assert proc.returncode == 0, f"{proc.stderr}\n{proc.stdout}"
         fake_serve.wait(timeout=2)
@@ -401,6 +433,7 @@ def test_stop_terminates_an_inflight_serve_process_tree(sandbox):
         while _pid_live(child_pid) and time.monotonic() < deadline:
             time.sleep(0.02)
         assert not _pid_live(child_pid), f"DM child {child_pid} survived stop"
+        assert not heartbeat.exists(), "forced stop left a stale serving marker"
     finally:
         if fake_serve.poll() is None:
             fake_serve.kill()

--- a/qa/test_agent_play.py
+++ b/qa/test_agent_play.py
@@ -13,6 +13,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -73,6 +74,20 @@ def _patch_session(sandbox, **updates) -> dict:
     return session
 
 
+def _pid_lstart(pid: int) -> str:
+    return subprocess.run(
+        ["ps", "-o", "lstart=", "-p", str(pid)], capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def _pid_live(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
 # ── start: session file + chat.jsonl format + the exact dry-run command ────────────────────────
 def test_start_writes_session_and_a_dm_chat_row(sandbox):
     proc = _start(sandbox)
@@ -92,7 +107,8 @@ def test_start_writes_session_and_a_dm_chat_row(sandbox):
     assert set(rows[0]) <= {"role", "text", "engine_logged", "fallback_recovered"}
 
 
-def test_start_dry_run_prints_the_exact_claude_command(sandbox):
+def test_start_dry_run_prints_the_exact_claude_command_without_auth_secret(sandbox, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "unit-test-secret-must-not-be-logged")
     proc = _start(sandbox)
     assert proc.returncode == 0, proc.stderr
     cmds = (sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log").read_text().splitlines()
@@ -104,6 +120,7 @@ def test_start_dry_run_prints_the_exact_claude_command(sandbox):
                    "CLAUDE_CONFIG_DIR=", "--session-id"):
         assert needle.replace(" ", " ") in cmd.replace("\\", ""), f"{needle!r} missing from: {cmd}"
     assert "--max-budget-usd" in cmd
+    assert "unit-test-secret-must-not-be-logged" not in cmd
 
 
 def test_start_seeds_the_quest_trace(sandbox):
@@ -159,11 +176,13 @@ def test_say_queues_without_running_a_beat_when_serve_pid_is_live(sandbox):
     assert _start(sandbox).returncode == 0
     fake_serve = subprocess.Popen(["sleep", "30"])
     try:
-        _patch_session(sandbox, serve_pid=str(fake_serve.pid))
+        _patch_session(sandbox, serve_pid=str(fake_serve.pid), serve_lstart=_pid_lstart(fake_serve.pid))
         proc = _run(sandbox["tmp"], "say", "--run", sandbox["run"], "--dry-run", "I listen.")
         assert proc.returncode == 0, f"{proc.stderr}\n{proc.stdout}"
         assert "queued for serve" in proc.stdout
-        assert [r["role"] for r in _chat_rows(sandbox["state"])] == ["dm", "player"]
+        assert [r["role"] for r in _chat_rows(sandbox["state"])] == ["dm"]
+        queued = [json.loads(line) for line in (sandbox["state"] / "player_moves.jsonl").read_text().splitlines()]
+        assert queued == [{"role": "player", "kind": "say", "text": "I listen."}]
         assert json.loads(_session_path(sandbox).read_text())["beats_used"] == "0"
         assert len((sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log")
                    .read_text().splitlines()) == 1
@@ -217,14 +236,95 @@ def test_serve_consumes_viewer_move_intent_exactly_once(sandbox, monkeypatch):
 
     proc = _run(sandbox["tmp"], "serve", "--run", sandbox["run"], "--max-beats", "1", "--dry-run")
     assert proc.returncode == 0, f"{proc.stderr}\n{proc.stdout}"
-    assert "[move] walks to (3,4)" in (sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log").read_text()
+    assert "walk_to_cell" in (sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log").read_text()
     assert json.loads(_session_path(sandbox).read_text())["move_cursor"] == "1"
+    move_rows = [row for row in _chat_rows(sandbox["state"]) if row.get("move_id")]
+    assert len(move_rows) == 1 and move_rows[0]["text"] == "[walk_to_cell] walks to (3,4)"
     assert len((sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log")
                .read_text().splitlines()) == 2
 
     again = _run(sandbox["tmp"], "serve", "--run", sandbox["run"], "--max-beats", "1", "--dry-run")
     assert again.returncode == 0, again.stderr
     assert "beats served: 0" in again.stdout
+    assert len([row for row in _chat_rows(sandbox["state"]) if row.get("move_id")]) == 1
+
+
+def test_move_is_durably_consumed_before_a_crash_and_not_replayed(sandbox, monkeypatch):
+    assert _start(sandbox).returncode == 0
+    moves = sandbox["state"] / "player_moves.jsonl"
+    moves.write_text(json.dumps({"role": "player", "kind": "do", "text": "raise the portcullis"}) + "\n")
+    monkeypatch.setenv("WORLDOS_AGENT_PLAY_TEST_CRASH_AFTER_CONSUME", "1")
+    crashed = _run(sandbox["tmp"], "serve", "--run", sandbox["run"], "--max-beats", "1", "--dry-run")
+    assert crashed.returncode == -9, f"{crashed.stderr}\n{crashed.stdout}"
+    session = json.loads(_session_path(sandbox).read_text())
+    assert session["move_cursor"] == "1"
+    player_rows = [row for row in _chat_rows(sandbox["state"]) if row["role"] == "player"]
+    assert len(player_rows) == 1 and player_rows[0].get("move_id")
+
+    monkeypatch.delenv("WORLDOS_AGENT_PLAY_TEST_CRASH_AFTER_CONSUME")
+    replay = _run(sandbox["tmp"], "serve", "--run", sandbox["run"], "--max-beats", "1", "--dry-run")
+    assert replay.returncode == 0, replay.stderr
+    assert "beats served: 0" in replay.stdout
+    assert len((sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log").read_text().splitlines()) == 1
+    assert len([row for row in _chat_rows(sandbox["state"]) if row.get("move_id")]) == 1
+
+
+def test_structured_move_kind_reaches_dm_without_say_wrapper(sandbox):
+    assert _start(sandbox).returncode == 0
+    moves = sandbox["state"] / "player_moves.jsonl"
+    moves.write_text(json.dumps({"role": "player", "kind": "attack", "target_id": "goblin-1", "weapon": "sword"}) + "\n")
+    proc = _run(sandbox["tmp"], "serve", "--run", sandbox["run"], "--max-beats", "1", "--dry-run")
+    assert proc.returncode == 0, proc.stderr
+    prompt = (sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log").read_text().splitlines()[-1]
+    assert "attack" in prompt and "goblin-1" in prompt and "sword" in prompt
+    assert "[say] [attack]" not in prompt
+
+
+def test_set_seed_param_payload_is_preserved_for_dm(sandbox):
+    assert _start(sandbox).returncode == 0
+    moves = sandbox["state"] / "player_moves.jsonl"
+    moves.write_text(json.dumps({"role": "player", "kind": "set_seed_param", "param": "difficulty",
+                                 "value": "hard", "force": True}) + "\n")
+    proc = _run(sandbox["tmp"], "serve", "--run", sandbox["run"], "--max-beats", "1", "--dry-run")
+    assert proc.returncode == 0, proc.stderr
+    prompt = (sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log").read_text().splitlines()[-1]
+    for value in ("set_seed_param", "difficulty", "hard", "force"):
+        assert value in prompt
+    assert "[set_seed_param] acts" not in prompt
+
+
+def test_live_say_and_viewer_moves_share_one_arrival_order(sandbox):
+    assert _start(sandbox).returncode == 0
+    moves = sandbox["state"] / "player_moves.jsonl"
+    moves.write_text(json.dumps({"role": "player", "kind": "do", "text": "first move"}) + "\n")
+    fake_serve = subprocess.Popen(["sleep", "30"])
+    try:
+        _patch_session(sandbox, serve_pid=str(fake_serve.pid), serve_lstart=_pid_lstart(fake_serve.pid))
+        queued = _run(sandbox["tmp"], "say", "--run", sandbox["run"], "--dry-run", "second say")
+        assert queued.returncode == 0 and "queued for serve" in queued.stdout
+    finally:
+        fake_serve.terminate()
+        fake_serve.wait(timeout=5)
+    _patch_session(sandbox, serve_pid="", serve_lstart="")
+
+    proc = _run(sandbox["tmp"], "serve", "--run", sandbox["run"], "--max-beats", "2", "--dry-run")
+    assert proc.returncode == 0, proc.stderr
+    prompts = (sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log").read_text().splitlines()[1:]
+    assert len(prompts) == 2 and "first move" in prompts[0] and "second say" in prompts[1]
+
+
+def test_clarify_answers_without_spending_a_beat_or_ticking_time(sandbox):
+    assert _start(sandbox).returncode == 0
+    snapshot = sandbox["state"] / "campaigns" / sandbox["cid"] / "snapshot.json"
+    before = snapshot.read_bytes()
+    moves = sandbox["state"] / "player_moves.jsonl"
+    moves.write_text(json.dumps({"role": "player", "kind": "clarify", "text": "How far is the door?"}) + "\n")
+    proc = _run(sandbox["tmp"], "serve", "--run", sandbox["run"], "--max-beats", "1", "--dry-run")
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(_session_path(sandbox).read_text())["beats_used"] == "0"
+    assert snapshot.read_bytes() == before
+    assert "beats served: 0" in proc.stdout
+    assert "How far is the door?" in (sandbox["tmp"] / "runs" / sandbox["run"] / "dryrun_cmds.log").read_text()
 
 
 def test_serve_surfaces_budget_exhaustion_as_dm_system_row(sandbox):
@@ -259,7 +359,7 @@ def test_status_and_stop(sandbox):
 def test_stop_terminates_recorded_serve_and_writes_bounded_closeout(sandbox):
     assert _start(sandbox).returncode == 0
     fake_serve = subprocess.Popen(["sleep", "30"])
-    _patch_session(sandbox, serve_pid=str(fake_serve.pid))
+    _patch_session(sandbox, serve_pid=str(fake_serve.pid), serve_lstart=_pid_lstart(fake_serve.pid))
     try:
         proc = _run(sandbox["tmp"], "stop", "--run", sandbox["run"])
         assert proc.returncode == 0, f"{proc.stderr}\n{proc.stdout}"
@@ -278,3 +378,49 @@ def test_stop_terminates_recorded_serve_and_writes_bounded_closeout(sandbox):
         if fake_serve.poll() is None:
             fake_serve.terminate()
             fake_serve.wait(timeout=5)
+
+
+def test_stop_terminates_an_inflight_serve_process_tree(sandbox):
+    assert _start(sandbox).returncode == 0
+    child_file = sandbox["tmp"] / "dm-child.pid"
+    fake_serve = subprocess.Popen([
+        "bash", "-c",
+        f"trap 'exit 0' TERM; value=$(sh -c 'echo $$ > {child_file}; exec sleep 30'); echo \"$value\"",
+    ])
+    try:
+        deadline = time.monotonic() + 2
+        while not child_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert child_file.exists(), "fake DM child never started"
+        child_pid = int(child_file.read_text().strip())
+        _patch_session(sandbox, serve_pid=str(fake_serve.pid), serve_lstart=_pid_lstart(fake_serve.pid))
+        proc = _run(sandbox["tmp"], "stop", "--run", sandbox["run"], timeout=10)
+        assert proc.returncode == 0, f"{proc.stderr}\n{proc.stdout}"
+        fake_serve.wait(timeout=2)
+        deadline = time.monotonic() + 2
+        while _pid_live(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert not _pid_live(child_pid), f"DM child {child_pid} survived stop"
+    finally:
+        if fake_serve.poll() is None:
+            fake_serve.kill()
+            fake_serve.wait(timeout=5)
+
+
+def test_recycled_pid_identity_neither_defers_say_nor_gets_signaled_by_stop(sandbox):
+    assert _start(sandbox).returncode == 0
+    unrelated = subprocess.Popen(["sleep", "30"])
+    try:
+        _patch_session(sandbox, serve_pid=str(unrelated.pid), serve_lstart="definitely-not-this-process")
+        say = _run(sandbox["tmp"], "say", "--run", sandbox["run"], "--dry-run", "I act now.")
+        assert say.returncode == 0, say.stderr
+        assert "queued for serve" not in say.stdout
+        assert json.loads(_session_path(sandbox).read_text())["beats_used"] == "1"
+
+        _patch_session(sandbox, serve_pid=str(unrelated.pid), serve_lstart="definitely-not-this-process")
+        stop = _run(sandbox["tmp"], "stop", "--run", sandbox["run"])
+        assert stop.returncode == 0, stop.stderr
+        assert unrelated.poll() is None, "stop signaled an unrelated recycled PID"
+    finally:
+        unrelated.terminate()
+        unrelated.wait(timeout=5)


### PR DESCRIPTION
Closes the seven dual-input `serve` gaps tracked in #1772.

## What changed

- stop verifies persisted PID start times, tracks every owned descendant through TERM/KILL, and clears serving markers before its bounded wait expires
- live `say` and viewer intents share the move queue, preserving arrival order
- move consumption appends one idempotent player transcript row and persists the cursor before the DM beat
- structured kinds and complete `set_seed_param` payloads reach the DM unchanged
- `clarify` answers without spending a beat or soft-ticking time, with a durable three-question consecutive cap that resets after an action
- dry-run command receipts redact inherited auth values

## Red-first proof

The new cases failed against the pre-fix implementation for process-tree cancellation, recycled PID refusal, crash replay, transcript durability, structured routing, seed payloads, queue ordering, and non-turn clarification. The single review round's focused regressions also failed red for chat `say` routing, clarification-call capping, TERM-resistant orphan cleanup, and stale heartbeat cleanup.

## Validation

- `uv run --directory servers/engine python -m pytest /Users/m1/worldos-wt-1772/qa/test_agent_play.py /Users/m1/worldos-wt-1772/qa/test_quest_progress.py /Users/m1/worldos-wt-1772/qa/test_owner_install.py -q -p no:xdist` — 64 passed
- `/Users/m1/worldos-wt-1772/qa/fast_gate.sh` — 257 passed
- `bash -n qa/agent_play.sh` — passed
- non-test delta: 190 changed lines, below the 220-line lane cap

## Proof boundary

Claim class: `unit-tested-fix`. No live DM beat, installed owner refresh, LaunchAgent mutation, runtime, built-app, release, or customer proof was performed.
