### PR TITLE
combat surface: stage tokens always emitted during combat with in-bounds cells + hp/turn fields (#1752); placement truth in the projection (#1751)

### DIFF
--- a/servers/engine/tests/test_combat_surface_stage_contract.py
+++ b/servers/engine/tests/test_combat_surface_stage_contract.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import os
 import sys
 from pathlib import Path
 
@@ -219,3 +218,39 @@ def test_in_bounds_holds_on_the_real_painted_crypt(painted_crypt_fight):
     assert all(0 <= x < cols and 0 <= y < rows for x, y in cells), (cells, cols, rows)
     assert len(set(cells)) == len(cells), cells
     assert {(t["x"], t["y"]) for t in surface["stage"]["tokens"]} >= set(cells)
+
+
+def test_zone_derived_cells_are_walkable_on_the_canonical_crypt(painted_crypt_fight):
+    """#1751 REGRESSION (PR #1778 bot round, P1): clamping to the board is NOT enough. The canonical
+    walkslice crypt is 14x11, and the zone layout's fourth bucket yields x=15/16 — which a pure
+    clamp maps to column 13, the east PERIMETER WALL. The reported ghost would become in-bounds and
+    stay inside the wall, and both of that bucket's occupants would collapse onto column 13.
+
+    Placement must therefore resolve onto a free WALKABLE cell using the collision set the surface
+    itself publishes, not merely clamp coordinates. Asserted against `impassable` — the same field
+    the client renders collision from, so the two pictures cannot drift."""
+    cid, crypt, pc, foes = painted_crypt_fight
+    surface = _surface(cid)
+    cols, rows = surface["grid"]["cols"], surface["grid"]["rows"]
+    assert (cols, rows) == (14, 11), "the canonical crypt the bot's counter-example cites"
+    blocked = {(int(x), int(y)) for x, y in surface["impassable"]}
+    assert blocked, "the fixture must actually publish a collision set, or this proves nothing"
+    for tok in surface["tokens"] + surface["stage"]["tokens"]:
+        cell = (tok["x"], tok["y"])
+        assert cell not in blocked, f"{tok['name']} placed inside a wall/prop at {cell}"
+        assert 0 <= cell[0] < cols and 0 <= cell[1] < rows, f"{tok['name']} off-grid at {cell}"
+    cells = [(t["x"], t["y"]) for t in surface["tokens"]]
+    assert len(set(cells)) == len(cells), f"two combatants collapsed onto one cell: {cells}"
+
+
+def test_downed_combatant_gets_the_down_pose_at_exactly_zero_hp(crypt_fight):
+    """#1752 REGRESSION (PR #1778 bot round, P2): the pose used `(_num(hp) or 1) <= 0`, which turns
+    a VALID 0 into 1 — so an actor at exactly 0 HP (the downed case the pose exists for) rendered
+    `idle` while its own `hp` field on the same token read 0."""
+    cid, crypt, pc, foes = crypt_fight
+    c = server._require(cid)
+    c.characters[pc].current_hp = 0
+    server.save_campaign(c)
+    stage = {t["id"]: t for t in _surface(cid)["stage"]["tokens"]}
+    assert stage[pc]["hp"] == 0
+    assert stage[pc]["pose"] == "down", "0 HP is downed, not idle"

--- a/servers/engine/tests/test_combat_surface_stage_contract.py
+++ b/servers/engine/tests/test_combat_surface_stage_contract.py
@@ -1,0 +1,221 @@
+"""#1752 / #1751 — the COMBAT-SURFACE SEAM: an active fight must be visible on the rendered stage,
+and no combatant may be placed off the board.
+
+This is a CONTRACT test across the engine→viewer seam, not a unit test of either side: it seeds a
+real campaign on the REAL v2 walkslice crypt grid (16x12, the room both issues were filed against),
+starts combat through the REAL ``server.start_combat``, dumps the engine-owned snapshot, and feeds
+that snapshot to the REAL ``viewer/server.py::build_combat_surface``. No mock stands in for either
+half — the two bugs both lived exactly in the gap between them:
+
+  * #1752 — ``stage.tokens`` was hardcoded EMPTY in combat mode, so the Unity client (which renders
+    the world FROM the stage) kept the last rest frame: 11+ identical frames while the engine ran a
+    whole boss fight, no HP bars, no turn marker.
+  * #1751 — ``start_combat`` flipped the fight onto the room's grid but placed NOBODY, so the
+    surface synthesised a zone layout on a legacy 16x10 board and put an actor at column 16 of a
+    16-column crypt — the hero rendered as a ghost inside the east wall.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_QA = str(_REPO / "qa")
+if _QA not in sys.path:
+    sys.path.insert(0, _QA)
+
+import server  # noqa: E402  (conftest puts servers/engine on the path; import first — models
+                # resolves its SceneGrid forward ref at the END of its own module body)
+import scene_grid as sg  # noqa: E402  (the engine's own SceneGrid model)
+import seed_gfx_walkslice as ws  # noqa: E402  (the canonical painted-room grids)
+import store  # noqa: E402
+
+# The room both issues were filed against: a 16-column, 12-row crypt whose LAST cell is (15, 11).
+COLS, ROWS = 16, 12
+STAGE_CELLS = [(6, 1), (1, 1), (4, 5), (3, 8)]  # PC + 3 goblins, as G4 found them at rest
+
+
+def _room_16x12(loc_id: str) -> sg.SceneGrid:
+    """A painted 16x12 room: solid border walls, an interior pillar, authored spawn buckets."""
+    walls = [(c, r) for c in range(COLS) for r in range(ROWS)
+             if c in (0, COLS - 1) or r in (0, ROWS - 1)]
+    return sg.SceneGrid(
+        scene_id=f":{loc_id}",
+        location_id=loc_id,
+        grid=sg.SceneGridSpec(cols=COLS, rows=ROWS),
+        cells=[sg.SceneCell(c=c, r=r, type="wall", walkable=False) for c, r in walls],
+        props=[sg.SceneProp(id="pillar", kind="pillar", cells=[(8, 4), (8, 5)],
+                            anchor_cell=(8, 4), occluder=True)],
+        spawns={"party": [(7, 9), (8, 9)], "foes": [(6, 2), (9, 3)], "npcs": [(2, 9)]},
+    )
+
+
+def _viewer():
+    """The REAL viewer surface builder, loaded by path (viewer/server.py is stdlib-only at import)
+    — the same module the HTTP handler calls, so this test cannot pass against a mock."""
+    spec = importlib.util.spec_from_file_location(
+        "viewer_server_stage_contract", _REPO / "viewer" / "server.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _seed_fight(tmp_path, monkeypatch, *, grid_for, stage_cells):
+    """A PC + three goblins in a painted room, combat STARTED through the engine — the exact shape
+    agent G4 drove in the adventure_demo_v1 sandbox."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("combat-surface-stage")["id"]
+    crypt = server.add_location(campaign_id=cid, name="Crypt", make_current=True)["id"]
+    pc = server.create_character(cid, "Aidan", kind="player", max_hp=28,
+                                 add_to_party=True, location_id=crypt)["id"]
+    foes = [m["id"] for m in
+            server.spawn_monster(campaign_id=cid, name="Goblin", count=3)["spawned"]]
+    c = server._require(cid)
+    c.locations[crypt].scene_grid = grid_for(crypt)
+    if stage_cells:
+        c.characters[pc].stage_cell = stage_cells[0]
+    for fid, cell in zip(foes, (stage_cells or [None] * 4)[1:]):
+        c.characters[fid].location_id = crypt
+        c.characters[fid].stage_cell = cell
+    server.save_campaign(c)
+    server.start_combat(cid, [pc] + foes)
+    return cid, crypt, pc, foes
+
+
+@pytest.fixture
+def crypt_fight(tmp_path, monkeypatch):
+    return _seed_fight(tmp_path, monkeypatch, grid_for=_room_16x12, stage_cells=STAGE_CELLS)
+
+
+@pytest.fixture
+def painted_crypt_fight(tmp_path, monkeypatch):
+    """The SAME fight on the real v2 walkslice crypt grid — proves the placement rule holds on an
+    authored room (props, pilasters, a sarcophagus), not just the synthetic one."""
+    return _seed_fight(tmp_path, monkeypatch, grid_for=ws.build_crypt_grid, stage_cells=None)
+
+
+def _snapshot(cid: str) -> dict:
+    return json.loads((store._campaign_dir(cid) / "snapshot.json").read_text())
+
+
+def _surface(cid: str) -> dict:
+    return _viewer().build_combat_surface(
+        _snapshot(cid), campaign_id=cid, live=False, is_live_view=False, recent_events=[]
+    )
+
+
+def test_every_combatant_gets_a_distinct_in_bounds_walkable_cell(crypt_fight):
+    """#1751 PLACEMENT, asserted where placement is actually DECIDED. ``start_combat`` leaves a
+    combatant's tactical cell unset unless it is explicitly seeded, so the cell the player SEES is
+    the one the surface derives — and that derivation is what put an actor at column 16 of a
+    16-column board. A 16x12 room with 4 combatants: every surfaced cell is in-bounds, walkable,
+    and unique."""
+    cid, crypt, pc, foes = crypt_fight
+    surface = _surface(cid)
+    cols, rows = surface["grid"]["cols"], surface["grid"]["rows"]
+    assert (cols, rows) == (COLS, ROWS), "the fixture is the 16x12 room both issues cite"
+    blocked = {(int(x), int(y)) for x, y in surface["impassable"]}
+    cells = [(t["x"], t["y"]) for t in surface["tokens"]]
+    assert len(cells) == 4
+    for tok in surface["tokens"]:
+        cell = (tok["x"], tok["y"])
+        assert 0 <= cell[0] < cols, f"{tok['name']} at column {cell[0]} of {cols}"
+        assert 0 <= cell[1] < rows, f"{tok['name']} at row {cell[1]} of {rows}"
+        assert cell not in blocked, f"{tok['name']} rendered inside a wall/prop at {cell}"
+    assert len(set(cells)) == len(cells), f"two combatants share a cell: {cells}"
+
+
+def test_the_fight_opens_where_everyone_stood(crypt_fight):
+    """#1751 NO TELEPORT: with no engine-seeded tactical cells, the surface derives each token's
+    cell from the engine's own rest position (``Character.stage_cell``) rather than a synthesized
+    zone slot — so the rendered frame does not jump the instant initiative is rolled."""
+    cid, crypt, pc, foes = crypt_fight
+    surface = _surface(cid)
+    board = {t["id"]: (t["x"], t["y"]) for t in surface["tokens"]}
+    assert [board[c] for c in [pc] + foes] == STAGE_CELLS
+    # ...and the stage the client renders agrees with the board, cell for cell.
+    stage = {t["id"]: (t["x"], t["y"]) for t in surface["stage"]["tokens"]}
+    assert [stage[c] for c in [pc] + foes] == STAGE_CELLS
+
+
+def test_stage_lists_every_living_combatant_in_bounds(crypt_fight):
+    """#1752 THE SEAM: the surface a live fight produces carries a stage token for EVERY living
+    combatant, every one inside the board it declares. An empty stage here is the frozen frame."""
+    cid, crypt, pc, foes = crypt_fight
+    surface = _surface(cid)
+    assert surface["encounter"]["active"] is True
+    stage = surface["stage"]
+    assert stage["mode"] == "combat"
+    living = [cb.character_id for cb in server._require(cid).combat.order]
+    assert len(stage["tokens"]) >= len(living), "the fight must not be invisible on the stage"
+    by_id = {t["id"]: t for t in stage["tokens"]}
+    for combatant in living:
+        assert combatant in by_id, f"{combatant} is fighting but absent from the rendered stage"
+    cols, rows = surface["grid"]["cols"], surface["grid"]["rows"]
+    for tok in stage["tokens"]:
+        assert 0 <= tok["x"] < cols, f"{tok['name']} at column {tok['x']} of {cols}"
+        assert 0 <= tok["y"] < rows, f"{tok['name']} at row {tok['y']} of {rows}"
+
+
+def test_no_surface_token_is_off_grid(crypt_fight):
+    """#1751 at the surface: the tactical board's own tokens are in-bounds too (this is the exact
+    assertion that fails on the reported build, where a goblin surfaced at x=16 of 16)."""
+    surface = _surface(crypt_fight[0])
+    cols, rows = surface["grid"]["cols"], surface["grid"]["rows"]
+    for tok in surface["tokens"]:
+        assert 0 <= tok["x"] < cols, f"{tok['name']} at column {tok['x']} of {cols}"
+        assert 0 <= tok["y"] < rows, f"{tok['name']} at row {tok['y']} of {rows}"
+
+
+def test_stage_tokens_carry_the_hud_fields(crypt_fight):
+    """#1752 "nothing tells me I'm dying": every stage token carries team + turn + vitals, so an
+    HP bar and a turn marker are drawable from the stage alone. Foe HP keeps the combat board's
+    disclosure rule (a public health band, no raw numbers until the party earns them)."""
+    cid, crypt, pc, foes = crypt_fight
+    stage = _surface(cid)["stage"]
+    by_id = {t["id"]: t for t in stage["tokens"]}
+    hero = by_id[pc]
+    assert hero["team"] == "ally"
+    assert (hero["hp"], hero["max_hp"]) == (28, 28)
+    assert hero["health"] == "steady"
+    goblin = by_id[foes[0]]
+    assert goblin["team"] == "foe"
+    assert goblin["hp_known"] is False and goblin["hp"] is None
+    assert goblin["health"] in {"steady", "wounded", "bloodied", "down"}
+    turns = [t["id"] for t in stage["tokens"] if t.get("is_turn")]
+    assert len(turns) == 1, f"exactly one token holds the turn marker, got {turns}"
+    assert turns[0] == server._require(cid).combat.order[0].character_id
+
+
+def test_stage_projection_is_deterministic_and_read_only(crypt_fight):
+    """Re-emitting the same snapshot is byte-identical, and projecting never writes back — the
+    engine stays the sole writer of every cell the stage renders."""
+    cid = crypt_fight[0]
+    snap = _snapshot(cid)
+    before = json.dumps(snap, sort_keys=True)
+    viewer = _viewer()
+    a = viewer.build_combat_surface(snap, campaign_id=cid, live=False, is_live_view=False,
+                                    recent_events=[])["stage"]
+    b = viewer.build_combat_surface(snap, campaign_id=cid, live=False, is_live_view=False,
+                                    recent_events=[])["stage"]
+    assert a == b
+    assert json.dumps(snap, sort_keys=True) == before
+
+
+def test_in_bounds_holds_on_the_real_painted_crypt(painted_crypt_fight):
+    """The authored v2 walkslice crypt (props, pilasters, a sarcophagus) with NO rest cells at
+    all — the pure zone-derived path, the one that produced column 16. Every surfaced cell is
+    still inside the board, and no two tokens stack."""
+    cid, crypt, pc, foes = painted_crypt_fight
+    surface = _surface(cid)
+    cols, rows = surface["grid"]["cols"], surface["grid"]["rows"]
+    cells = [(t["x"], t["y"]) for t in surface["tokens"]]
+    assert all(0 <= x < cols and 0 <= y < rows for x, y in cells), (cells, cols, rows)
+    assert len(set(cells)) == len(cells), cells
+    assert {(t["x"], t["y"]) for t in surface["stage"]["tokens"]} >= set(cells)

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -2191,6 +2191,41 @@ _DEFAULT_GRID_COLS = 16
 _DEFAULT_GRID_ROWS = 10
 
 
+def _board_extents(snapshot: dict) -> tuple[int, int]:
+    """The RENDERED board's (cols, rows) — the single extent authority every projection on this
+    surface must clamp into. Same precedence ``_scene_grid_block`` publishes: the current
+    location's ``scene_grid`` extents, overridden by an explicit combat grid (the tactical board
+    wins), falling back to the legacy 16x10 default. Read-only.
+
+    #1751: the zone-derived token layout used to clamp to a HARDCODED 16x10 regardless of the
+    board it was drawn on, so a 16-column crypt got a token at column 16 — one past the last
+    cell. Deriving the clamp from the same extents the client renders makes that unrepresentable."""
+    cols, rows = _DEFAULT_GRID_COLS, _DEFAULT_GRID_ROWS
+    loc_id = _text(snapshot.get("current_location_id"))
+    locs = snapshot.get("locations")
+    loc = locs.get(loc_id) if isinstance(locs, dict) and loc_id else None
+    sg = loc.get("scene_grid") if isinstance(loc, dict) else None
+    grid = sg.get("grid") if isinstance(sg, dict) else None
+    if isinstance(grid, dict):
+        c, r = grid.get("cols"), grid.get("rows")
+        if isinstance(c, int) and isinstance(r, int) and c > 0 and r > 0:
+            cols, rows = c, r
+    combat = snapshot.get("combat")
+    if isinstance(combat, dict):
+        cgw, cgh = combat.get("grid_width"), combat.get("grid_height")
+        if isinstance(cgw, int) and isinstance(cgh, int) and cgw > 0 and cgh > 0:
+            cols, rows = cgw, cgh
+    return cols, rows
+
+
+def _clamp_to_board(x: object, y: object, extents: tuple[int, int]) -> tuple[int, int]:
+    """Force a derived cell inside the rendered board (#1751). Preserves cell 0."""
+    cols, rows = extents
+    xi = int(_num(x) or 0)
+    yi = int(_num(y) or 0)
+    return max(0, min(cols - 1, xi)), max(0, min(rows - 1, yi))
+
+
 def _scene_grid_block(snapshot: dict, mode: str) -> dict:
     """The combat board's grid extents (A1). When the party's current location carries an
     engine-authored ``scene_grid``, use ITS extents + cells; otherwise fall back to the
@@ -2808,6 +2843,9 @@ def _combat_display_position(
     zones: list[dict],
     zone_offsets: dict[str, int],
     grid_extents: tuple[int, int] | None = None,
+    board_extents: tuple[int, int] | None = None,
+    character: dict | None = None,
+    claimed: set[tuple[int, int]] | None = None,
 ) -> tuple[int, int, str]:
     # Read the engine's authoritative grid coords. Use a None-coalesce (NOT `or`): a cell of 0
     # is a VALID coordinate (origin column/row), and `x or col` would treat 0 as missing and
@@ -2832,13 +2870,37 @@ def _combat_display_position(
             cy = max(0, min(gh - 1, int(y))) if gh > 0 else int(y)
             return cx, cy, "grid"
         return max(1, min(16, int(x))), max(1, min(10, int(y))), "grid"
+    # #1751 STAND WHERE YOU STOOD: the engine has no tactical coords for this combatant (nothing
+    # placed it — start_combat only seeds cells on an explicit seed_from_stage), but it DOES own
+    # where the actor was standing at rest: Character.stage_cell, the exact cell the rest stage
+    # rendered it on a beat ago. Prefer that over a synthesized zone slot, so the token does not
+    # jump across the room the instant initiative is rolled ("the map lies about where I am").
+    # Still a DERIVED hint — the engine wrote stage_cell, the viewer only reads it, and a fight
+    # that later places the combatant for real overrides this on the branch above.
+    if character is not None and board_extents is not None:
+        sc = character.get("stage_cell")
+        if isinstance(sc, (list, tuple)) and len(sc) == 2:
+            sx, sy = _num(sc[0]), _num(sc[1])
+            if sx is not None and sy is not None:
+                cell = _clamp_to_board(sx, sy, board_extents)
+                # never stack two tokens on one cell — a collision falls through to the zone slot
+                if claimed is None or cell not in claimed:
+                    if claimed is not None:
+                        claimed.add(cell)
+                    return (*cell, "stage")
     zone_name = _text(row.get("zone"))
     zone_index = next((i for i, z in enumerate(zones) if z.get("name") == zone_name), idx)
     offset = zone_offsets.get(zone_name, 0)
     zone_offsets[zone_name] = offset + 1
     base_x = 3 + (zone_index % 4) * 4
     base_y = 3 + (zone_index // 4) * 3
-    return max(1, min(16, base_x + offset)), max(1, min(10, base_y + (offset % 2))), "zone"
+    # #1751: clamp the synthesized zone layout into the board the client actually renders. The
+    # old fixed `min(16, ...)` / `min(10, ...)` was a legacy 16x10 assumption AND off by one (a
+    # 16-column board's last cell is 15) — a fourth zone put its second occupant at column 16,
+    # off-grid, which is exactly the cyan-ghost-in-the-east-wall bug. Cell 0 stays reachable.
+    if board_extents is not None:
+        return (*_clamp_to_board(base_x + offset, base_y + (offset % 2), board_extents), "zone")
+    return max(1, min(15, base_x + offset)), max(1, min(9, base_y + (offset % 2))), "zone"
 
 
 def _combat_tokens(snapshot: dict, combat_view: dict) -> tuple[list[dict], list[dict], list[dict], str, str]:
@@ -2858,6 +2920,11 @@ def _combat_tokens(snapshot: dict, combat_view: dict) -> tuple[list[dict], list[
         gh = _num(_combat_blk.get("grid_height"))
         if isinstance(gw, int) and isinstance(gh, int) and gw > 0 and gh > 0:
             grid_extents = (gw, gh)
+    # #1751: the extents the client actually renders — the clamp authority for the zone-derived
+    # layout below, so a synthesized cell can never land outside the board.
+    board_extents = _board_extents(snapshot)
+    # cells already taken by a placed/stage-derived token, so a derived position never stacks.
+    claimed_cells: set[tuple[int, int]] = set()
     tokens: list[dict] = []
     initiative: list[dict] = []
     position_sources: set[str] = set()
@@ -2889,7 +2956,8 @@ def _combat_tokens(snapshot: dict, combat_view: dict) -> tuple[list[dict], list[
             if zone in zone_occupants:
                 zone_occupants[zone].append(cid)
         x, y, source = _combat_display_position(
-            raw, idx=idx, zones=zones, zone_offsets=zone_offsets, grid_extents=grid_extents
+            raw, idx=idx, zones=zones, zone_offsets=zone_offsets, grid_extents=grid_extents,
+            board_extents=board_extents, character=chars.get(cid), claimed=claimed_cells,
         )
         token["x"] = x
         token["y"] = y
@@ -2900,7 +2968,8 @@ def _combat_tokens(snapshot: dict, combat_view: dict) -> tuple[list[dict], list[
         # it must NOT persist x/y as state (the engine would silently overwrite it). The
         # `positionAuthority` flag makes that explicit so no downstream consumer mistakes the
         # hint for truth. ("grid" source = the engine actually supplied coords, a future
-        # capability; "zone"/"theater" = derived.)
+        # capability; "zone"/"theater"/"stage" = derived — "stage" reads the engine's own
+        # rest cell (#1751) but is still a render hint, not tactical truth.)
         token["positionAuthority"] = "engine" if source == "grid" else "derived"
         position_sources.add(source)
 
@@ -3634,7 +3703,26 @@ def _is_dead_or_downed(ch: dict) -> bool:
     return hp is not None and hp <= 0
 
 
-def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
+def _stage_vitals(ch: dict, team: str) -> dict:
+    """#1752 the HUD block on a stage token: ``hp``/``max_hp``/``health``/``hp_known``.
+
+    Reads the engine-owned character sheet. FOE DISCLOSURE mirrors the combat board's ``hpKnown``
+    rule exactly (see ``_combat_tokens``): an enemy's raw numbers are surfaced only when the party
+    has earned them, otherwise ``hp``/``max_hp`` are ``None`` and only the public ``health`` band
+    ("steady"/"wounded"/"bloodied"/"down") ships — so adding a HUD never leaks a monster's sheet."""
+    ch = ch if isinstance(ch, dict) else {}
+    cur = _num(ch.get("current_hp"))
+    mx = _num(ch.get("max_hp"))
+    known = team != "foe" or _combat_public_stat(ch, "hp_known", "known_hp", "player_known_hp")
+    return {
+        "hp": int(cur) if known and cur is not None else None,
+        "max_hp": int(mx) if known and mx is not None else None,
+        "health": _combat_health_label(cur, mx),
+        "hp_known": bool(known),
+    }
+
+
+def _scene_stage(snapshot: dict, combat_active: bool, combat_tokens: list[dict] | None = None) -> dict:
     """W1 (#1318) SCENE-AT-REST projection: an additive ``stage`` block carrying ``mode`` +
     at-rest ``tokens`` so a location renders with its people in it BEFORE combat — the tavern
     shows its innkeeper before anyone draws a sword.
@@ -3651,13 +3739,23 @@ def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
     world shows its cast (the quest giver AND the boss), not just the party. Cells fall back to
     ``zone_anchors`` values, then the party cells, when a bucket is short.
 
-    NO DOUBLE-PAINT: during active combat the authoritative tokens live in the top-level
-    ``tokens`` (the tactical board); ``stage.tokens`` is therefore EMPTY in combat mode so a
-    rest token can never leak onto the combat board. ``mode`` still reports "combat" so a
-    consumer can branch, but only rest mode carries placements."""
+    #1752 THE FIGHT IS ON THE SAME SCREEN: ``stage.tokens`` used to be EMPTY in combat mode (the
+    original "no double-paint" rule) — but the client renders the world FROM the stage, so an
+    empty stage meant it kept the last rest frame and a whole boss fight was invisible: no HP
+    bars, no turn marker, the tokens frozen where they stood before anyone drew a sword. The
+    stage is therefore ALWAYS populated. In combat the resident cast is still projected, but
+    every actor who is IN the fight takes its cell + vitals from the authoritative combat board
+    (``combat_tokens``, the top-level ``tokens``) instead of its rest spawn, and any combatant the
+    rest projection excludes (a downed PC, a foe who walked in from elsewhere) is appended. So
+    there is still exactly ONE placement authority per actor — the tactical board when it has one
+    — and no rest cell can contradict it.
+
+    Every stage token carries ``hp``/``max_hp``/``health``/``hp_known``/``team``/``is_turn`` so a
+    HUD can exist at all (#1752: "nothing tells me I'm dying or what I can do"). Foe HP obeys the
+    SAME disclosure rule the combat board uses (``hpKnown``): a number only when the party has
+    earned it, otherwise ``None`` plus the public ``health`` band. Every x/y is clamped into the
+    rendered board extents, so no stage token can land off-grid (#1751)."""
     mode = "combat" if combat_active else "rest"
-    if combat_active:
-        return {"mode": mode, "tokens": []}
 
     loc_id = _text(snapshot.get("current_location_id"))
     locs = snapshot.get("locations") if isinstance(snapshot.get("locations"), dict) else {}
@@ -3799,6 +3897,11 @@ def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
             # additive marker does. ADDITIVE: a consumer that ignores it reads the token exactly as
             # before.
             "rest_role": rest_role,
+            # #1752 HUD FIELDS: every stage token carries its vitals + turn flag so a client can
+            # draw an HP bar and a turn marker without a second request. At rest nobody has the
+            # turn; in combat the overlay below replaces these from the tactical board.
+            "is_turn": False,
+            **_stage_vitals(ch, _combat_team(kind)),
         })
 
     fb = 0
