### PR TITLE
qa: align adventure completion bar with recorded G2 threshold

### DIFF
--- a/qa/adventure_eval_config.json
+++ b/qa/adventure_eval_config.json
@@ -3,7 +3,7 @@
   "beat_budget": 20,
   "stage_gap_outlier_beats": 5,
   "dead_beat_stuck_threshold": 2,
-  "pass_completion_rate": 0.5,
+  "pass_completion_rate": 0.67,
   "measured_dm_model": "claude-opus-4-8",
   "dimensions": {
     "completion": {"lever": "arc-completion: tighten the DM arc addendum, verify the giver->crypt->boss->return seam is unblocked, or raise the beat budget"},

--- a/qa/test_adventure_eval.py
+++ b/qa/test_adventure_eval.py
@@ -433,6 +433,11 @@ def test_executable_beat_budget_is_twenty():
     assert ae.load_config()["beat_budget"] == 20
 
 
+def test_executable_completion_rate_matches_g2_bar():
+    """PRODUCT-ROADMAP §§4d/9.3 and the SCORECARD set G2 completion at 0.67."""
+    assert ae.load_config()["pass_completion_rate"] == 0.67
+
+
 def test_beat_budget_override_scores_pace_under_its_own_budget(tmp_path):
     """A control run that really ran at 15 beats is scored under 15, and the row SAYS so."""
     p = _write_run(tmp_path, "ctl", completed=True, complete_beat=15)


### PR DESCRIPTION
## Outcome

`qa/adventure_eval_config.json` now sets `pass_completion_rate` from `0.5` to `0.67`, matching the recorded G2 bar. A direct executable-config test pins the value so the docs and runnable ruler cannot silently drift again.

## Ruler

- Adventure ruler: `av_bc15bcc23d53` -> `av_2aa0edfe7407`
- `SCORING_CONFIG_FILES` is unchanged.
- Full/lens rulers are unchanged: `sc_257531b10b73` / `lc_e9fcdb20a4f7`.

## Recorded authority for 0.67

- `docs/roadmap/PRODUCT-ROADMAP.md` §4d defines A-T at `N>=3`, completion `>= 0.67`, behavioral GREEN.
- `docs/roadmap/PRODUCT-ROADMAP.md` §9.3 clause 4 defines World Readiness text-arc completion as `>= 0.67` at the recorded ruler.
- SCORECARD line: `G2 arc-duo text eval, N>=3 blind-adjudicated, completion >= 0.67, behavioral GREEN`.

## Proof

- Red-first pin: failed at `0.5 != 0.67`, then passed after the config change.
- Focused adventure-eval file: `29 passed`.
- QA CI pytest bundle: `900 passed, 11 skipped, 5 subtests passed`.
- QA CI arc-mode runbook proof: `PASS` (14 checks).
- `qa/fast_gate.sh`: `257 passed`.
- Diff: 6 insertions / 1 deletion across two QA files; no live run, engine-state mutation, or model call.

Refs #1702. Companion correction to #1784.

Claim class: `unit-tested-config-change`. This does not prove any live G2 verdict.
