### PR TITLE
tests: seed the force_hit dead-code test deterministically (#1739 flake)

### DIFF
--- a/servers/engine/tests/test_combat_core.py
+++ b/servers/engine/tests/test_combat_core.py
@@ -969,7 +969,12 @@ def test_force_hit_is_dead_code_without_env(tmp_path, monkeypatch):
     monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
     monkeypatch.delenv("WORLDOS_COMBAT_TEST", raising=False)
     import server
-    dice_mod.reseed_process_rng(None)
+    # Deterministic dice (the #1739 flake): unseeded, the hit count was a fresh binomial n=40 p=0.05
+    # draw on every run and the original `hits <= 6` cap failed ~0.3 % of runs (P(hits >= 7) =
+    # 0.0034), reddening CI on unrelated PRs. The RNG source is orthogonal to what this test proves —
+    # the double guard reads ONLY the env + is_sandbox, never the dice — so a fixed seed keeps the
+    # proof intact and makes the count reproducible run to run (seed 20260902 currently lands 2/40).
+    dice_mod.reseed_process_rng(20260902)
     cid = server.create_campaign("Guard")["id"]
     server.add_location(campaign_id=cid, name="P", description="x", make_current=True)
     c = server._require(cid)
@@ -983,9 +988,11 @@ def test_force_hit_is_dead_code_without_env(tmp_path, monkeypatch):
         if _one_attack(server, store, cid, a, t, force_hit=True)["hit"]
     )
     # vs AC 30 with +0, only natural 20s hit (~5%). NOT ~40. So force_hit is DEAD here.
-    assert hits <= 12, (  # binomial n=40, p=0.05 (nat-20 only): P(hits > 12) < 1e-7; the forced case is 40/40 — the old cap of 6 failed ~1.2 % of runs
-        f"force_hit leaked without the env guard: {hits}/40 hits"
-    )
+    # The cap stays a WIDE statistical bound (binomial n=40 p=0.05: P(hits > 12) < 1e-7) rather than
+    # the seed's exact count, so a future change to how many dice `attack` draws (e.g. a new rider
+    # roll reshuffling the seeded sequence) cannot turn this into a brittle golden value. The forced
+    # case is 40/40 — see the sibling test below.
+    assert hits <= 12, f"force_hit leaked without the env guard: {hits}/40 hits"
 
 
 def test_force_hit_forces_hit_under_guard_without_faking_crits(tmp_path, monkeypatch):
