### PR TITLE
viewer: bound placeholder caption length + multi-session recap scan (#1764 follow-up)

### DIFF
--- a/viewer/openworlds/chrome.jsx
+++ b/viewer/openworlds/chrome.jsx
@@ -311,6 +311,7 @@ const _PH_SLOT_NAMES = {
 };
 // Aspect ratios are pure art direction and never a subject.
 const _PH_ASPECT_RE = /^\d+\s*[:x×]\s*\d+$/i;
+const _PH_CAPTION_MAX = 40;
 
 // Turn an art brief into a caption a player can read. Segments are the brief's "·" parts: the
 // first recognised SLOT word names the frame, and at most one SHORT (≤2 words) remaining segment
@@ -331,9 +332,17 @@ function phCaption(label) {
   let subject = "";
   for (const part of rest) {
     if (_PH_ASPECT_RE.test(part)) continue;
-    if (part.split(/\s+/).length > 2) continue;
+    // Direction prose ("painted hero scene") is dropped only from a BRIEFED slot. A label with no
+    // slot word is a bare player-facing display name — "Last Light Inn", "Potion of Healing" — and
+    // must survive whole, or the frame goes blank (#1773 review, P2).
+    if (slot && part.split(/\s+/).length > 2) continue;
     subject = part.charAt(0).toUpperCase() + part.slice(1);
     break;
+  }
+  if (subject.length > _PH_CAPTION_MAX) {
+    const head = subject.slice(0, _PH_CAPTION_MAX);
+    const cut = head.lastIndexOf(" ");
+    subject = (cut > 0 ? head.slice(0, cut) : head) + "\u2026";
   }
   if (slot) {
     const full = subject ? `${slot} · ${subject}` : slot;

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -6987,6 +6987,7 @@ def _relative_time_label(ts: float, *, now: float) -> str:
 _RECAP_MAX = 240
 # Session-log kinds whose text is a beat rather than a mechanism dump.
 _RECAP_NARRATION_KINDS = ("narration", "scene", "dm")
+_RECAP_SESSION_SCAN = 8
 
 
 def _recap_snip(text: str) -> str:
@@ -6999,16 +7000,8 @@ def _recap_snip(text: str) -> str:
     return (head[:cut] if cut > 0 else head).rstrip() + "\u2026"
 
 
-def _session_derived_recap(campaign_dir: Path, snapshot: dict) -> str:
-    """The chronicle's OWN last words, read from the session log (#1764).
-
-    The launcher used to print ``snapshot["summary"]``, which for a seeded campaign is the
-    AUTHORING blurb — so a player twelve beats into a crypt read the harness's own wording back.
-    Prefer the tail of the campaign's session log (the same read-only projection the chronicle
-    band uses): the last narration beat, else the last event of any kind. Returns "" when there
-    is no session history at all, which is the caller's signal to fall back to the fixture.
-    """
-    rows = _session_event_tail_from_dir(campaign_dir, snapshot, limit=24)
+def _recap_candidates(rows: list[dict]) -> tuple[str, str]:
+    """(last narration beat, last event of any kind) out of one session's tail."""
     narration = ""
     latest = ""
     for row in rows:
@@ -7023,7 +7016,65 @@ def _session_derived_recap(campaign_dir: Path, snapshot: dict) -> str:
         latest = f"{speaker}: \u201c{snip}\u201d" if kind == "dialogue" and speaker else snip
         if kind in _RECAP_NARRATION_KINDS:
             narration = snip
-    return narration or latest
+    return narration, latest
+
+
+def _campaign_session_ids(campaign_dir: Path, snapshot: dict) -> list[str]:
+    """The campaign's session ids, NEWEST FIRST — declared ones, then orphaned logs on disk.
+
+    Mirrors store.read_all_logs' canonical ordering (session_ids first, then any *.jsonl not
+    named there), reversed: a recap wants the most recent beat, so it walks backwards.
+    """
+    ordered: list[str] = []
+    declared = snapshot.get("session_ids")
+    if isinstance(declared, list):
+        for sid in declared:
+            sid = _safe_session_id(sid)
+            if sid and sid not in ordered:
+                ordered.append(sid)
+    ordered.reverse()
+    try:
+        orphans = sorted(
+            (campaign_dir / "sessions").glob("*.jsonl"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    except OSError:
+        orphans = []
+    for log in orphans:
+        sid = _safe_session_id(log.stem)
+        if sid and sid not in ordered:
+            ordered.append(sid)
+    return ordered
+
+
+def _session_derived_recap(campaign_dir: Path, snapshot: dict) -> str:
+    """The chronicle's OWN last words, read from the session log (#1764).
+
+    The launcher used to print ``snapshot["summary"]``, which for a seeded campaign is the
+    AUTHORING blurb — so a player twelve beats into a crypt read the harness's own wording back.
+    Prefer the tail of the campaign's session log (the same read-only projection the chronicle
+    band uses): the last narration beat, else the last event of any kind. Returns "" when there
+    is no session history at all, which is the caller's signal to fall back to the fixture.
+
+    #1773 review (P1): under lean / fast-turn play EVERY beat opens a fresh session id, so the
+    active log can hold nothing but its "Session N began" marker while the real last beat sits in
+    an earlier file (store.read_all_logs documents exactly this). Walking only the active session
+    would recap the marker. So when the active session yields no narration, walk the campaign's
+    session history newest-first for one — keeping the active session's own latest row as the
+    last resort.
+    """
+    narration, latest = _recap_candidates(
+        _session_event_tail_from_dir(campaign_dir, snapshot, limit=24))
+    if narration:
+        return narration
+    for sid in _campaign_session_ids(campaign_dir, snapshot)[:_RECAP_SESSION_SCAN]:
+        older, older_latest = _recap_candidates(
+            _session_event_tail_from_dir(campaign_dir, {"active_session_id": sid}, limit=24))
+        if older:
+            return older
+        latest = latest or older_latest
+    return latest
 
 
 def _infer_catalog_provider(state_root: Path, source: str) -> str:

--- a/viewer/tests/test_launcher_recap_source.py
+++ b/viewer/tests/test_launcher_recap_source.py
@@ -121,5 +121,44 @@ class LauncherRecapSourceTests(unittest.TestCase):
         self.assertEqual(row["recapLabel"], "New campaign")
 
 
+class LeanPlaySessionRotationTests(unittest.TestCase):
+    """#1773 review (P1): under lean play the ACTIVE session can hold only its start marker.
+
+    Every beat opens a fresh session id (store.read_all_logs documents this), so the newest log is
+    often just "Session N began: …" while the real last beat sits in the previous file. Recapping
+    only the active session printed the marker at the player.
+    """
+
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+
+    def _summary(self) -> dict:
+        cdir = self._tmp / "campaigns" / "adventure_demo_v1"
+        (cdir / "sessions").mkdir(parents=True, exist_ok=True)
+        snap = _snapshot(session_id="session-new")
+        snap["session_ids"] = ["session-old", "session-new"]
+        (cdir / "snapshot.json").write_text(json.dumps(snap), encoding="utf-8")
+        (cdir / "sessions" / "session-old.jsonl").write_text(
+            json.dumps({"t": 1788350100.0, "kind": "narration", "text": LAST_BEAT}) + "\n",
+            encoding="utf-8",
+        )
+        (cdir / "sessions" / "session-new.jsonl").write_text(
+            json.dumps({"t": 1788350300.0, "kind": "system",
+                        "text": "Session 2 began: The Crypt Below"}) + "\n",
+            encoding="utf-8",
+        )
+        return server.build_openworlds_campaign_summary(
+            "play", "run-1", "adventure_demo_v1", snap,
+            campaign_dir=cdir, state_root=self._tmp, last_played=time.time(),
+            current=True, can_resume=True, now=time.time(),
+        )
+
+    def test_recap_reaches_back_past_an_empty_rotated_session(self):
+        row = self._summary()
+        self.assertIn("slate-carrier", row["recap"])
+        self.assertNotIn("Session 2 began", row["recap"])
+        self.assertEqual(row["recapSource"], "session")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/viewer/tests/test_placeholder_caption.py
+++ b/viewer/tests/test_placeholder_caption.py
@@ -139,3 +139,30 @@ def test_1764_brief_survives_as_a_data_attribute_for_generators():
         assert brief in out["props"], (
             f"brief {brief!r} must remain available to generators (data-art-brief); props={out['props']}"
         )
+
+
+# ── #1773 review (P2): a bare display name is not a brief and must not be swallowed ──────────
+
+BARE_DISPLAY_NAMES = ["Last Light Inn", "Potion of Healing", "Aidan", "Keeper Maera"]
+
+
+def test_1773_bare_display_names_are_never_blanked():
+    """`label={selected.name}` / `label={item.name}` carry player-facing names, not art direction.
+
+    The first cut of the de-brief filter dropped any segment longer than two words, so a
+    slot-less label like "Last Light Inn" left the frame with NO caption at all.
+    """
+    rendered = _render_placeholders(BARE_DISPLAY_NAMES)
+    for name, out in zip(BARE_DISPLAY_NAMES, rendered):
+        assert out["caption"] == name, (
+            f"bare display name {name!r} must survive as its own caption; got {out['caption']!r}"
+        )
+
+
+def test_1773_a_long_bare_name_is_bounded_not_dropped():
+    """An unreasonably long name is trimmed to a caption, never blanked."""
+    long_name = "The Hall of the Goblin Boss Beneath the Weeping Stair of Old Kings"
+    out = _render_placeholders([long_name])[0]
+    assert out["caption"], "a long name must still caption the frame"
+    assert len(out["caption"]) <= 42, f"caption not bounded: {out['caption']!r}"
+    assert long_name.startswith(out["caption"].rstrip("\u2026"))


### PR DESCRIPTION
Follow-up to [#1764](https://github.com/electricsheephq/WorldOS/issues/1764) and merged [#1773](https://github.com/electricsheephq/WorldOS/pull/1773).

Addresses the #1773 review points:
- `chrome.jsx`: preserve bare player-facing display names as captions while bounding long captions to 40 characters.
- `server.py`: scan up to eight newest campaign session logs so lean-play recaps reach the last narration beat beyond a marker-only active session.

Tests: `/Users/m1/worldos-wt-viewer1764/.venv-viewer/bin/python -m pytest /Users/m1/worldos-wt-viewer1764/viewer/tests -q -p no:xdist` — 908 passed, 8 skipped, 122 subtests.

Scope is limited to the two viewer fixes and their tests (138 insertions, 12 deletions across four files).
