### PR TITLE
arc eval: close completion-truth review findings

### DIFF
--- a/qa/adventure_eval.py
+++ b/qa/adventure_eval.py
@@ -297,6 +297,7 @@ def read_run(prefix: str, config: dict) -> dict:
     dead_thr = int(config.get("dead_beat_stuck_threshold", 2))
     stuck = bool((dead is not None and dead >= dead_thr) or gap_outlier)
     wall_s, s_per_beat = _wall_and_pace(prefix)
+    resolved_models = _resolved_models(prefix, summary)
     return {
         "run": Path(prefix).name,
         "prefix": prefix,
@@ -324,8 +325,8 @@ def read_run(prefix: str, config: dict) -> dict:
         # The CONCRETE ids. The summary wins when the run recorded them (run_adventure.sh resolves
         # them at write time); otherwise they are resolved HERE from the run's own transcripts, so a
         # run predating provenance stamping still ledgers a real model id instead of a drifting alias.
-        **_resolved_models(prefix, summary),
-        "measured": bool((summary or {}).get("measured", False)),
+        **resolved_models,
+        "measured": resolved_models["dm_model_resolved"] == config.get("measured_dm_model"),
     }
 
 

--- a/qa/run_adventure.sh
+++ b/qa/run_adventure.sh
@@ -243,7 +243,10 @@ fi
 if [ "$RESUME_MODE" != "1" ]; then
   adv_clean_stale_artifacts   # fresh run: a rerun of a completed run-id must not inherit stale state
   adv_seed
-  adv_quest_poll 0 >/dev/null  # freeze seeded IDs before the DM can rename/reuse/mint world content
+  if ! adv_quest_poll 0 >/dev/null; then  # freeze IDs before any DM mutation
+    echo "[adventure] could not freeze the seeded world before the DM turn — aborting" >&2
+    exit 1
+  fi
 fi
 
 worldos_isolate_claude_auth

--- a/qa/scoring_config_version.py
+++ b/qa/scoring_config_version.py
@@ -101,6 +101,7 @@ ARTIFACT_CONFIG_FILES: list[str] = [
 ADVENTURE_CONFIG_FILES: list[str] = [
     "adventure_eval_config.json",
     "adventure_eval.py",
+    "quest_progress.py",
 ]
 
 

--- a/qa/test_adventure_eval.py
+++ b/qa/test_adventure_eval.py
@@ -72,7 +72,8 @@ def _write_run(
     summary = {"behavioral": behavioral, "engagement_pct": engagement_pct, "dead_beats": dead_beats,
                "completion_claimed": completed,
                "completion_verified": completed if completion_verified is None else completion_verified,
-               "completion_truth": completion_truth or [], "measured": measured}
+               "completion_truth": completion_truth or [], "measured": measured,
+               "dm_model_resolved": "claude-opus-4-8" if measured else None}
     Path(f"{prefix}.adventure.json").write_text(json.dumps(summary))
 
     # latency
@@ -150,6 +151,15 @@ def test_unpinned_model_persists_as_unmeasured(tmp_path):
     assert scores_db.fetch_rows(str(db))[0]["measured"] == 0
 
 
+def test_measured_is_recomputed_against_active_model_pin(tmp_path):
+    prefix = _write_run(tmp_path, "old-pin", measured=True)
+    summary_path = Path(f"{prefix}.adventure.json")
+    summary = json.loads(summary_path.read_text())
+    summary["dm_model_resolved"] = "a-previously-measured-model"
+    summary_path.write_text(json.dumps(summary))
+    assert ae.aggregate([prefix])["measured"] is False
+
+
 def test_stuck_detection_dead_beats_and_stage_gap(tmp_path):
     # adv0: clean. adv1: dead beats over threshold. adv2: a big stage gap (2 -> 12) outlier.
     p0 = _write_run(tmp_path, "adv0", dead_beats=0)
@@ -197,7 +207,7 @@ def test_persist_writes_one_adventure_row(tmp_path):
     assert row["surface"] == "adventure"
     # methodology names the budget the row was scored under + the models (aliases + resolved ids)
     assert row["methodology"].startswith("arc-duo N=3 beat_budget=20 ")
-    assert "dm=opus(unresolved)" in row["methodology"]
+    assert "dm=opus(claude-opus-4-8)" in row["methodology"]
     assert row["behavioral"] == "GREEN"
     assert "WEAKEST-LINK:" in row["notes"]
     assert adventure_config_version() in row["notes"]  # av_ ruler stamped in notes
@@ -232,6 +242,7 @@ def test_stages_bound_to_quest_progress():
 def test_adventure_ruler_fences_formulas():
     assert "adventure_eval.py" in ADVENTURE_CONFIG_FILES
     assert "adventure_eval_config.json" in ADVENTURE_CONFIG_FILES
+    assert "quest_progress.py" in ADVENTURE_CONFIG_FILES
 
 
 # ── item 3: stage-gap outlier uses abs() (guards corrupted/partial traces) ───────────────────────

--- a/qa/test_quest_progress.py
+++ b/qa/test_quest_progress.py
@@ -30,6 +30,10 @@ sys.path.insert(0, str(REPO / "servers" / "engine"))
 import quest_progress as qp  # noqa: E402
 
 
+def test_runner_fails_closed_when_seed_snapshot_cannot_be_frozen():
+    assert 'if ! adv_quest_poll 0 >/dev/null; then' in RUNNER.read_text()
+
+
 def _seed(state_dir: Path) -> str:
     """Seed the adventure fixture into ``state_dir`` via the real seeder; return the campaign id."""
     os.environ["WORLDOS_STATE_DIR"] = str(state_dir)


### PR DESCRIPTION
Follow-up delta to #1784 after its single Codex review completed post-merge.

Fixed verified findings:
- abort before the first DM turn when the seeded-world snapshot cannot be frozen
- recompute measured from dm_model_resolved against the active measured_dm_model pin
- include quest_progress.py in the av_ ruler inputs

Terminal dispositions for the other review comments:
- boss-location check: false/not applicable; the accepted contract explicitly permits the seeded throne hall or the seeded boss location at the stamped beat
- reward inventory check: false/not applicable; the accepted contract requires living giver + co-location + engine-resolved quest, not item transfer

Ruler delta: av_f281380acd11 -> av_bc15bcc23d53. Original pre-instrument ruler -> final: av_a9536e9af875 -> av_bc15bcc23d53.

Proof:
- full absolute-path QA CI list plus quest/adventure/seed: 950 passed, 11 skipped, 5 subtests
- focused truth suite: 119 passed
- qa/fast_gate.sh: 257 passed
- bash syntax: pass

Claim class: unit-tested-instrument. No live/model run.