@@ -995,7 +1002,9 @@ def test_force_hit_forces_hit_under_guard_without_faking_crits(tmp_path, monkeyp
     monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
     monkeypatch.setenv("WORLDOS_COMBAT_TEST", "1")
     import server
-    dice_mod.reseed_process_rng(None)
+    # Same fixed seed as the sibling above: the crit count is reproducible, and the bound below stays
+    # a wide statistical one (binomial n=80 p=0.05: P(crits >= 40) is ~1e-30), not a golden value.
+    dice_mod.reseed_process_rng(20260902)
     cid = server.create_campaign("Guard2")["id"]
     server.add_location(campaign_id=cid, name="P", description="x", make_current=True)
     c = server._require(cid)


### PR DESCRIPTION
# Pull Request

## Summary

`test_force_hit_is_dead_code_without_env` reseeded the process RNG with `None` (fresh OS entropy per roll), made 40 attacks vs AC 30 with +0 to hit, and asserted a count of natural-20 hits. That count is a fresh binomial(n=40, p=0.05) draw on every run, so the assertion failed at random on PRs that touched nothing under `servers/`. Observed on #1739 (docs-only): push run 33628000598 failed with `7/40 hits / assert 7 <= 6` while the pull_request run on the identical commit passed. P(hits >= 7) = 0.0034 per run, roughly 0.3 %.

#1769 already widened the cap from 6 to 12 (P(hits >= 13) = 4e-8). This PR applies the preferred fix on top of that: seed the RNG deterministically so the outcome is reproducible run to run, and keep the wide cap as the assertion so the test never becomes a brittle golden value.

The double guard reads only `WORLDOS_COMBAT_TEST` + `Campaign.is_sandbox`, never the dice source, so seeding does not weaken what the test proves. Verified by mutation: with the env half of the guard set in a temp copy of the test, `force_hit` leaks and the test fails with `40/40 hits`.

## Linked Issue

No dedicated issue. CI hygiene under the active sprint charter #1702 (same framing as #1769). Originating failure: #1739's push-event run 33628000598.

## Tracker / Milestone

- Tracker or milestone: #1702 (sprint charter, hygiene)
- Required? no. Test-only de-flake with no product surface.

## Changes

All in `servers/engine/tests/test_combat_core.py`; no engine code touched.

- `test_force_hit_is_dead_code_without_env`: `reseed_process_rng(None)` -> `reseed_process_rng(20260902)`. The hit count is now fixed (currently 2/40). The assertion stays `hits <= 12` rather than a golden `== 2`, so a future change to how many dice `attack` draws (a new rider roll reshuffles the seeded sequence) cannot make the test brittle.
- `test_force_hit_forces_hit_under_guard_without_faking_crits`: same unseeded pattern, same fixed seed (currently 5/80 crits, 80/80 hits). Its existing bound (`crits < 40` of 80) already had a negligible false-failure rate (~1e-30); seeded for reproducibility only, bound unchanged.

Siblings reviewed and left alone:

- `test_fast_resolve_averages_damage_under_guard`: unseeded but not statistical. Its only random failure path is all 20 strikes critting (0.05^20 ~ 1e-26).
- `test_unset_seed_is_nondeterministic_path` and `test_unseeded_roll_does_not_touch_shared_stream`: `reseed_process_rng(None)` is the behaviour under test there (the live-game default), so they must stay unseeded.
- No other test under `servers/engine/tests` uses `reseed_process_rng(None)`.

## Licensing / CLA

- [x] I have read `CLA.md` and submit this contribution under the WorldOS Contributor License Agreement.
- [x] I have not included confidential information, private customer data, private imported content, or third-party-restricted material.
- [x] Any third-party material in this PR is clearly identified with source and license. (None.)

## Review Thread State

- Current-head unresolved review threads: 0 (head 8859cf2)
- P0-P2 blocker count: 0
- P3/advisory count: 0
- Top-level bot comments requiring action: none. CodeRabbit hit its OSS review limit on this PR and produced no review; the Codex GitHub review is the cross-model reviewer of record (status in its summary comment).
- Check annotations requiring action: none
- Bot rerun status: n/a

## Validation

- `uv run --directory servers/engine --group dev pytest -q tests/test_combat_core.py` on this branch: all green.
- Seeded test repeated 3x: 2/40 every time.
- Broken-guard mutation (temp copy with `WORLDOS_COMBAT_TEST=1` set): fails with `40/40 hits`, as it must.
- Full engine suite on this branch: `uv run --directory servers/engine --group dev pytest -q` -> 3553 passed in 75 s.

## Release / WorldOS Proof Tier

- [x] Not release-affecting
- [ ] Local or fast smoke only
- [ ] Staging artifact proof
- [ ] Release proof
- [ ] Runtime/customer proof
- [ ] WorldOS RRI/persona proof required

## Release Notes / Changelog

- Release-note impact: none
- Draft human-readable entry or no-impact rationale: tests only; no engine behaviour changes.
- Verification/evidence tail needed? no

## Safety / Rollback

Tests only. Rollback is a revert of the single squash commit; the previous cap-12 assertion from #1769 would be restored unchanged.

## Evidence

- Evidence path: engine-only change with no visual surface, so per the template the evidence is the test names + suite line in Validation above.

## Notes For Next Agent

- Exact next action: once required checks are green and the Codex review is terminal with no findings, `gh pr merge 1780 --squash --auto`. Nothing else is pending on this PR.
