### PR TITLE
arc eval: completion verified against the seeded world (boss id / party location / giver alive) — av_ ruler bump; measured-model flag

### DIFF
--- a/qa/BEHAVIORAL_GATE_TAXONOMY.json
+++ b/qa/BEHAVIORAL_GATE_TAXONOMY.json
@@ -563,6 +563,16 @@
       "retest": "bash qa/run_combat_sprint.sh sprint-retest",
       "hint": "A ranged shot fired in melee (mutual-melee proxy => adjacency) without disadvantage. OFF-grid (theater-of-mind) this is a DM-adherence WARN — reinforce the ranged-in-melee disadvantage rule in the DM/angry-DM guidance; the proxy can mis-fire on a genuine gap. ON a grid (#461 PR-5) the engine AUTO-APPLIES the rule in server.py attack() and surfaces attack_roll.ranged_in_melee_disadvantage; the check reads that field so a grid run passes by construction. WARN only."
     },
+    "arc_objective_completion_truth": {
+      "category": "ENGINE_INVARIANT",
+      "likely_code_locations": [
+        "qa/quest_progress.py",
+        "qa/adventure_eval.py",
+        "qa/run_adventure.sh"
+      ],
+      "retest": "bash qa/run_adventure.sh arc-retest 20 4.00",
+      "hint": "The DM claimed objective completion but the seeded IDs, party location, giver life, or engine quest status disagreed at the stamp beat. The raw claim is retained; only seeded-world verification counts toward completion_rate. Arc-only (WORLDOS_GATE_ARC)."
+    },
     "arc_no_reroll_character": {
       "category": "DM_ADHERENCE",
       "likely_code_locations": [

--- a/qa/adventure_eval.py
+++ b/qa/adventure_eval.py
@@ -282,7 +282,16 @@ def read_run(prefix: str, config: dict) -> dict:
     """Read one run's artifacts (by path PREFIX) into a per-run record."""
     summary = _read_json(f"{prefix}.adventure.json")
     trace = _read_json(f"{prefix}.quest_trace.json")
-    completed, beats_to_complete, stamps = _completion_from_trace(trace)
+    claimed_from_status, beats_to_complete, stamps = _completion_from_trace(trace)
+    completion_claimed = bool((trace or {}).get("completion_claimed", claimed_from_status))
+    explicit_verified = (summary or {}).get("completion_verified")
+    if not isinstance(explicit_verified, bool):
+        explicit_verified = (trace or {}).get("completion_verified")
+    completion_verified = bool(explicit_verified) if isinstance(explicit_verified, bool) else False
+    completion_truth = list((summary or {}).get("completion_truth")
+                            or (trace or {}).get("completion_truth") or [])
+    if completion_claimed and not completion_verified and not completion_truth:
+        completion_truth = ["completion truth missing (pre-instrument run)"]
     dead = _dead_beats(prefix, summary)
     gap_outlier = _stage_gap_outlier(stamps, int(config.get("stage_gap_outlier_beats", 5)))
     dead_thr = int(config.get("dead_beat_stuck_threshold", 2))
@@ -291,7 +300,10 @@ def read_run(prefix: str, config: dict) -> dict:
     return {
         "run": Path(prefix).name,
         "prefix": prefix,
-        "completed": completed,
+        "completed": completion_verified,
+        "completion_claimed": completion_claimed,
+        "completion_verified": completion_verified,
+        "completion_truth": completion_truth,
         "beats_to_complete": beats_to_complete,
         "dead_beats": dead,
         "stage_gap_outlier": gap_outlier,
@@ -313,6 +325,7 @@ def read_run(prefix: str, config: dict) -> dict:
         # them at write time); otherwise they are resolved HERE from the run's own transcripts, so a
         # run predating provenance stamping still ledgers a real model id instead of a drifting alias.
         **_resolved_models(prefix, summary),
+        "measured": bool((summary or {}).get("measured", False)),
     }
 
 
@@ -357,7 +370,8 @@ def aggregate(prefixes: list[str], config: Optional[dict] = None) -> dict:
     if n == 0:
         raise ValueError("aggregate() needs at least one run prefix")
 
-    completion_rate = _mean([1.0 if r["completed"] else 0.0 for r in runs]) or 0.0
+    completion_rate = _mean([1.0 if r["completion_verified"] else 0.0 for r in runs]) or 0.0
+    completion_claimed = _mean([1.0 if r["completion_claimed"] else 0.0 for r in runs]) or 0.0
     completed_beats = [r["beats_to_complete"] for r in runs if r["completed"] and r["beats_to_complete"] is not None]
     median_beats_to_complete = _median(completed_beats)
 
@@ -420,6 +434,11 @@ def aggregate(prefixes: list[str], config: Optional[dict] = None) -> dict:
     return {
         "n": n,
         "completion_rate": round(completion_rate, 3),
+        "completion_claimed": round(completion_claimed, 3),
+        "completion_verified": all(r["completion_verified"] for r in runs),
+        "completion_truth": [{"run": r["run"], "reasons": r["completion_truth"]}
+                             for r in runs if r["completion_truth"]],
+        "measured": all(r["measured"] for r in runs),
         "median_beats_to_complete": median_beats_to_complete,
         "median_wall_s": _median([r["wall_s"] for r in runs]),
         "median_s_per_beat": _median([r["s_per_beat"] for r in runs]),
@@ -492,7 +511,8 @@ def persist_row(
     # MISSING evidence (green_rate None -> behavioral None) fails — a citable passing row requires
     # positive gate evidence on every aggregated run.
     pass_bar = float(load_config().get("pass_completion_rate", 0.5))
-    passed = 1 if (agg["completion_rate"] >= pass_bar and behavioral == "GREEN") else 0
+    passed = 1 if (agg["completion_rate"] >= pass_bar and behavioral == "GREEN"
+                   and agg.get("measured") is True) else 0
 
     # Provenance: a CLI override wins, else the model the runs recorded, else a default (+ note).
     defaulted: list[str] = []
@@ -535,6 +555,10 @@ def persist_row(
         "mech_overall": agg["mech_overall"],
         "angrydm_overall": agg["angrydm_overall"],
         "behavioral": behavioral,
+        "completion_claimed": agg["completion_claimed"],
+        "completion_verified": int(agg["completion_verified"]),
+        "completion_truth": json.dumps(agg["completion_truth"], ensure_ascii=False, sort_keys=True),
+        "measured": int(agg["measured"]),
         "engagement_pct": agg["engagement_pct"],
         "s_per_beat": agg["median_s_per_beat"],
         "duration_wall_s": agg["median_wall_s"],

--- a/qa/adventure_eval_config.json
+++ b/qa/adventure_eval_config.json
@@ -4,6 +4,7 @@
   "stage_gap_outlier_beats": 5,
   "dead_beat_stuck_threshold": 2,
   "pass_completion_rate": 0.5,
+  "measured_dm_model": "claude-opus-4-8",
   "dimensions": {
     "completion": {"lever": "arc-completion: tighten the DM arc addendum, verify the giver->crypt->boss->return seam is unblocked, or raise the beat budget"},
     "pace": {"lever": "pace: the arc drags to completion; sharpen the per-beat objective nudges that push toward the crypt and the boss"},

--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -1887,6 +1887,17 @@ def main() -> int:
     if os.environ.get("WORLDOS_GATE_ARC"):
         arc_events = _arc_tool_events(events)
 
+        truth_path = os.environ.get("WORLDOS_ARC_QUEST_TRACE", "")
+        try:
+            truth = json.loads(Path(truth_path).read_text(encoding="utf-8")) if truth_path else {}
+        except (OSError, ValueError):
+            truth = {}
+        if truth.get("completion_claimed") is True and truth.get("completion_verified") is not True:
+            reasons = truth.get("completion_truth") or ["seeded-world verification missing"]
+            chk("arc_objective_completion_truth", False,
+                "objective ticked against invented content: " + "; ".join(map(str, reasons)),
+                fatal=True)
+
         rerolls = [_arc_beat_label(bt) for bt, short, _i, _o, err in arc_events
                    if short == "reroll_character" and not err]
         if rerolls:

--- a/qa/gate_corpus/builder.py
+++ b/qa/gate_corpus/builder.py
@@ -75,7 +75,7 @@ TODO_REASONS = {
 # baseline session gates (dice_used / player_in_party), so no case here can ISOLATE one arc row.
 # Covered instead by qa/test_arc_gate.py, which drives this same gate CLI over tiny synthetic
 # transcripts with the toggles set and asserts each row is a [FAIL] naming its beat.
-for _arc_check in ("arc_no_reroll_character", "arc_no_add_location",
+for _arc_check in ("arc_objective_completion_truth", "arc_no_reroll_character", "arc_no_add_location", "arc_no_create_character",
                    "arc_only_seeded_species", "arc_end_combat_live_hostiles",
                    "arc_essential_npc_killed", "arc_quest_softlocked_on_dead_npc"):
     TODO_REASONS[_arc_check] = (

--- a/qa/gate_corpus/manifest.json
+++ b/qa/gate_corpus/manifest.json
@@ -229,6 +229,12 @@
       "reason": "seeded-arc lens: opt-in via WORLDOS_GATE_ARC (+ WORLDOS_ARC_SEED_SPECIES for the species rule) \u2014 env toggles and a 5th artifact path that _write_case's 4 positional argv artifacts cannot express, and no synthetic arc bundle can isolate one arc row from the baseline session gates \u2014 covered by qa/test_arc_gate.py (red-first, per-row, per-beat)"
     },
     {
+      "case_dir": "TODO__arc_objective_completion_truth",
+      "expected_red_check": "arc_objective_completion_truth",
+      "todo": true,
+      "reason": "seeded-arc lens: opt-in via WORLDOS_GATE_ARC (+ WORLDOS_ARC_SEED_SPECIES for the species rule) \u2014 env toggles and a 5th artifact path that _write_case's 4 positional argv artifacts cannot express, and no synthetic arc bundle can isolate one arc row from the baseline session gates \u2014 covered by qa/test_arc_gate.py (red-first, per-row, per-beat)"
+    },
+    {
       "case_dir": "TODO__arc_only_seeded_species",
       "expected_red_check": "arc_only_seeded_species",
       "todo": true,

--- a/qa/quest_progress.py
+++ b/qa/quest_progress.py
@@ -279,6 +279,88 @@ def _stamped_stages(trace: dict) -> set[str]:
     return {str(s.get("stage")) for s in trace.get("stamps") or [] if s.get("stage")}
 
 
+def _seeded_world(server, campaign_id: str, quest: dict) -> dict:
+    """Freeze fixture identities before the DM can rename, reuse, move, or mint content."""
+    c = server._require(campaign_id)
+    giver_id = str(quest.get("giver_id") or "")
+    crypt_id = str(quest.get("location_id") or "")
+    throne_id = next((str(lid) for lid, loc in c.locations.items()
+                      if str(lid) == "throne_hall"
+                      or str(getattr(loc, "name", "")).lower().replace(" ", "_") == "throne_hall"), "")
+    monsters = [(str(cid), ch) for cid, ch in c.characters.items()
+                if str(getattr(ch, "kind", "")) == "monster"]
+    boss_id = next((cid for cid, ch in monsters
+                    if str(getattr(ch, "creature_slug", "")) == "goblin-boss"), "")
+    return {
+        "giver_id": giver_id,
+        "giver_location_id": getattr(c.characters.get(giver_id), "location_id", None),
+        "crypt_location_id": crypt_id,
+        "throne_location_id": throne_id,
+        "crypt_hostile_ids": [cid for cid, ch in monsters
+                              if getattr(ch, "location_id", None) == crypt_id],
+        "boss_id": boss_id,
+    }
+
+
+def _verify_objective(server, campaign_id: str, quest: dict, seed: dict, index: int) -> dict:
+    c = server._require(campaign_id)
+    objective = str((quest.get("objectives") or [])[index - 1])
+    party_loc = getattr(c, "current_location_id", None)
+    giver = c.characters.get(seed.get("giver_id"))
+    giver_alive = giver is not None and not getattr(giver, "dead", False) \
+        and (getattr(giver, "current_hp", 1) or 0) > 0
+    failures: list[str] = []
+    if index == 1:
+        if party_loc != seed.get("giver_location_id"):
+            failures.append(f"party at {party_loc}, not giver location {seed.get('giver_location_id')}")
+        if not giver_alive:
+            failures.append(f"seeded giver {seed.get('giver_id')} is not alive")
+    elif index == 2:
+        for cid in seed.get("crypt_hostile_ids") or []:
+            ch = c.characters.get(cid)
+            if ch is None or (not getattr(ch, "dead", False)
+                              and (getattr(ch, "current_hp", 1) or 0) > 0
+                              and getattr(ch, "location_id", None) is not None):
+                hp = getattr(ch, "current_hp", "missing") if ch is not None else "missing"
+                failures.append(f"seeded crypt hostile {cid} alive at {hp}")
+    elif index == 3:
+        boss = c.characters.get(seed.get("boss_id"))
+        if boss is None or not getattr(boss, "dead", False):
+            hp = getattr(boss, "current_hp", "missing") if boss is not None else "missing"
+            max_hp = getattr(boss, "max_hp", "?") if boss is not None else "?"
+            failures.append(f"seeded boss {seed.get('boss_id')} alive at {hp}/{max_hp}")
+        valid_locs = {seed.get("throne_location_id"), getattr(boss, "location_id", None)} - {None, ""}
+        if party_loc not in valid_locs:
+            failures.append(f"party at {party_loc}, not seeded throne/boss location")
+    elif index == 4:
+        if not giver_alive:
+            failures.append(f"seeded giver {seed.get('giver_id')} is not alive")
+        if party_loc != seed.get("giver_location_id"):
+            failures.append(f"party at {party_loc}, not giver location {seed.get('giver_location_id')}")
+        if str(quest.get("status") or "").lower() != "completed":
+            failures.append(f"engine quest status is {quest.get('status')!r}, not completed")
+    return {"index": index, "objective": objective, "verified": not failures,
+            "reason": f"objective {index} {objective!r}: " + "; ".join(failures) if failures else ""}
+
+
+def _stamp_completion_truth(server, campaign_id: str, quest: dict, trace: dict) -> None:
+    if "seeded_world" not in trace:
+        trace["seeded_world"] = _seeded_world(server, campaign_id, quest)
+    old_done = set(trace.get("completed_objectives") or [])
+    records = {int(r["index"]): r for r in trace.get("objective_truth") or []}
+    for index, objective in enumerate(quest.get("objectives") or [], 1):
+        if objective in (quest.get("completed_objectives") or []) and objective not in old_done:
+            records[index] = _verify_objective(server, campaign_id, quest, trace["seeded_world"], index)
+    trace["objective_truth"] = [records[i] for i in sorted(records)]
+    claimed = str(quest.get("status") or "").lower() == "completed"
+    missing = [i for i in range(1, len(quest.get("objectives") or []) + 1) if i not in records]
+    trace["completion_claimed"] = claimed
+    trace["completion_verified"] = claimed and not missing and all(r["verified"] for r in records.values())
+    trace["completion_truth"] = [r["reason"] for r in records.values() if not r["verified"]]
+    if claimed:
+        trace["completion_truth"] += [f"objective {i}: no world verification recorded" for i in missing]
+
+
 def stamp_beat(
     trace: dict,
     found: dict[str, str],
@@ -370,6 +452,7 @@ def poll(
         except Exception:
             giver_name = ""
 
+    _stamp_completion_truth(server, campaign_id, quest, trace)
     found = detect_stages(server, campaign_id, state_dir, quest=quest, giver_name=giver_name)
     newly = stamp_beat(trace, found, beat=beat, campaign_id=campaign_id, quest=quest)
     save_trace(trace_path, trace)

--- a/qa/run_adventure.sh
+++ b/qa/run_adventure.sh
@@ -243,6 +243,7 @@ fi
 if [ "$RESUME_MODE" != "1" ]; then
   adv_clean_stale_artifacts   # fresh run: a rerun of a completed run-id must not inherit stale state
   adv_seed
+  adv_quest_poll 0 >/dev/null  # freeze seeded IDs before the DM can rename/reuse/mint world content
 fi
 
 worldos_isolate_claude_auth
@@ -503,7 +504,7 @@ done
 
 # WORLDOS_GATE_ARC turns on the seeded-arc lens (the addendum's five rules as hard FAIL rows);
 # WORLDOS_ARC_SEED_SPECIES hands it the species this run was actually SEEDED with.
-WORLDOS_GATE_ARC=1 WORLDOS_ARC_SEED_SPECIES="$SEED_SPECIES" \
+WORLDOS_GATE_ARC=1 WORLDOS_ARC_SEED_SPECIES="$SEED_SPECIES" WORLDOS_ARC_QUEST_TRACE="$TRACE" \
   python3 "$ASSERT_BEHAVIORAL_SCRIPT" "$COMBINED" "$T/$RUN.state.json" "$T/$RUN.chat.jsonl" "$MOVES" | tee "$T/$RUN.gate.txt"; GATE=${PIPESTATUS[0]}
 # ── honest scoring on a RED gate (item 11; mirrors run_duo) ──────────────────────────────────────
 # A structurally broken (gate-RED) run must not persist high lens medians — CAP the three lens files
@@ -548,7 +549,10 @@ if completed_stamp:
     if sig.startswith("status:"): status=sig.split(":",1)[1].strip().lower()
 if not status: status=str(tr.get("quest_status") or "active").strip().lower()
 completed=(status=="completed")   # completion HONESTY — a terminal "failed"/other is NOT a completion
-btc=completed_stamp.get("beat") if (completed and completed_stamp) else None
+completion_claimed=bool(tr.get("completion_claimed", completed))
+completion_verified=bool(tr.get("completion_verified", False))
+completion_truth=list(tr.get("completion_truth") or [])
+btc=completed_stamp.get("beat") if (completion_verified and completed_stamp) else None
 gate_txt=""
 try: gate_txt=Path(gate).read_text()
 except Exception: pass
@@ -563,12 +567,18 @@ else:
 dead=rj(lat).get("failed_beats")
 lb=int(last_beat) if str(last_beat).lstrip("-").isdigit() else None
 session_beats=lb if (lb is not None and lb>=0) else None
+cfg=rj(str(Path(qa_dir)/"adventure_eval_config.json"))
+measured=(resolved.get("dm_model_resolved") == cfg.get("measured_dm_model", "claude-opus-4-8"))
 Path(out).write_text(json.dumps({"run":run,"campaign_id":tr.get("campaign_id"),"quest_status":tr.get("quest_status"),
-  "completed":bool(completed),"beats_to_complete":btc,"last_completed_beat":lb,"session_beats":session_beats,
+  "completed":completion_verified,"completion_claimed":completion_claimed,
+  "completion_verified":completion_verified,"completion_truth":completion_truth,
+  "beats_to_complete":btc,"last_completed_beat":lb,"session_beats":session_beats,
   "dm_model":dm_model or None,"actor_model":actor_model or None,
   "dm_model_resolved":resolved.get("dm_model_resolved"),"player_model_resolved":resolved.get("player_model_resolved"),
+  "measured":measured,
   "dead_beats":dead,"behavioral":behavioral,"stages_reached":[s.get("stage") for s in stamps]},indent=2)+"\n")
-print(f"[adventure] summary: completed={completed} beats_to_complete={btc} behavioral={behavioral} "
+print(f"[adventure] summary: claimed={completion_claimed} verified={completion_verified} "
+      f"beats_to_complete={btc} behavioral={behavioral} measured={measured} "
       f"dm={dm_model}({resolved.get('dm_model_resolved') or 'unresolved'}) "
       f"actor={actor_model}({resolved.get('player_model_resolved') or 'unresolved'})")
 PY

--- a/qa/scores_db.py
+++ b/qa/scores_db.py
@@ -118,6 +118,10 @@ COLUMNS: tuple[str, ...] = (
                                # aggregator's OWN hash family (see scoring_config_version.py
                                # ADVENTURE_CONFIG_FILES). Stamped ONLY on surface="adventure" rows;
                                # NULL on every other row (additive, migration-free — mirrors ac_ruler).
+    "completion_claimed",      # raw DM/engine completion stamp rate; never used as completion score
+    "completion_verified",     # 1 only when every run's seeded-world objective checks passed
+    "completion_truth",        # JSON [{run,reasons}] explaining claimed/verified disagreement
+    "measured",                # 1 only for the ruler-pinned resolved DM model
     "rc_label",           # release candidate this run scored, e.g. "v1.0.4-rc1" (NULL = ad-hoc)
     "story_overall",      # Tolkien/story-craft lens (0-5), NULL if not scored
     "mech_overall",       # Mechanical lens (0-5), NULL if not scored
@@ -203,12 +207,14 @@ _REAL_COLS = {
     "duration_wall_s",
     # WS0 engagement coverage fraction (0.0-1.0 → REAL; engagement_inert is TEXT)
     "engagement_pct",
+    "completion_claimed",
     # visual-critic loop (0-10 gap-to-reference score → REAL)
     "visual_overall",
     # L7 motion lens (0-10 holistic motion score → REAL)
     "motion_overall",
 }
-_INT_COLS = {"critical_bugs", "pass", "is_canonical_baseline", "acts_reached", "visual_round"}
+_INT_COLS = {"critical_bugs", "pass", "is_canonical_baseline", "acts_reached", "visual_round",
+             "completion_verified", "measured"}
 
 
 def _coltype(col: str) -> str:

--- a/qa/test_adventure_eval.py
+++ b/qa/test_adventure_eval.py
@@ -36,6 +36,9 @@ def _write_run(
     dead_beats: int | None = 0,
     wall_s: float | None = 300.0,
     s_per_beat: float | None = 20.0,
+    completion_verified: bool | None = None,
+    completion_truth: list[str] | None = None,
+    measured: bool = True,
 ) -> str:
     """Write one synthetic run's artifacts under tmp/<run_id>.* and return the prefix."""
     prefix = str(tmp / run_id)
@@ -49,6 +52,9 @@ def _write_run(
     trace = {
         "campaign_id": "adventure_demo_v1",
         "quest_status": "completed" if completed else "active",
+        "completion_claimed": completed,
+        "completion_verified": completed if completion_verified is None else completion_verified,
+        "completion_truth": completion_truth or [],
         "stamps": [{"stage": s, "beat": b, "ts": "t", "signal": "objective:x"} for s, b in stages],
     }
     Path(f"{prefix}.quest_trace.json").write_text(json.dumps(trace))
@@ -63,7 +69,10 @@ def _write_run(
         gate = "[PASS] all good\n" if behavioral == "GREEN" else "[FAIL] player_turns_structured\n"
         Path(f"{prefix}.gate.txt").write_text(gate)
 
-    summary = {"behavioral": behavioral, "engagement_pct": engagement_pct, "dead_beats": dead_beats}
+    summary = {"behavioral": behavioral, "engagement_pct": engagement_pct, "dead_beats": dead_beats,
+               "completion_claimed": completed,
+               "completion_verified": completed if completion_verified is None else completion_verified,
+               "completion_truth": completion_truth or [], "measured": measured}
     Path(f"{prefix}.adventure.json").write_text(json.dumps(summary))
 
     # latency
@@ -115,6 +124,32 @@ def test_partial_completion_rate_and_median_beats(tmp_path):
     assert agg["dimensions"]["completion"] < 1.0
 
 
+def test_claimed_boss_completion_does_not_count_without_world_truth(tmp_path):
+    reason = "objective 3 'Slay the goblin boss': seeded boss boss-1 alive at 21/21"
+    prefix = _write_run(tmp_path, "invented", completed=True,
+                        completion_verified=False, completion_truth=[reason])
+    agg = ae.aggregate([prefix])
+    assert agg["completion_claimed"] == 1.0
+    assert agg["completion_rate"] == 0.0
+    assert agg["runs"][0]["completion_verified"] is False
+    db = tmp_path / "scores.db"
+    ae.persist_row(agg, run_id="invented", db_path=str(db))
+    row = scores_db.fetch_rows(str(db))[0]
+    assert row["completion_claimed"] == 1.0
+    assert row["completion_verified"] == 0
+    assert reason in json.loads(row["completion_truth"])[0]["reasons"]
+
+
+def test_unpinned_model_persists_as_unmeasured(tmp_path):
+    prefix = _write_run(tmp_path, "unmeasured", measured=False)
+    agg = ae.aggregate([prefix])
+    db = tmp_path / "scores.db"
+    fields = ae.persist_row(agg, run_id="unmeasured", db_path=str(db))
+    assert fields["measured"] == 0
+    assert fields["pass"] == 0
+    assert scores_db.fetch_rows(str(db))[0]["measured"] == 0
+
+
 def test_stuck_detection_dead_beats_and_stage_gap(tmp_path):
     # adv0: clean. adv1: dead beats over threshold. adv2: a big stage gap (2 -> 12) outlier.
     p0 = _write_run(tmp_path, "adv0", dead_beats=0)
@@ -139,7 +174,9 @@ def test_missing_artifacts_are_tolerated(tmp_path):
         {"quest_status": "completed",
          "stamps": [{"stage": "quest_completed", "beat": 7, "signal": "status:completed"}]}))
     agg = ae.aggregate([prefix])
-    assert agg["completion_rate"] == 1.0
+    assert agg["completion_claimed"] == 1.0
+    assert agg["completion_rate"] == 0.0
+    assert "pre-instrument" in agg["completion_truth"][0]["reasons"][0]
     assert agg["dimensions"]["story"] is None
     assert agg["dimensions"]["mechanics"] is None
     assert agg["dimensions"]["behavioral"] is None
@@ -223,14 +260,15 @@ def test_failed_quest_is_not_a_completion(tmp_path):
     assert per["advfail"]["beats_to_complete"] is None
 
 
-def test_completed_status_signal_counts(tmp_path):
+def test_completed_status_signal_is_claim_only_without_world_truth(tmp_path):
     prefix = str(tmp_path / "advok")
     Path(f"{prefix}.quest_trace.json").write_text(json.dumps({
         "quest_status": "completed",
         "stamps": [{"stage": "quest_completed", "beat": 5, "signal": "status:completed"}]}))
     agg = ae.aggregate([prefix])
-    assert agg["completion_rate"] == 1.0
-    assert agg["median_beats_to_complete"] == 5
+    assert agg["completion_claimed"] == 1.0
+    assert agg["completion_rate"] == 0.0
+    assert agg["median_beats_to_complete"] is None
 
 
 # ── item 17: behavioral GREEN requires POSITIVE evidence, not the absence of [FAIL] ──────────────

--- a/qa/test_arc_gate.py
+++ b/qa/test_arc_gate.py
@@ -64,7 +64,8 @@ def _clean_events() -> list[dict]:
 
 def _run_gate(tmp_path: Path, events: list[dict], *, arc: bool = True,
               manifest: dict | None = SEED_MANIFEST,
-              state_obj: dict | None = None) -> tuple[int, str]:
+              state_obj: dict | None = None,
+              truth_trace: dict | None = None) -> tuple[int, str]:
     run = tmp_path / "run.jsonl"
     run.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
     state = tmp_path / "state.json"
@@ -79,6 +80,10 @@ def _run_gate(tmp_path: Path, events: list[dict], *, arc: bool = True,
             mp = tmp_path / "seed_species.json"
             mp.write_text(json.dumps(manifest), encoding="utf-8")
             env["WORLDOS_ARC_SEED_SPECIES"] = str(mp)
+        if truth_trace is not None:
+            tp = tmp_path / "quest_trace.json"
+            tp.write_text(json.dumps(truth_trace), encoding="utf-8")
+            env["WORLDOS_ARC_QUEST_TRACE"] = str(tp)
     proc = subprocess.run([sys.executable, str(GATE), str(run), str(state)],
                           cwd=str(REPO), env=env, capture_output=True, text=True)
     return proc.returncode, proc.stdout + proc.stderr
@@ -99,6 +104,18 @@ def _arc_fail_rows(out: str) -> list[str]:
 def test_clean_arc_transcript_is_green(tmp_path):
     _rc, out = _run_gate(tmp_path, _clean_events())
     assert not _arc_fail_rows(out), out
+
+
+def test_objective_ticked_against_invented_content_is_a_hard_fail(tmp_path):
+    reason = "objective 3 'Slay the goblin boss': seeded boss boss-1 alive at 21/21"
+    rc, out = _run_gate(tmp_path, _clean_events(), truth_trace={
+        "quest_status": "completed", "completion_claimed": True,
+        "completion_verified": False, "completion_truth": [reason],
+    })
+    assert rc == 1, out
+    rows = [row for row in _arc_fail_rows(out) if "arc_objective_completion_truth" in row]
+    assert rows, out
+    assert f"objective ticked against invented content: {reason}" in rows[0]
 
 
 # ── 1. reroll_character ────────────────────────────────────────────────────────────────────────

--- a/qa/test_artifact_evals.py
+++ b/qa/test_artifact_evals.py
@@ -34,7 +34,7 @@ import artifact_calibration_panel as panel  # noqa: E402
 # would silently re-version every historical engine-duo score. These pin the exact current hashes
 # (origin/main @ the HV1 branch point). If a future edit changes them, this test goes RED and forces a
 # conscious re-baseline (the same discipline test_scores_db_comparability enforces for content edits).
-EXPECTED_SC = "sc_903cf42f4e49"  # re-baselined 2026-09-02 (arc-addendum-v2, bot round 2): the arc
+EXPECTED_SC = "sc_257531b10b73"  # re-baselined 2026-09-02 (arc-addendum-v2, bot round 2): the arc
 # lens gained a SEVENTH FATAL row (arc_no_create_character) and three correctness fixes — the
 # manifest SHAPE guard, the engine's downed-vs-dead predicate, and standing the essential-cast rows
 # down once no quest is unresolved. Still OPT-IN (WORLDOS_GATE_ARC, set only by qa/run_adventure.sh
@@ -43,11 +43,11 @@ EXPECTED_SC = "sc_903cf42f4e49"  # re-baselined 2026-09-02 (arc-addendum-v2, bot
 # change, not a ruler recalibration.
 # (prior: sc_191aeb7c0450 — the same lens's first six FATAL rows, re-baselined earlier the same day)
 # (prior: sc_38b768e2fd1b — re-baselined #1427: release_readiness.py touched by #1417/#1414)
-EXPECTED_LC = "lc_5e2170acc38d"  # re-baselined 2026-09-02 with sc_ above: assert_behavioral.py is in
+EXPECTED_LC = "lc_e9fcdb20a4f7"  # re-baselined 2026-09-02 with sc_ above: assert_behavioral.py is in
 # LENS_CONFIG_FILES too, so the same opt-in-lens byte change moves lc_ by construction. This is also
 # what fences the ADVENTURE trend across this change: scores_db.add_run auto-stamps
 # lens_config_version on every row and _BASELINE_KEY includes it, so pre- and post-change adventure
-# aggregates cannot be compared as one trend — which is why av_ is deliberately NOT bumped here.
+# aggregates cannot be compared as one trend; completion truth also moves av_ via formula/config.
 # (prior: lc_04e90e3b56d3 — the same lens's first six FATAL rows)
 # (prior: lc_b031bd9f47e1 — "qa: auto-persist scores rows for the manual-append bucket",
 # commit 9f244613) — that PR only ADDS a new --scores-db CLI arg and an auto-persist call for the

--- a/qa/test_quest_progress.py
+++ b/qa/test_quest_progress.py
@@ -137,6 +137,56 @@ def test_full_arc_stamps_all_six_in_order(seeded):
     assert beats == sorted(beats)
 
 
+def test_claimed_completion_is_false_when_seeded_boss_is_alive(seeded):
+    server, state, cid = seeded
+    q = _quest(server, cid)
+    qp.poll(state, cid, beat=0)  # freezes the seeded ids before any objective is ticked
+    for objective in q["objectives"]:
+        server.complete_objective(cid, q["id"], objective)
+    res = qp.poll(state, cid, beat=1)
+    trace = _load(res["trace_path"])
+    assert trace["completion_claimed"] is True
+    assert trace["completion_verified"] is False
+    assert any("objective 3" in reason and "alive" in reason
+               for reason in trace["completion_truth"]), trace["completion_truth"]
+
+
+def test_world_true_completion_verifies_all_seeded_objectives(seeded):
+    server, state, cid = seeded
+    q = _quest(server, cid)
+    baseline = qp.poll(state, cid, beat=0)
+    seed = _load(baseline["trace_path"])["seeded_world"]
+
+    _set_location(server, cid, seed["giver_location_id"])
+    server.complete_objective(cid, q["id"], _obj(server, cid, "Speak with"))
+    qp.poll(state, cid, beat=1)
+
+    c = server._require(cid)
+    for hostile_id in seed["crypt_hostile_ids"]:
+        c.characters[hostile_id].dead = True
+        c.characters[hostile_id].current_hp = 0
+    server.save_campaign(c)
+    _set_location(server, cid, seed["crypt_location_id"])
+    server.complete_objective(cid, q["id"], _obj(server, cid, "Clear the crypt"))
+    qp.poll(state, cid, beat=2)
+
+    c = server._require(cid)
+    c.characters[seed["boss_id"]].dead = True
+    c.characters[seed["boss_id"]].current_hp = 0
+    server.save_campaign(c)
+    _set_location(server, cid, seed["throne_location_id"])
+    server.complete_objective(cid, q["id"], _obj(server, cid, "Slay the goblin boss"))
+    qp.poll(state, cid, beat=3)
+
+    _set_location(server, cid, seed["giver_location_id"])
+    server.complete_objective(cid, q["id"], _obj(server, cid, "Return to Maera"))
+    res = qp.poll(state, cid, beat=4)
+    trace = _load(res["trace_path"])
+    assert trace["completion_claimed"] is True
+    assert trace["completion_verified"] is True
+    assert trace["completion_truth"] == []
+
+
 def test_terminal_signals_are_never_gated(seeded):
     """A real terminal signal (a slain-boss objective) stamps boss_dead even when the intervening
     entered_dungeon location-beat was never independently caught — telemetry must never DROP a real


### PR DESCRIPTION
## Outcome

Arc completion now counts only when each objective agrees with the seeded engine world at the beat it is stamped. Raw terminal stamps remain visible as completion_claimed; completion_rate uses completion_verified. Claimed/verified disagreement emits the hard arc row objective ticked against invented content.

The run summary and scores row now carry completion_claimed, completion_verified, completion_truth, and measured. measured is true only when dm_model_resolved matches adventure_eval_config.measured_dm_model (claude-opus-4-8); unpinned runs cannot pass.

## Rulers

SCORECARD: av_a9536e9af875 -> av_f281380acd11 — completion_rate now world-verified; completion_claimed retained; measured_model=claude-opus-4-8

SCORING_CONFIG_FILES is unchanged. The added opt-in assert_behavioral row necessarily restamps its existing byte-hash families: sc_903cf42f4e49 -> sc_257531b10b73; lc_5e2170acc38d -> lc_e9fcdb20a4f7.

## Fixture verdicts

- synthetic boss-alive fixture: completion_claimed=true, completion_verified=false, hard FAIL row
- adv_ctl_o48_b20: completion_verified=false — finding: Keeper Maera was killed before the reward stamp, and the three seeded crypt hostile IDs remain alive in crypt
- adv_v2_smoke1: completion_verified=false — seeded boss alive 21/21, party never entered throne_hall, one seeded crypt hostile alive, reward collected by invented characters

## Proof

- full absolute-path QA bundle: 948 passed, 11 skipped, 5 subtests passed
- focused truth/ruler/corpus bundle: 133 passed, 9 skipped
- qa/fast_gate.sh: 257 passed
- qa/tests/test_arc_mode_runbook.sh: PASS
- bash -n qa/run_adventure.sh: PASS
- no live/model run performed

Follow-up context: #1766 and #1781.

Claim class: unit-tested-instrument. This does not prove a live arc completion.