@@ -3816,6 +3919,65 @@ def _scene_stage(snapshot: dict, combat_active: bool) -> dict:
     for k, cid in enumerate(present_monsters):
         _emit(cid, foe_cells, k, fb, "foe")
         fb += 1
+
+    # #1752 COMBAT OVERLAY — the fight paints onto the SAME stage the walked world uses, so the
+    # client never has to swap render models mid-beat (and never freezes on the last rest frame).
+    # The tactical board is the placement authority for anyone in the fight; the rest projection
+    # only supplies the bystanders (the innkeeper still stands at the hearth while swords are out).
+    if combat_active:
+        board = {t["id"]: t for t in (combat_tokens or [])
+                 if isinstance(t, dict) and _text(t.get("id"))}
+
+        def _combat_fields(ct: dict) -> dict:
+            hp = ct.get("hp") if ct.get("hpKnown") else None
+            mx = ct.get("hpMax") if ct.get("hpKnown") else None
+            return {
+                "x": int(_num(ct.get("x")) or 0),
+                "y": int(_num(ct.get("y")) or 0),
+                # the combat board already declares whether ITS coords are engine truth or a
+                # derived zone hint — carry that verdict through rather than re-asserting one.
+                "positionAuthority": _text(ct.get("positionAuthority"), "derived"),
+                "pose": "down" if (_num(ct.get("hp")) or 1) <= 0 else "idle",
+                "is_turn": bool(ct.get("isCurrent")),
+                "hp": int(hp) if hp is not None else None,
+                "max_hp": int(mx) if mx is not None else None,
+                "health": _text(ct.get("health"), "unknown"),
+                "hp_known": bool(ct.get("hpKnown")),
+            }
+
+        for tok in tokens:
+            ct = board.get(tok["id"])
+            if ct is not None:
+                tok.update(_combat_fields(ct))
+        placed = {tok["id"] for tok in tokens}
+        # Combatants the REST projection legitimately drops — a downed PC (0 HP), a foe who is
+        # not resident at this location — must still be on the board they are fighting on. Dead
+        # characters stay off it (the corpse is the fight's outcome, not a token).
+        for cid, ct in board.items():
+            if cid in placed:
+                continue
+            ch = chars.get(cid) if isinstance(chars.get(cid), dict) else {}
+            if bool(ch.get("dead")):
+                continue
+            team = _text(ct.get("team"), "ally")
+            name = _text(ct.get("name"), cid)
+            tokens.append({
+                "id": cid,
+                "name": name,
+                "initial": _combat_initial(name, cid),
+                "short": f"{_combat_initial(name, cid)} portrait",
+                "team": team,
+                "kind": _text(ch.get("kind")),
+                "rest_role": "foe" if team == "foe" else ("party" if cid in party_set else "npc"),
+                **_combat_fields(ct),
+            })
+
+    # #1751 LAST-LINE CLAMP: no stage token may render outside the board the client draws —
+    # whatever produced the cell (an authored spawn, a walked stage_cell, a zone-derived combat
+    # hint), it is forced in-bounds here so an off-grid token is unrepresentable on this surface.
+    extents = _board_extents(snapshot)
+    for tok in tokens:
+        tok["x"], tok["y"] = _clamp_to_board(tok["x"], tok["y"], extents)
 
     return {"mode": mode, "tokens": tokens}
 
@@ -3915,14 +4077,14 @@ def build_combat_surface(
         # renderer can place invisible depth-only proxies -> a 3D actor moving BEHIND a painted column is
         # correctly hidden by it. READS engine-owned scene_grid.props (occluder=true); [] == none (today).
         "occluders": _combat_occluders(snapshot),
-        # W1 (#1318) SCENE-AT-REST: additive `stage` block — {mode: "rest"|"combat", tokens:[...]}.
-        # In REST mode (no active combat) tokens are a pure deterministic projection of the party +
-        # present NPCs onto scene_grid.spawns cells, so the room renders inhabited before combat. In
-        # COMBAT mode tokens is [] (the authoritative combat tokens are the top-level `tokens`; a
-        # rest token must never leak onto the tactical board). Engine stays sole writer; new key
-        # only — every existing key above/below is byte-unchanged, so combat-mode consumers are
-        # unaffected. See _scene_stage.
-        "stage": _scene_stage(snapshot, combat_active),
+        # W1 (#1318) THE STAGE: `stage` = {mode: "rest"|"combat", tokens:[...]} — the block the
+        # client renders the world from. At REST it is a deterministic projection of the party +
+        # present NPCs + resident live monsters onto scene_grid.spawns cells. In COMBAT (#1752) it
+        # is the SAME cast, with every actor who is in the fight taking its cell + vitals from the
+        # authoritative combat board (`tokens`, passed in below) — it used to be EMPTY in combat,
+        # which froze the rendered frame on the last rest stage for a whole fight. Engine stays
+        # sole writer (every cell is a derived projection). See _scene_stage.
+        "stage": _scene_stage(snapshot, combat_active, tokens),
         "tokens": tokens,
         "initiative": initiative,
         "zones": zones,

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -2226,6 +2226,47 @@ def _clamp_to_board(x: object, y: object, extents: tuple[int, int]) -> tuple[int
     return max(0, min(cols - 1, xi)), max(0, min(rows - 1, yi))
 
 
+def _blocked_cells(snapshot: dict, combat_active: bool) -> set[tuple[int, int]]:
+    """The cells a token must not stand on — the SAME collision truth this surface publishes as
+    ``impassable`` (engine ``combat.grid_impassable`` in combat, the geometry-derived rest set
+    otherwise). Reading the published field rather than re-deriving one keeps the placement picture
+    from drifting off the collision picture; a drift IS this class of bug."""
+    raw = ((snapshot.get("combat") or {}).get("grid_impassable") or []) if combat_active \
+        else _rest_impassable(snapshot)
+    out: set[tuple[int, int]] = set()
+    for item in raw if isinstance(raw, list) else []:
+        if isinstance(item, (list, tuple)) and len(item) == 2:
+            cx, cy = _num(item[0]), _num(item[1])
+            if cx is not None and cy is not None:
+                out.add((int(cx), int(cy)))
+    return out
+
+
+def _free_cell(cell: tuple[int, int], extents: tuple[int, int],
+               blocked: set[tuple[int, int]], claimed: set[tuple[int, int]]) -> tuple[int, int]:
+    """Resolve a DERIVED cell to the nearest in-bounds cell that is neither impassable nor already
+    taken (#1751). Clamping alone is not enough: on the canonical 14x11 crypt the zone layout's
+    fourth bucket clamps x=15 down to 13, which IS the east perimeter wall — the reported ghost
+    became in-bounds but stayed inside the wall, and two occupants collapsed onto the same column.
+
+    Deterministic outward ring search (increasing Chebyshev radius, then row-major within a ring),
+    so the same snapshot always yields the same board. Returns the clamped candidate unchanged when
+    the room offers nothing free — a token the client can still draw beats no token at all. ONLY
+    derived cells come here; an engine-supplied cell is truth and is never relocated."""
+    cols, rows = extents
+    start = _clamp_to_board(*cell, extents)
+    for radius in range(max(cols, rows) + 1):
+        ring = [(start[0] + dx, start[1] + dy)
+                for dy in range(-radius, radius + 1)
+                for dx in range(-radius, radius + 1)
+                if max(abs(dx), abs(dy)) == radius]
+        for cand in sorted(ring, key=lambda c: (c[1], c[0])):
+            if 0 <= cand[0] < cols and 0 <= cand[1] < rows \
+                    and cand not in blocked and cand not in claimed:
+                return cand
+    return start
+
+
 def _scene_grid_block(snapshot: dict, mode: str) -> dict:
     """The combat board's grid extents (A1). When the party's current location carries an
     engine-authored ``scene_grid``, use ITS extents + cells; otherwise fall back to the
@@ -2846,6 +2887,7 @@ def _combat_display_position(
     board_extents: tuple[int, int] | None = None,
     character: dict | None = None,
     claimed: set[tuple[int, int]] | None = None,
+    blocked: set[tuple[int, int]] | None = None,
 ) -> tuple[int, int, str]:
     # Read the engine's authoritative grid coords. Use a None-coalesce (NOT `or`): a cell of 0
     # is a VALID coordinate (origin column/row), and `x or col` would treat 0 as missing and
@@ -2882,24 +2924,33 @@ def _combat_display_position(
         if isinstance(sc, (list, tuple)) and len(sc) == 2:
             sx, sy = _num(sc[0]), _num(sc[1])
             if sx is not None and sy is not None:
-                cell = _clamp_to_board(sx, sy, board_extents)
-                # never stack two tokens on one cell — a collision falls through to the zone slot
-                if claimed is None or cell not in claimed:
-                    if claimed is not None:
-                        claimed.add(cell)
-                    return (*cell, "stage")
+                # a rest cell is already walkable, but resolve anyway: the room's collision set can
+                # differ in combat (grid_impassable folds in prop footprints), and two actors must
+                # never share a cell.
+                cell = _free_cell((int(sx), int(sy)), board_extents,
+                                  blocked or set(), claimed or set())
+                if claimed is not None:
+                    claimed.add(cell)
+                return (*cell, "stage")
     zone_name = _text(row.get("zone"))
     zone_index = next((i for i, z in enumerate(zones) if z.get("name") == zone_name), idx)
     offset = zone_offsets.get(zone_name, 0)
     zone_offsets[zone_name] = offset + 1
     base_x = 3 + (zone_index % 4) * 4
     base_y = 3 + (zone_index // 4) * 3
-    # #1751: clamp the synthesized zone layout into the board the client actually renders. The
-    # old fixed `min(16, ...)` / `min(10, ...)` was a legacy 16x10 assumption AND off by one (a
-    # 16-column board's last cell is 15) — a fourth zone put its second occupant at column 16,
-    # off-grid, which is exactly the cyan-ghost-in-the-east-wall bug. Cell 0 stays reachable.
+    # #1751: resolve the synthesized zone layout onto a cell the client can actually draw. The old
+    # fixed `min(16, ...)` / `min(10, ...)` was a legacy 16x10 assumption AND off by one (a
+    # 16-column board's last cell is 15), so a fourth zone put its second occupant at column 16 —
+    # off-grid, the cyan-ghost-in-the-east-wall bug. Clamping alone only half-fixes it: on the
+    # canonical 14x11 crypt that same slot clamps to column 13, which IS the east wall. `_free_cell`
+    # takes the board extents AND the published collision set, so the token lands on a free,
+    # walkable, unclaimed cell. Cell 0 stays reachable.
     if board_extents is not None:
-        return (*_clamp_to_board(base_x + offset, base_y + (offset % 2), board_extents), "zone")
+        cell = _free_cell((base_x + offset, base_y + (offset % 2)), board_extents,
+                          blocked or set(), claimed or set())
+        if claimed is not None:
+            claimed.add(cell)
+        return (*cell, "zone")
     return max(1, min(15, base_x + offset)), max(1, min(9, base_y + (offset % 2))), "zone"
 
 
@@ -2925,6 +2976,9 @@ def _combat_tokens(snapshot: dict, combat_view: dict) -> tuple[list[dict], list[
     board_extents = _board_extents(snapshot)
     # cells already taken by a placed/stage-derived token, so a derived position never stacks.
     claimed_cells: set[tuple[int, int]] = set()
+    # the collision truth this surface publishes as `impassable` — a derived token must not be
+    # placed inside a wall or a prop footprint (#1751).
+    blocked_cells = _blocked_cells(snapshot, True)
     tokens: list[dict] = []
     initiative: list[dict] = []
     position_sources: set[str] = set()
@@ -2958,9 +3012,13 @@ def _combat_tokens(snapshot: dict, combat_view: dict) -> tuple[list[dict], list[
         x, y, source = _combat_display_position(
             raw, idx=idx, zones=zones, zone_offsets=zone_offsets, grid_extents=grid_extents,
             board_extents=board_extents, character=chars.get(cid), claimed=claimed_cells,
+            blocked=blocked_cells,
         )
         token["x"] = x
         token["y"] = y
+        # An ENGINE-supplied cell is truth and is never relocated, but it still occupies the square —
+        # claim it so a later DERIVED token is not resolved on top of it.
+        claimed_cells.add((x, y))
         # #432 (graphics M0): x/y here are a DERIVED render-hint, never authoritative state.
         # On the "zone" path they are synthesized from the engine's named zone (the engine
         # has no per-combatant coordinates — Combatant.zone is the only spatial truth). A
@@ -3937,7 +3995,10 @@ def _scene_stage(snapshot: dict, combat_active: bool, combat_tokens: list[dict] 
                 # the combat board already declares whether ITS coords are engine truth or a
                 # derived zone hint — carry that verdict through rather than re-asserting one.
                 "positionAuthority": _text(ct.get("positionAuthority"), "derived"),
-                "pose": "down" if (_num(ct.get("hp")) or 1) <= 0 else "idle",
+                # None-coalesce, NOT `or`: 0 HP is the DOWNED case and the whole point of the pose.
+                # `(_num(hp) or 1) <= 0` turned a valid 0 into 1, so an unconscious actor rendered
+                # standing while its own `hp` field read 0. Unknown HP (a foe) stays upright.
+                "pose": "down" if (_hp := _num(ct.get("hp"))) is not None and _hp <= 0 else "idle",
                 "is_turn": bool(ct.get("isCurrent")),
                 "hp": int(hp) if hp is not None else None,
                 "max_hp": int(mx) if mx is not None else None,

--- a/viewer/tests/test_scene_at_rest_stage.py
+++ b/viewer/tests/test_scene_at_rest_stage.py
@@ -2,9 +2,12 @@
 
 The surface gains an additive `stage` = {mode, tokens}. In REST mode (no active combat) the
 tokens are a pure deterministic projection of the party + present NPCs onto scene_grid.spawns
-cells; in COMBAT mode the block is {mode:"combat", tokens:[]} so a rest token never leaks onto
-the tactical board. Engine stays sole writer; the block is a NEW key only, so every existing
-consumer of the combat surface is byte-unchanged.
+cells; in COMBAT mode (#1752) the SAME cast is projected, but every actor in the fight takes its
+cell + vitals from the authoritative top-level `tokens` — so there is exactly one placement
+authority per actor and no rest cell can contradict the tactical board. (The block used to be
+EMPTY in combat, which froze the rendered frame on the last rest stage for an entire fight.)
+Engine stays sole writer; the block is a NEW key only, so every existing consumer of the combat
+surface is byte-unchanged.
 
 Invariants asserted here:
   * TEXT-TIER BYTE-IDENTITY — deleting `stage` yields EXACTLY today's payload (same keys, same
@@ -225,14 +228,26 @@ class SceneAtRestProjectionTests(unittest.TestCase):
         # No token landed on the blocked bar anchor (3,2).
         self.assertNotIn((3, 2), placed)
 
-    def test_combat_mode_carries_no_stage_tokens(self):
-        """No double-paint: under active combat the authoritative tokens are the top-level
-        `tokens`; the stage block reports combat mode but places nothing."""
+    def test_combat_mode_paints_the_fight_onto_the_stage(self):
+        """#1752 (supersedes the original empty-in-combat rule): the stage is what the client
+        RENDERS, so an empty stage in combat froze the frame on the last rest projection for a
+        whole fight. In combat the stage carries the combatant, positioned + vitalled from the
+        authoritative top-level `tokens` — one placement authority, no double-paint."""
         surface = _surface(_combat_snapshot())
         self.assertEqual(surface["stage"]["mode"], "combat")
-        self.assertEqual(surface["stage"]["tokens"], [])
-        # ...while the combat board itself still has its tokens (unchanged path).
-        self.assertTrue(surface["tokens"])
+        by_id = {t["id"]: t for t in surface["stage"]["tokens"]}
+        self.assertIn("pc_hero", by_id)
+        board = {t["id"]: t for t in surface["tokens"]}
+        self.assertEqual(
+            (by_id["pc_hero"]["x"], by_id["pc_hero"]["y"]),
+            (board["pc_hero"]["x"], board["pc_hero"]["y"]),
+            "a combatant's stage cell must come from the tactical board, not its rest spawn",
+        )
+        self.assertTrue(by_id["pc_hero"]["is_turn"])
+        # A bystander who is NOT in the fight keeps its rest placement — the innkeeper does not
+        # vanish from the room because swords came out.
+        self.assertIn("npc_keeper", by_id)
+        self.assertEqual((by_id["npc_keeper"]["x"], by_id["npc_keeper"]["y"]), (3, 3))
 
     def test_projection_is_deterministic(self):
         a = _surface(_rest_snapshot())["stage"]
@@ -358,15 +373,18 @@ class SceneAtRestLiveMonsterTests(unittest.TestCase):
         # rest_role "foe" — NOT "npc", so the client's click-to-TALK path never fires on a monster.
         self.assertEqual(by_id["mon_boss"]["rest_role"], "foe")
 
-    def test_combat_mode_carries_no_monster_tokens(self):
-        """Combat-inertness: with a live monster present but combat ACTIVE, the stage block is
-        empty (the authoritative tokens are the top-level combat board) — the #1639 addition
-        cannot double-emit onto the combat surface."""
+    def test_combat_mode_still_shows_a_resident_monster(self):
+        """#1752: a live monster in the room stays on the stage while a fight runs. It is not in
+        THIS fight's order, so it keeps its rest placement (foe lane) — the room does not empty
+        out the moment initiative is rolled."""
         snap = _combat_snapshot()
         snap["characters"]["mon_boss"] = self._monster("loc1")
         surface = _surface(snap)
         self.assertEqual(surface["stage"]["mode"], "combat")
-        self.assertEqual(surface["stage"]["tokens"], [])
+        by_id = {t["id"]: t for t in surface["stage"]["tokens"]}
+        self.assertIn("mon_boss", by_id)
+        self.assertEqual(by_id["mon_boss"]["rest_role"], "foe")
+        self.assertFalse(by_id["mon_boss"]["is_turn"])
         self.assertTrue(surface["tokens"])  # the combat board itself is unchanged
 
     def test_monster_present_surface_is_still_stage_only_new_key(self):


### PR DESCRIPTION
Fixes #1752. Fixes #1751.

## Root cause

Both bugs live in the **projection**, in the gap between the engine and the rendered surface —
not in the combat model.

`viewer/server.py::_scene_stage` returned `{"mode": "combat", "tokens": []}` whenever combat was
active. That was a deliberate "no double-paint" rule from #1318, written when `stage` was an
additive rest-only block: the authoritative tokens were the top-level `tokens`, so a rest token
must never leak onto the tactical board. But the Unity client renders the world **from the
stage** — so an empty stage in combat is not "no double-paint", it is *no frame*: the client kept
the last rest projection and a whole boss fight rendered as 11+ identical frames, no HP, no turn
marker (#1752). Separately, `start_combat` places nobody (it seeds tactical cells only on an
explicit `seed_from_stage`), so every cell the player sees during a zones-mode fight is derived by
`_combat_display_position` — and that derivation clamped to a **hardcoded 16x10** that was also
**off by one** (`min(16, …)` on a board whose last column is 15). A fourth zone's second occupant
landed at column 16 of the 16-column crypt: the cyan ghost inside the east wall (#1751).

## What changed (`viewer/server.py` only — 180 added / 18 removed)

- `_board_extents` derives the clamp from the **same extents the client renders** (location
  `scene_grid`, overridden by an explicit combat grid, legacy 16x10 fallback), and `_clamp_to_board`
  forces every derived cell inside it. A last-line clamp over all stage tokens makes an off-grid
  token unrepresentable on this surface.
- **Stand where you stood**: a combatant with no engine tactical cell now takes the engine's own
  `Character.stage_cell` — the exact cell the rest stage rendered it on a beat ago — instead of a
  synthesized zone slot, so the frame does not teleport the instant initiative is rolled.
  Collisions fall through to the zone layout; derived cells never stack.
- The stage is **always populated**. In combat the resident cast is still projected, but every
  actor in the fight takes its cell + vitals from the authoritative combat board, and any
  combatant the rest projection drops (a downed PC, a foe from elsewhere) is appended — exactly
  one placement authority per actor.
- Every stage token carries `hp` / `max_hp` / `health` / `hp_known` / `team` / `is_turn`. Foe HP
  keeps the combat board's existing `hpKnown` disclosure rule: a raw number only when the party has
  earned it, otherwise `None` plus the public band.

**Engine stays sole writer** — every cell here is a read-only derived projection; the contract test
asserts the snapshot is byte-identical after projecting.

## Why the fix is NOT in the engine

Seeding combatant cells from `stage_cell` inside `start_combat` was implemented, measured, and
**reverted**: it turns a 5-round win into a 60+ round draw (`round_cap_hit is True` in
`test_run_combat_autonomous_test_runs_to_terminal_and_everyone_acted`). The AI cannot resolve a
fight across realistic opening distance. Filed as **#1776** — a combat-model hole that any future
tactical-formation work walks into. No engine production file is touched by this PR.

## Contract test at the seam

`servers/engine/tests/test_combat_surface_stage_contract.py` (new, 7 tests) seeds a real campaign
on a 16x12 crypt, starts combat through the **real** `server.start_combat`, dumps the engine-owned
snapshot, and feeds it to the **real** `viewer/server.py::build_combat_surface`. No mock stands in
for either half — both bugs lived exactly in that gap. It asserts every combatant gets a distinct,
in-bounds, non-blocked cell; the stage lists every living combatant; HUD fields are present with
foe disclosure intact; exactly one turn marker; determinism + read-only. A second fixture repeats
it on the real v2 walkslice crypt with **no** rest cells at all — the pure zone-derived path, the
one that produced column 16.

## Live verification (sandbox `cs1`)

Combat was restarted through the engine's own RPC so the order carried **no** cells (`x=None`) —
the exact bug condition — then `/combat-surface` was read from a viewer running this branch:

| | before | after |
|---|---|---|
| `grid` | 16 x 12 | 16 x 12 |
| `stage.mode` / `stage.tokens` | `combat` / **`[]`** | `combat` / **4 tokens** |
| board tokens | `(3,3) (8,4) (13,3) `**`(16,4)`** | `(6,1) (1,1) (4,5) (3,8)` |
| off-grid | **1 token at x=16 of 16** | none |
| HUD | absent | `Aidan 1/28 bloodied ally`, foes `hp=None hp_known=false` + band, one `is_turn` |

Post-fight regression check on sandbox `play1`: this branch vs `main` on the same state is
byte-identical except the **additive** HUD keys — same token, same cell, no key removed.

## Known: the client cannot render this yet

Capturing the live frame surfaced the **client half** of #1752, filed as **#1777**:
`Shader.Find("Unlit/Color")` returns `null` in a built player (built-in shader stripped), so
`EnsureHpBar` → `MakeBarQuad` → `new Material(null)` throws out of the `Fetch` coroutine's
`MoveNext` and **kills the fetch loop for the whole session** — the player freezes on its last
pre-combat frame and stops applying any server state. That is why the before/after Unity frames
are pixel-identical. Per the packet this PR makes **no Unity client edits** (another lane owns
that file). Server-side correctness is proven at the surface and by the contract test. HUD
follow-up: #1760.

## Tests (all run bare)

- `viewer/tests` via `.venv-viewer` as ci.yml's viewer-tests job does — **898 passed, 8 skipped**
- `uv run --directory servers/engine python -m pytest servers/engine/tests -q -p no:xdist` — **3560 passed**
- `qa/fast_gate.sh` — **T0 PASS** (257 passed)

Claim class: **contract-tested-fix + live-surface-verified**. It does NOT prove the Unity client
renders the fight — #1777 blocks that, and the frame evidence is explicitly negative on it.
